### PR TITLE
Fix for cursor hiding on OS X

### DIFF
--- a/src/cocoa_platform.h
+++ b/src/cocoa_platform.h
@@ -70,6 +70,7 @@ typedef struct _GLFWwindowNS
     id	            delegate;
     id              view;
     unsigned int    modifierFlags;
+    GLboolean       cursorHidden;
 } _GLFWwindowNS;
 
 
@@ -107,8 +108,6 @@ typedef struct _GLFWlibraryNS
     id              delegate;
     id              autoreleasePool;
     id              cursor;
-
-    GLboolean       cursorHidden;
 
     char*           clipboardString;
 

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -604,7 +604,8 @@ static int translateKey(unsigned int key)
 - (void)resetCursorRects
 {
     [self discardCursorRects];
-    [self addCursorRect:[self bounds] cursor:_glfw.ns.cursor];
+    if (window->ns.cursorHidden)
+        [self addCursorRect:[self bounds] cursor:_glfw.ns.cursor];
 }
 
 @end
@@ -821,7 +822,7 @@ static GLboolean createWindow(_GLFWwindow* window,
     [window->ns.object setContentView:window->ns.view];
     [window->ns.object setDelegate:window->ns.delegate];
     [window->ns.object setAcceptsMouseMovedEvents:YES];
-    [window->ns.object disableCursorRects];
+    [window->ns.object enableCursorRects];
     [window->ns.object center];
 
     if ([window->ns.object respondsToSelector:@selector(setRestorable:)])
@@ -1022,37 +1023,17 @@ void _glfwPlatformSetCursorPos(_GLFWwindow* window, double x, double y)
 
 void _glfwPlatformSetCursorMode(_GLFWwindow* window, int mode)
 {
-    if (mode == GLFW_CURSOR_HIDDEN)
-    {
-        [window->ns.object enableCursorRects];
-        [window->ns.object invalidateCursorRectsForView:window->ns.view];
-    }
+    if (mode == GLFW_CURSOR_NORMAL)
+        window->ns.cursorHidden = GL_FALSE;
     else
-    {
-        [window->ns.object disableCursorRects];
-        [window->ns.object invalidateCursorRectsForView:window->ns.view];
-    }
+        window->ns.cursorHidden = GL_TRUE;
+
+    [window->ns.object invalidateCursorRectsForView:window->ns.view];
 
     if (mode == GLFW_CURSOR_DISABLED)
-    {
         CGAssociateMouseAndMouseCursorPosition(false);
-
-        if (!_glfw.ns.cursorHidden)
-        {
-            [NSCursor hide];
-            _glfw.ns.cursorHidden = GL_TRUE;
-        }
-    }
     else
-    {
         CGAssociateMouseAndMouseCursorPosition(true);
-
-        if (_glfw.ns.cursorHidden)
-        {
-            [NSCursor unhide];
-            _glfw.ns.cursorHidden = GL_FALSE;
-        }
-    }
 }
 
 


### PR DESCRIPTION
There's probably still an oddity in here to do with having more than one window's cursor disabled, but I don't think there's any sane fix for that.

Anyway, the issue with cursors is actually pretty simple and mostly down to a misreading of what I thought disableCursorRects did. Calling it will stop the window from doing anything based on cursor rects, but it will not restore cursor state to whatever it was prior to the window using cursor rects. So, it's just letting you do your thing for as long as they're disabled.

The fix for this is to simply not add a cursor rect when the window's cursor is hidden. So, I moved the cursorHidden flag from the library globals for OS X into the window flags, removed use of NSCursor show and hide because that's just trouble waiting to happen, and now the window only adds a cursor rect to hide the cursor if the cursor is supposed to be hidden.

Because the cursor is moved into the window for when the cursor is disabled, it functions the same as hiding and showing the cursor. When the cursor is simply hidden, it also functions as expected.

Also, as a bonus, there's now less code. Fancy that.

This should close #3.
