### PR TITLE
Add support for precise scrolling deltas

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ See the [GLFW documentation](http://www.glfw.org/docs/latest/).
                    returned by `glfwGetProcAddress`
  - [Win32] Bugfix: The user32 and dwmapi module handles were not freed on
                    library termination
+ - [Cocoa] Changed scroll callback to use precise scrolling deltas when available
  - [Cocoa] Enabled explicit creation of OpenGL 3.x and 4.x contexts as supported
            by OS X 10.9
  - [Cocoa] Bugfix: The clipboard string was not freed on terminate

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -560,7 +560,7 @@ static int translateKey(unsigned int key)
                                                userInfo:nil];
 
     [self addTrackingArea:trackingArea];
-	[super updateTrackingAreas];
+    [super updateTrackingAreas];
 }
 
 - (void)keyDown:(NSEvent *)event
@@ -606,8 +606,27 @@ static int translateKey(unsigned int key)
 
 - (void)scrollWheel:(NSEvent *)event
 {
-    double deltaX = [event deltaX];
-    double deltaY = [event deltaY];
+    double deltaX, deltaY;
+
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
+    if ([event respondsToSelector:@selector(hasPreciseScrollingDeltas:)])
+    {
+        deltaX = [event scrollingDeltaX];
+        deltaY = [event scrollingDeltaY];
+
+        if ([event hasPreciseScrollingDeltas])
+        {
+            deltaX *= 0.1;
+            deltaY *= 0.1;
+        }
+    }
+    else
+#else
+    {
+        deltaX = [event deltaX];
+        deltaY = [event deltaY];
+    }
+#endif /*MAC_OS_X_VERSION_MAX_ALLOWED*/
 
     if (fabs(deltaX) > 0.0 || fabs(deltaY) > 0.0)
         _glfwInputScroll(window, deltaX, deltaY);


### PR DESCRIPTION
From NSEvent Class Reference,

```
- (CGFloat)deltaY

Returns the y-coordinate change for a scroll wheel, mouse-move, or mouse-drag event.
```

```
- (BOOL)hasPreciseScrollingDeltas

Returns whether there are precise scrolling deltas available.

This method is valid for NSScrollWheel events. A generic scroll wheel issues rather coarse
scroll deltas. Some mice and trackpads provide much more precise delta. This method
determines how the values of the scrollingDeltaX and scrollingDeltaY should be interpreted.
```

```
- (CGFloat)scrollingDeltaY

Returns the scroll wheel vertical delta.

Return Value
The vertical scroll wheel delta in points.

Discussion
This is the preferred method for accessing NSScrollWheel delta values. When
hasPreciseScrollingDeltas returns NO, multiply the value returned by this method by the line
or row height. Otherwise scroll by the returned amount.
```

The 0.1 multiply factor comes in just by looking at that data below and seeing that the ratio of scrollingDelta compared to regular delta is roughly 10:1.

I added a debug print statement and scrolled around using my trackpad:

```
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=0.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=1.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=0.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=0.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=0.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=0.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=1.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=0.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=0.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=1.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=0.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=0.000000
hasPreciseScrollingDeltas=1 deltaY=1.000000 scrollingDeltaY=1.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=0.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=1.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=0.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=1.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=0.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=0.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=0.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=1.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=0.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=0.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=0.000000
hasPreciseScrollingDeltas=1 deltaY=1.000000 scrollingDeltaY=13.000000
hasPreciseScrollingDeltas=1 deltaY=4.000000 scrollingDeltaY=40.000000
hasPreciseScrollingDeltas=1 deltaY=6.000000 scrollingDeltaY=63.000000
hasPreciseScrollingDeltas=1 deltaY=8.000000 scrollingDeltaY=87.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=0.000000
hasPreciseScrollingDeltas=1 deltaY=7.000000 scrollingDeltaY=71.000000
hasPreciseScrollingDeltas=1 deltaY=22.000000 scrollingDeltaY=221.000000
hasPreciseScrollingDeltas=1 deltaY=42.000000 scrollingDeltaY=422.000000
hasPreciseScrollingDeltas=1 deltaY=35.000000 scrollingDeltaY=350.000000
hasPreciseScrollingDeltas=1 deltaY=20.000000 scrollingDeltaY=200.000000
hasPreciseScrollingDeltas=1 deltaY=33.000000 scrollingDeltaY=336.000000
hasPreciseScrollingDeltas=1 deltaY=17.000000 scrollingDeltaY=172.000000
hasPreciseScrollingDeltas=1 deltaY=33.000000 scrollingDeltaY=329.000000
hasPreciseScrollingDeltas=1 deltaY=28.000000 scrollingDeltaY=287.000000
hasPreciseScrollingDeltas=1 deltaY=41.000000 scrollingDeltaY=411.000000
hasPreciseScrollingDeltas=1 deltaY=36.000000 scrollingDeltaY=365.000000
hasPreciseScrollingDeltas=1 deltaY=23.000000 scrollingDeltaY=232.000000
hasPreciseScrollingDeltas=1 deltaY=21.000000 scrollingDeltaY=216.000000
hasPreciseScrollingDeltas=1 deltaY=19.000000 scrollingDeltaY=199.000000
hasPreciseScrollingDeltas=1 deltaY=19.000000 scrollingDeltaY=193.000000
hasPreciseScrollingDeltas=1 deltaY=26.000000 scrollingDeltaY=268.000000
hasPreciseScrollingDeltas=1 deltaY=8.000000 scrollingDeltaY=83.000000
hasPreciseScrollingDeltas=1 deltaY=23.000000 scrollingDeltaY=236.000000
hasPreciseScrollingDeltas=1 deltaY=15.000000 scrollingDeltaY=153.000000
hasPreciseScrollingDeltas=1 deltaY=14.000000 scrollingDeltaY=148.000000
hasPreciseScrollingDeltas=1 deltaY=13.000000 scrollingDeltaY=136.000000
hasPreciseScrollingDeltas=1 deltaY=12.000000 scrollingDeltaY=126.000000
hasPreciseScrollingDeltas=1 deltaY=11.000000 scrollingDeltaY=115.000000
hasPreciseScrollingDeltas=1 deltaY=10.000000 scrollingDeltaY=107.000000
hasPreciseScrollingDeltas=1 deltaY=10.000000 scrollingDeltaY=102.000000
hasPreciseScrollingDeltas=1 deltaY=9.000000 scrollingDeltaY=97.000000
hasPreciseScrollingDeltas=1 deltaY=9.000000 scrollingDeltaY=93.000000
hasPreciseScrollingDeltas=1 deltaY=8.000000 scrollingDeltaY=88.000000
hasPreciseScrollingDeltas=1 deltaY=8.000000 scrollingDeltaY=84.000000
hasPreciseScrollingDeltas=1 deltaY=12.000000 scrollingDeltaY=119.000000
hasPreciseScrollingDeltas=1 deltaY=6.000000 scrollingDeltaY=66.000000
hasPreciseScrollingDeltas=1 deltaY=6.000000 scrollingDeltaY=63.000000
hasPreciseScrollingDeltas=1 deltaY=6.000000 scrollingDeltaY=59.000000
hasPreciseScrollingDeltas=1 deltaY=5.000000 scrollingDeltaY=57.000000
hasPreciseScrollingDeltas=1 deltaY=5.000000 scrollingDeltaY=53.000000
hasPreciseScrollingDeltas=1 deltaY=5.000000 scrollingDeltaY=51.000000
hasPreciseScrollingDeltas=1 deltaY=4.000000 scrollingDeltaY=48.000000
hasPreciseScrollingDeltas=1 deltaY=4.000000 scrollingDeltaY=46.000000
hasPreciseScrollingDeltas=1 deltaY=4.000000 scrollingDeltaY=43.000000
hasPreciseScrollingDeltas=1 deltaY=3.000000 scrollingDeltaY=39.000000
hasPreciseScrollingDeltas=1 deltaY=3.000000 scrollingDeltaY=33.000000
hasPreciseScrollingDeltas=1 deltaY=1.000000 scrollingDeltaY=15.000000
hasPreciseScrollingDeltas=1 deltaY=3.000000 scrollingDeltaY=30.000000
hasPreciseScrollingDeltas=1 deltaY=2.000000 scrollingDeltaY=28.000000
hasPreciseScrollingDeltas=1 deltaY=2.000000 scrollingDeltaY=26.000000
hasPreciseScrollingDeltas=1 deltaY=2.000000 scrollingDeltaY=24.000000
hasPreciseScrollingDeltas=1 deltaY=2.000000 scrollingDeltaY=22.000000
hasPreciseScrollingDeltas=1 deltaY=2.000000 scrollingDeltaY=21.000000
hasPreciseScrollingDeltas=1 deltaY=1.000000 scrollingDeltaY=20.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=18.000000
hasPreciseScrollingDeltas=1 deltaY=3.000000 scrollingDeltaY=17.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=16.000000
hasPreciseScrollingDeltas=1 deltaY=3.000000 scrollingDeltaY=15.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=14.000000
hasPreciseScrollingDeltas=1 deltaY=3.000000 scrollingDeltaY=19.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=11.000000
hasPreciseScrollingDeltas=1 deltaY=2.000000 scrollingDeltaY=11.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=10.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=9.000000
hasPreciseScrollingDeltas=1 deltaY=3.000000 scrollingDeltaY=9.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=7.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=8.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=6.000000
hasPreciseScrollingDeltas=1 deltaY=2.000000 scrollingDeltaY=7.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=6.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=6.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=5.000000
hasPreciseScrollingDeltas=1 deltaY=2.000000 scrollingDeltaY=7.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=4.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=4.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=3.000000
hasPreciseScrollingDeltas=1 deltaY=2.000000 scrollingDeltaY=4.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=3.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=2.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=3.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=2.000000
hasPreciseScrollingDeltas=1 deltaY=0.000000 scrollingDeltaY=0.000000
```

When I scrolled using an external mouse scroll wheel:

```
hasPreciseScrollingDeltas=0 deltaY=1.000000 scrollingDeltaY=1.000000
hasPreciseScrollingDeltas=0 deltaY=1.000000 scrollingDeltaY=1.000000
hasPreciseScrollingDeltas=0 deltaY=1.000000 scrollingDeltaY=1.000000
hasPreciseScrollingDeltas=0 deltaY=1.000000 scrollingDeltaY=1.000000
hasPreciseScrollingDeltas=0 deltaY=2.000000 scrollingDeltaY=2.000000
hasPreciseScrollingDeltas=0 deltaY=2.000000 scrollingDeltaY=2.000000
hasPreciseScrollingDeltas=0 deltaY=1.000000 scrollingDeltaY=1.000000
hasPreciseScrollingDeltas=0 deltaY=2.000000 scrollingDeltaY=2.000000
hasPreciseScrollingDeltas=0 deltaY=2.000000 scrollingDeltaY=2.000000
hasPreciseScrollingDeltas=0 deltaY=2.000000 scrollingDeltaY=2.000000
hasPreciseScrollingDeltas=0 deltaY=1.000000 scrollingDeltaY=1.000000
hasPreciseScrollingDeltas=0 deltaY=2.000000 scrollingDeltaY=2.000000
hasPreciseScrollingDeltas=0 deltaY=4.000000 scrollingDeltaY=4.000000
hasPreciseScrollingDeltas=0 deltaY=7.000000 scrollingDeltaY=7.000000
hasPreciseScrollingDeltas=0 deltaY=8.000000 scrollingDeltaY=8.000000
hasPreciseScrollingDeltas=0 deltaY=10.000000 scrollingDeltaY=10.000000
hasPreciseScrollingDeltas=0 deltaY=10.000000 scrollingDeltaY=10.000000
hasPreciseScrollingDeltas=0 deltaY=10.000000 scrollingDeltaY=10.000000
hasPreciseScrollingDeltas=0 deltaY=10.000000 scrollingDeltaY=10.000000
hasPreciseScrollingDeltas=0 deltaY=10.000000 scrollingDeltaY=10.000000
hasPreciseScrollingDeltas=0 deltaY=10.000000 scrollingDeltaY=10.000000
hasPreciseScrollingDeltas=0 deltaY=10.000000 scrollingDeltaY=10.000000
hasPreciseScrollingDeltas=0 deltaY=10.000000 scrollingDeltaY=10.000000
hasPreciseScrollingDeltas=0 deltaY=10.000000 scrollingDeltaY=10.000000
hasPreciseScrollingDeltas=0 deltaY=10.000000 scrollingDeltaY=10.000000
hasPreciseScrollingDeltas=0 deltaY=10.000000 scrollingDeltaY=10.000000
hasPreciseScrollingDeltas=0 deltaY=10.000000 scrollingDeltaY=10.000000
hasPreciseScrollingDeltas=0 deltaY=10.000000 scrollingDeltaY=10.000000
hasPreciseScrollingDeltas=0 deltaY=10.000000 scrollingDeltaY=10.000000
hasPreciseScrollingDeltas=0 deltaY=10.000000 scrollingDeltaY=10.000000
hasPreciseScrollingDeltas=0 deltaY=9.000000 scrollingDeltaY=9.000000
hasPreciseScrollingDeltas=0 deltaY=9.000000 scrollingDeltaY=9.000000
hasPreciseScrollingDeltas=0 deltaY=9.000000 scrollingDeltaY=9.000000
hasPreciseScrollingDeltas=0 deltaY=6.000000 scrollingDeltaY=6.000000
hasPreciseScrollingDeltas=0 deltaY=10.000000 scrollingDeltaY=10.000000
hasPreciseScrollingDeltas=0 deltaY=11.000000 scrollingDeltaY=11.000000
hasPreciseScrollingDeltas=0 deltaY=11.000000 scrollingDeltaY=11.000000
hasPreciseScrollingDeltas=0 deltaY=11.000000 scrollingDeltaY=11.000000
hasPreciseScrollingDeltas=0 deltaY=40.000000 scrollingDeltaY=40.000000
hasPreciseScrollingDeltas=0 deltaY=1.000000 scrollingDeltaY=1.000000
hasPreciseScrollingDeltas=0 deltaY=3.000000 scrollingDeltaY=3.000000
hasPreciseScrollingDeltas=0 deltaY=7.000000 scrollingDeltaY=7.000000
hasPreciseScrollingDeltas=0 deltaY=10.000000 scrollingDeltaY=10.000000
hasPreciseScrollingDeltas=0 deltaY=37.000000 scrollingDeltaY=37.000000
hasPreciseScrollingDeltas=0 deltaY=32.000000 scrollingDeltaY=32.000000
hasPreciseScrollingDeltas=0 deltaY=18.000000 scrollingDeltaY=18.000000
hasPreciseScrollingDeltas=0 deltaY=18.000000 scrollingDeltaY=18.000000
hasPreciseScrollingDeltas=0 deltaY=1.000000 scrollingDeltaY=1.000000
hasPreciseScrollingDeltas=0 deltaY=3.000000 scrollingDeltaY=3.000000
hasPreciseScrollingDeltas=0 deltaY=7.000000 scrollingDeltaY=7.000000
hasPreciseScrollingDeltas=0 deltaY=35.000000 scrollingDeltaY=35.000000
hasPreciseScrollingDeltas=0 deltaY=28.000000 scrollingDeltaY=28.000000
hasPreciseScrollingDeltas=0 deltaY=37.000000 scrollingDeltaY=37.000000
hasPreciseScrollingDeltas=0 deltaY=18.000000 scrollingDeltaY=18.000000
```
