### PR TITLE
Remove caching of cursor position 

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -858,6 +858,14 @@ static GLboolean createWindow(_GLFWwindow* window,
     [window->ns.object disableCursorRects];
     [window->ns.object center];
 
+    if (window->cursorMode != GLFW_CURSOR_DISABLED)
+    {
+        const NSRect contentRect = [window->ns.view frame];
+        const NSPoint p = [window->ns.object mouseLocationOutsideOfEventStream];
+        window->cursorPosX = p.x;
+        window->cursorPosY = contentRect.size.height - p.y;
+    }
+
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
     if ([window->ns.object respondsToSelector:@selector(setRestorable:)])
         [window->ns.object setRestorable:NO];
@@ -960,6 +968,17 @@ void _glfwPlatformSetWindowPos(_GLFWwindow* window, int x, int y)
     const NSRect dummyRect = NSMakeRect(x, transformY(y + contentRect.size.height), 0, 0);
     const NSRect frameRect = [window->ns.object frameRectForContentRect:dummyRect];
     [window->ns.object setFrameOrigin:frameRect.origin];
+
+    if (window->cursorMode != GLFW_CURSOR_DISABLED)
+    {
+        const NSPoint p = [window->ns.object mouseLocationOutsideOfEventStream];
+        // TODO: This should enqueue an event that will result in cursor position callback being called
+        // during the next glfwPollEvents()
+        // (But can't call _glfwInputCursorMotion directly here because that'd result in callbacks
+        // being called outside of glfwPollEvents() timeframe)
+        window->cursorPosX = p.x;
+        window->cursorPosY = contentRect.size.height - p.y;
+    }
 }
 
 void _glfwPlatformGetWindowSize(_GLFWwindow* window, int* width, int* height)


### PR DESCRIPTION
Currently, at least on OS X, if the user creates a window and calls `glfwGetCursorPos()` before moving the mouse, the return value will be (0, 0). After moving the mouse even just by 1 pixel, the return value will be an accurate cursor position.

There's no technical reason why the cursor position cannot be reported accurately before the mouse is moved.

I'm attaching some code for OS X, but it's just to get the ball rolling on this issue (i.e. it's fine if the issue is solved without merging this PR).

The code added to `createWindow()` fixes that use case.

The code added to `_glfwPlatformSetWindowPos()` is to take care of the use case where the user creates a window, then sets its position to somewhere else, and then calls `glfwGetCursorPos()`.

A related but somewhat distinct issue. When the user moves the **window** programmatically via `glfwSetWindowPos()`, the cursor position callback (if set) should be called with the new cursor position. Since the cursor position is reported relative to the window position, it will have changed. The code below does not implement this because I didn't know how to do it. Calling the callback directly from `_glfwPlatformSetWindowPos()` is not an option because then it breaks the fact that callbacks occur only immediately after a call to `glfwPollEvents()` or similar.
