### PR TITLE
Fix non-used monitors blanked by full screen window

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -58,8 +58,12 @@ static void enterFullscreenMode(_GLFWwindow* window)
 
     _glfwSetVideoMode(window->monitor, &window->videoMode);
 
+	NSDictionary *opts = [NSDictionary dictionaryWithObjectsAndKeys:
+	      [NSNumber numberWithBool:NO], NSFullScreenModeAllScreens,
+	       nil];
+	       
     [window->ns.view enterFullScreenMode:window->monitor->ns.screen
-                             withOptions:nil];
+                             withOptions:opts];
 }
 
 // Leave fullscreen mode


### PR DESCRIPTION
I guess the correct behavior should be to NOT black out all screens. With this fix implemented, other monitors can still be blacked out by creating fullscreen windows on them. Another possibility could be to have the original behavior accessible with an option. Using the same syntax, multiple behaviors are probably possible.
