### PR TITLE
Add support for WGL_NV_gpu_affinity

### DIFF
--- a/docs/window.dox
+++ b/docs/window.dox
@@ -188,6 +188,11 @@ used by the context.  This can be one of `GLFW_NO_RESET_NOTIFICATION` or
 `GLFW_LOSE_CONTEXT_ON_RESET`, or `GLFW_NO_ROBUSTNESS` to not request
 a robustness strategy.
 
+The `GLFW_AFFINITY_GPU` hint specifies which GPU should render OpenGL commands
+for the associated context. This uses the WGL_NV_gpu_affinity extension, and is
+only available on windows systems. The value corresponds with an index position
+returned from a call to wglEnumGpusNV(...). Note that if sharing context resources
+with another window, both windows must have the same affinity gpu mask.
 
 @subsection window_hints_values Supported and default values
 
@@ -218,6 +223,7 @@ a robustness strategy.
 | `GLFW_OPENGL_FORWARD_COMPAT` | `GL_FALSE`                | `GL_TRUE` or `GL_FALSE` |
 | `GLFW_OPENGL_DEBUG_CONTEXT`  | `GL_FALSE`                | `GL_TRUE` or `GL_FALSE` |
 | `GLFW_OPENGL_PROFILE`        | `GLFW_OPENGL_ANY_PROFILE` | `GLFW_OPENGL_ANY_PROFILE`, `GLFW_OPENGL_COMPAT_PROFILE` or `GLFW_OPENGL_CORE_PROFILE` |
+| `GLFW_AFFINITY_GPU`          | -1                        | 0 to maximum number of GPUs |
 
 
 @section window_close Window close flag

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -511,6 +511,7 @@ extern "C" {
 #define GLFW_SAMPLES                0x0002100D
 #define GLFW_SRGB_CAPABLE           0x0002100E
 #define GLFW_REFRESH_RATE           0x0002100F
+#define GLFW_AFFINITY_GPU           0x00021010
 
 #define GLFW_CLIENT_API             0x00022001
 #define GLFW_CONTEXT_VERSION_MAJOR  0x00022002

--- a/include/GLFW/glfw3native.h
+++ b/include/GLFW/glfw3native.h
@@ -115,6 +115,11 @@ GLFWAPI HWND glfwGetWin32Window(GLFWwindow* window);
  *  @ingroup native
  */
 GLFWAPI HGLRC glfwGetWGLContext(GLFWwindow* window);
+/*! @brief Returns the `HDC` of the specified window.
+ *  @return The `HDC` of the specified window.
+ *  @ingroup native
+ */
+GLFWAPI HDC glfwGetWGLDC(GLFWwindow* window);
 #endif
 
 #if defined(GLFW_EXPOSE_NATIVE_COCOA)

--- a/src/internal.h
+++ b/src/internal.h
@@ -299,6 +299,7 @@ struct _GLFWlibrary
         GLboolean   glDebug;
         int         glProfile;
         int         glRobustness;
+        int         gpu;
     } hints;
 
     double          cursorPosX, cursorPosY;

--- a/src/wgl_platform.h
+++ b/src/wgl_platform.h
@@ -50,6 +50,7 @@ typedef struct _GLFWcontextWGL
 {
     // Platform specific window resources
     HDC       dc;              // Private GDI device context
+	HDC       affinityDC;      // gpu affinity device context
     HGLRC     context;         // Permanent rendering context
 
     // Platform specific extensions (context specific)
@@ -58,6 +59,9 @@ typedef struct _GLFWcontextWGL
     PFNWGLGETEXTENSIONSSTRINGEXTPROC    GetExtensionsStringEXT;
     PFNWGLGETEXTENSIONSSTRINGARBPROC    GetExtensionsStringARB;
     PFNWGLCREATECONTEXTATTRIBSARBPROC   CreateContextAttribsARB;
+	PFNWGLCREATEAFFINITYDCNVPROC		CreateAffinityDCNV;
+	PFNWGLDELETEDCNVPROC				DeleteDCNV;
+	PFNWGLENUMGPUSNVPROC				EnumGpusNV;
     GLboolean                           EXT_swap_control;
     GLboolean                           ARB_multisample;
     GLboolean                           ARB_framebuffer_sRGB;
@@ -66,6 +70,7 @@ typedef struct _GLFWcontextWGL
     GLboolean                           ARB_create_context_profile;
     GLboolean                           EXT_create_context_es2_profile;
     GLboolean                           ARB_create_context_robustness;
+	GLboolean							NV_gpu_affinity;
 } _GLFWcontextWGL;
 
 

--- a/src/window.c
+++ b/src/window.c
@@ -284,6 +284,9 @@ void glfwDefaultWindowHints(void)
     _glfw.hints.alphaBits   = 8;
     _glfw.hints.depthBits   = 24;
     _glfw.hints.stencilBits = 8;
+
+	// Set the default gpu to -1.
+    _glfw.hints.gpu = -1;
 }
 
 GLFWAPI void glfwWindowHint(int target, int hint)
@@ -366,6 +369,9 @@ GLFWAPI void glfwWindowHint(int target, int hint)
             break;
         case GLFW_OPENGL_PROFILE:
             _glfw.hints.glProfile = hint;
+            break;
+		case GLFW_AFFINITY_GPU:
+            _glfw.hints.gpu = hint;
             break;
         default:
             _glfwInputError(GLFW_INVALID_ENUM, NULL);


### PR DESCRIPTION
This patch allows users to choose which GPU the opengl rendering commands are sent to using the wgl_nv_affinity extension. The gpu is specified through a new 'GLFW_AFFINITY_GPU' hint. If the extension is unsupported on the current hardware, the hint is just ignored. If the hint is not set, a normal device context is created as usual.
For systems with multiple GPUs, using multiple windows this can greatly speed up rendering efficiency.

It also adds a new Native API call to get the device context.