### PR TITLE
Declared unnamed typedef structs as their types

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -793,7 +793,7 @@ typedef void (* GLFWmonitorfun)(GLFWmonitor*,int);
  *
  *  @ingroup monitor
  */
-typedef struct
+typedef struct GLFWvidmode
 {
     /*! The width, in screen coordinates, of the video mode.
      */
@@ -823,7 +823,7 @@ typedef struct
  *
  *  @ingroup monitor
  */
-typedef struct
+typedef struct GLFWgammaramp
 {
     /*! An array of value describing the response of the red channel.
      */


### PR DESCRIPTION
Without defining them as structs it was impossible to forward declare `GLFWgammaramp` and `GLFWvidmode`.
