### PR TITLE
Small cleanups and fixes

### DIFF
--- a/src/glx_context.c
+++ b/src/glx_context.c
@@ -344,7 +344,7 @@ void _glfwTerminateContextAPI(void)
 { \
     attribs[index++] = attribName; \
     attribs[index++] = attribValue; \
-    assert(index < sizeof(attribs) / sizeof(attribs[0])); \
+    assert(index < (int)(sizeof(attribs) / sizeof(attribs[0]))); \
 }
 
 // Prepare for creation of the OpenGL context

--- a/src/input.c
+++ b/src/input.c
@@ -30,6 +30,9 @@
 
 #include "internal.h"
 
+#include <float.h>
+#include <math.h>
+
 // Internal key state used for sticky keys
 #define _GLFW_STICK 3
 
@@ -154,9 +157,6 @@ void _glfwInputKey(_GLFWwindow* window, int key, int scancode, int action, int m
 
 void _glfwInputChar(_GLFWwindow* window, unsigned int character)
 {
-    if (character == -1)
-        return;
-
     if (character < 32 || (character > 126 && character < 160))
         return;
 
@@ -189,7 +189,7 @@ void _glfwInputCursorMotion(_GLFWwindow* window, double x, double y)
 {
     if (window->cursorMode == GLFW_CURSOR_DISABLED)
     {
-        if (x == 0.0 && y == 0.0)
+        if (fabs(x) <= DBL_EPSILON && fabs(y) <= DBL_EPSILON)
             return;
 
         window->cursorPosX += x;
@@ -197,7 +197,7 @@ void _glfwInputCursorMotion(_GLFWwindow* window, double x, double y)
     }
     else
     {
-        if (window->cursorPosX == x && window->cursorPosY == y)
+        if (fabs(window->cursorPosX - x) <= DBL_EPSILON && fabs(window->cursorPosY - y) <= DBL_EPSILON)
             return;
 
         window->cursorPosX = x;
@@ -334,7 +334,7 @@ GLFWAPI void glfwSetCursorPos(GLFWwindow* handle, double xpos, double ypos)
         return;
 
     // Don't do anything if the cursor position did not change
-    if (xpos == window->cursorPosX && ypos == window->cursorPosY)
+    if (fabs(xpos - window->cursorPosX) <= DBL_EPSILON && fabs(ypos - window->cursorPosY) <= DBL_EPSILON)
         return;
 
     // Set GLFW cursor position

--- a/src/x11_joystick.c
+++ b/src/x11_joystick.c
@@ -177,7 +177,7 @@ void _glfwInitJoysticks(void)
         return;
     }
 
-    for (i = 0;  i < sizeof(dirs) / sizeof(dirs[0]);  i++)
+    for (i = 0;  i < (int)(sizeof(dirs) / sizeof(dirs[0]));  i++)
     {
         struct dirent* entry;
 

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -36,6 +36,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <limits.h>
+#include <float.h>
+#include <math.h>
 
 // Action for EWMH client messages
 #define _NET_WM_STATE_REMOVE        0
@@ -520,7 +522,12 @@ static void processEvent(XEvent *event)
             _glfwInputKey(window, key, event->xkey.keycode, GLFW_PRESS, mods);
 
             if (!(mods & GLFW_MOD_CONTROL) && !(mods & GLFW_MOD_ALT))
-                _glfwInputChar(window, translateChar(&event->xkey));
+            {
+                const int translatedChar = translateChar(&event->xkey);
+
+                if (translatedChar != -1)
+                    _glfwInputChar(window, translatedChar);
+            }
 
             break;
         }
@@ -786,8 +793,8 @@ static void processEvent(XEvent *event)
                     window = _glfwFindWindowByHandle(data->event);
                     if (window)
                     {
-                        if (data->event_x != window->x11.warpPosX ||
-                            data->event_y != window->x11.warpPosY)
+                        if (fabs(data->event_x - window->x11.warpPosX) >= DBL_EPSILON ||
+                            fabs(data->event_y - window->x11.warpPosY) >= DBL_EPSILON)
                         {
                             // The cursor was moved by something other than GLFW
 


### PR DESCRIPTION
Here is just a few small cleanups and fixes including:
- Avoiding comparison of `signed` and `unsigned` integer data types
- Avoiding comparison of `double` data types for equality (`!=` and `==`)
- Eliminating dead code path (comparing an `unsigned int` with `-1`) and moving necessary checks to the caller function
