### PR TITLE
Fixed _glfwPlatformGetWindowPos to include borders

### DIFF
--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -980,14 +980,18 @@ void _glfwPlatformGetWindowPos(_GLFWwindow* window, int* xpos, int* ypos)
 {
     Window child;
     int x, y;
+    int left, top;
 
     XTranslateCoordinates(_glfw.x11.display, window->x11.handle, _glfw.x11.root,
                           0, 0, &x, &y, &child);
 
+	XTranslateCoordinates(_glfw.x11.display, window->x11.handle,  child,
+		   	   	   	   	  0, 0, &left, &top, &child);
+
     if (xpos)
         *xpos = x;
     if (ypos)
-        *ypos = y;
+        *ypos = y-top;
 }
 
 void _glfwPlatformSetWindowPos(_GLFWwindow* window, int xpos, int ypos)


### PR DESCRIPTION
Fixes #85 for linux, as described in #61, there's probably a better method to do this but this seems to work without problem. It's actually how freeglut does it.
