### PR TITLE
Fix incorrect cursor position

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -55,7 +55,12 @@ static void setCursorMode(_GLFWwindow* window, int newMode)
     if (window == _glfw.focusedWindow)
     {
         if (oldMode == GLFW_CURSOR_DISABLED)
+        {
+            window->cursorPosX = _glfw.cursorPosX;
+            window->cursorPosY = _glfw.cursorPosY;
+
             _glfwPlatformSetCursorPos(window, _glfw.cursorPosX, _glfw.cursorPosY);
+        }
         else if (newMode == GLFW_CURSOR_DISABLED)
         {
             int width, height;


### PR DESCRIPTION
When reactivating the cursor its position was updated visually but not internally which caused glfwGetCursorPos to return wrong values.

See [Nibe/glfw-cursor-bug-repro](https://github.com/Nibe/glfw-cursor-bug-repro) for a simple application that demonstrates this issue.
