### PR TITLE
Fix precise scrolling delta logic in scrollWheel.

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -609,7 +609,7 @@ static int translateKey(unsigned int key)
     double deltaX, deltaY;
 
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
-    if ([event respondsToSelector:@selector(hasPreciseScrollingDeltas:)])
+    if ([event respondsToSelector:@selector(hasPreciseScrollingDeltas)])
     {
         deltaX = [event scrollingDeltaX];
         deltaY = [event scrollingDeltaY];
@@ -621,12 +621,11 @@ static int translateKey(unsigned int key)
         }
     }
     else
-#else
+#endif /*MAC_OS_X_VERSION_MAX_ALLOWED*/
     {
         deltaX = [event deltaX];
         deltaY = [event deltaY];
     }
-#endif /*MAC_OS_X_VERSION_MAX_ALLOWED*/
 
     if (fabs(deltaX) > 0.0 || fabs(deltaY) > 0.0)
         _glfwInputScroll(window, deltaX, deltaY);


### PR DESCRIPTION
`[event respondsToSelector:@selector(hasPreciseScrollingDeltas:)]` always returns false, so it cannot be used as a test.

Also, the #if-#else-#endif logic was wrong, preventing `_glfwInputScroll()` from being called had the respondsToSelector test returned true. 

Please see [this comment](https://github.com/glfw/glfw/pull/95#issuecomment-21464735) for further details.
