### PR TITLE
Added support for OS X 10.6

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -111,11 +111,9 @@ static void centerCursor(_GLFWwindow *window)
     [window->nsgl.context update];
 
     const NSRect contentRect = [window->ns.view frame];
-#if MAC_OS_X_VERSION_MAX_ALLOWED < 1070
-	  const NSRect fbRect = contentRect;
-#else
-  	const NSRect fbRect = [window->ns.view convertRectToBacking:contentRect];
-#endif
+  	const NSRect fbRect = [window->ns.view respondsToSelector:@selector(convertRectToBacking:)]
+	      ? [window->ns.view convertRectToBacking:contentRect]
+      	: contentRect;
 
     _glfwInputFramebufferSize(window, fbRect.size.width, fbRect.size.height);
     _glfwInputWindowSize(window, contentRect.size.width, contentRect.size.height);
@@ -527,12 +525,10 @@ static int translateKey(unsigned int key)
 
 - (void)viewDidChangeBackingProperties
 {
-    const NSRect contentRect = [window->ns.view frame];
-#if MAC_OS_X_VERSION_MAX_ALLOWED < 1070
-  	const NSRect fbRect = contentRect;
-#else
-  	const NSRect fbRect = [window->ns.view convertRectToBacking:contentRect];
-#endif
+  	const NSRect contentRect = [window->ns.view frame];
+  	const NSRect fbRect = [window->ns.view respondsToSelector:@selector(convertRectToBacking:)]
+  	  	? [window->ns.view convertRectToBacking:contentRect]
+  		  : contentRect;
 
     _glfwInputFramebufferSize(window, fbRect.size.width, fbRect.size.height);
 }
@@ -821,10 +817,9 @@ static GLboolean createWindow(_GLFWwindow* window,
     }
 
     window->ns.view = [[GLFWContentView alloc] initWithGlfwWindow:window];
-#if MAC_OS_X_VERSION_MAX_ALLOWED < 1070
-#else
-    [window->ns.view setWantsBestResolutionOpenGLSurface:YES];
-#endif
+	
+	  if ([window->ns.view respondsToSelector:@selector(setWantsBestResolutionOpenGLSurface:)])
+        [window->ns.view setWantsBestResolutionOpenGLSurface:YES];
 
     [window->ns.object setTitle:[NSString stringWithUTF8String:wndconfig->title]];
     [window->ns.object setContentView:window->ns.view];
@@ -833,11 +828,8 @@ static GLboolean createWindow(_GLFWwindow* window,
     [window->ns.object disableCursorRects];
     [window->ns.object center];
 	
-#if MAC_OS_X_VERSION_MAX_ALLOWED < 1070
-#else
     if ([window->ns.object respondsToSelector:@selector(setRestorable:)])
         [window->ns.object setRestorable:NO];
-#endif
 
     return GL_TRUE;
 }


### PR DESCRIPTION
Some of the features being used in `cocoa_window.m` are specific to OS X 10.7+

So I added preprocessor macros to ignore those. I've built GLFW on 10.6.8 using these settings and used it with an experimental version of openFrameworks.

If there's a cleaner or different way to do this, that would be great :)
