### PR TITLE
Fix for compiling with 10.6 SDK

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -32,6 +32,12 @@
 // Needed for _NSGetProgname
 #include <crt_externs.h>
 
+// Fix for 10.6.
+@interface NSWindow (GLFWNSWindowPolyfill)
+
+-(NSRect)convertRectToBacking:(NSRect)rect;
+
+@end
 
 // Enter fullscreen mode
 //


### PR DESCRIPTION
Hi,

Currently GLFW does not compile on Mac OS X 10.6 (although it runs). This is because `convertRectToBacking:` returns an `NSRect`, but undefined methods in Objective-C are assumed to return `id`. Unfortunately `id` is not castable to `NSRect`, so the build fails.

This patch fixes this problem using a category. Maybe there's a better way, but this seemed to work. Tested on OS X 10.6 and OS X 10.8.
