### PR TITLE
Fixed gcc -Wextra warnings.

### DIFF
--- a/src/egl_context.c
+++ b/src/egl_context.c
@@ -243,7 +243,7 @@ void _glfwTerminateContextAPI(void)
 { \
     attribs[index++] = attribName; \
     attribs[index++] = attribValue; \
-    assert((size_t) index < sizeof(attribs) / sizeof(attribs[0])); \
+    assert(index < sizeof(attribs) / sizeof(attribs[0])); \
 }
 
 // Prepare for creation of the OpenGL context
@@ -339,7 +339,8 @@ int _glfwCreateContext(_GLFWwindow* window,
 
     if (_glfw.egl.KHR_create_context)
     {
-        int index = 0, mask = 0, flags = 0, strategy = 0;
+        int mask = 0, flags = 0, strategy = 0;
+        size_t index = 0;
 
         if (wndconfig->clientAPI == GLFW_OPENGL_API)
         {
@@ -384,7 +385,7 @@ int _glfwCreateContext(_GLFWwindow* window,
     }
     else
     {
-        int index = 0;
+        size_t index = 0;
 
         if (wndconfig->clientAPI == GLFW_OPENGL_ES_API)
             setEGLattrib(EGL_CONTEXT_CLIENT_VERSION, wndconfig->glMajor);

--- a/src/glx_context.c
+++ b/src/glx_context.c
@@ -172,6 +172,8 @@ static GLXContext createLegacyContext(_GLFWwindow* window,
                                       GLXFBConfig fbconfig,
                                       GLXContext share)
 {
+    (void) window;
+
     if (_glfw.glx.SGIX_fbconfig)
     {
         return _glfw.glx.CreateContextWithConfigSGIX(_glfw.x11.display,
@@ -341,7 +343,7 @@ void _glfwTerminateContextAPI(void)
 { \
     attribs[index++] = attribName; \
     attribs[index++] = attribValue; \
-    assert((size_t) index < sizeof(attribs) / sizeof(attribs[0])); \
+    assert(index < sizeof(attribs) / sizeof(attribs[0])); \
 }
 
 // Prepare for creation of the OpenGL context
@@ -420,7 +422,8 @@ int _glfwCreateContext(_GLFWwindow* window,
 
     if (_glfw.glx.ARB_create_context)
     {
-        int index = 0, mask = 0, flags = 0, strategy = 0;
+        int mask = 0, flags = 0, strategy = 0;
+        size_t index = 0;
 
         if (wndconfig->clientAPI == GLFW_OPENGL_API)
         {

--- a/src/wgl_context.c
+++ b/src/wgl_context.c
@@ -329,7 +329,7 @@ void _glfwTerminateContextAPI(void)
 { \
     attribs[index++] = attribName; \
     attribs[index++] = attribValue; \
-    assert((size_t) index < sizeof(attribs) / sizeof(attribs[0])); \
+    assert(index < sizeof(attribs) / sizeof(attribs[0])); \
 }
 
 // Prepare for creation of the OpenGL context
@@ -378,7 +378,8 @@ int _glfwCreateContext(_GLFWwindow* window,
 
     if (window->wgl.ARB_create_context)
     {
-        int index = 0, mask = 0, flags = 0, strategy = 0;
+        int mask = 0, flags = 0, strategy = 0;
+        size_t index = 0;
 
         if (wndconfig->clientAPI == GLFW_OPENGL_API)
         {

--- a/src/x11_clipboard.c
+++ b/src/x11_clipboard.c
@@ -36,6 +36,9 @@
 //
 static Bool isSelectionMessage(Display* display, XEvent* event, XPointer pointer)
 {
+    (void)display;
+    (void)pointer;
+
     return event->type == SelectionRequest ||
            event->type == SelectionNotify ||
            event->type == SelectionClear;
@@ -181,6 +184,8 @@ static Atom writeTargetToProperty(const XSelectionRequestEvent* request)
 
 void _glfwHandleSelectionClear(XEvent* event)
 {
+    (void) event;
+
     free(_glfw.x11.selection.string);
     _glfw.x11.selection.string = NULL;
 }

--- a/src/x11_init.c
+++ b/src/x11_init.c
@@ -591,6 +591,8 @@ static void terminateDisplay(void)
 //
 static int errorHandler(Display *display, XErrorEvent* event)
 {
+    (void)display;
+
     _glfw.x11.errorCode = event->error_code;
     return 0;
 }


### PR DESCRIPTION
Hello dreda,

this pull request implements or improves the existing implementation of gcc -Wall warning fixes. Those warnings are about unused parameters and comparision between signed and unsigned types.
