### PR TITLE
Add glfw_ prefix to configuration header.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,8 +386,8 @@ endif()
 configure_file(${GLFW_SOURCE_DIR}/docs/Doxyfile.in
                ${GLFW_BINARY_DIR}/docs/Doxyfile @ONLY)
 
-configure_file(${GLFW_SOURCE_DIR}/src/config.h.in 
-               ${GLFW_BINARY_DIR}/src/config.h @ONLY)
+configure_file(${GLFW_SOURCE_DIR}/src/glfw_config.h.in 
+               ${GLFW_BINARY_DIR}/src/glfw_config.h @ONLY)
 
 configure_file(${GLFW_SOURCE_DIR}/src/glfwConfig.cmake.in
                ${GLFW_BINARY_DIR}/src/glfwConfig.cmake @ONLY)

--- a/docs/internal.dox
+++ b/docs/internal.dox
@@ -105,8 +105,8 @@ Examples: `clearScrollOffsets`
 @section internals_config Configuration macros
 
 GLFW uses a number of configuration macros to select at compile time which
-interfaces and code paths to use.  They are defined in the config.h header file,
-which is generated from the `config.h.in` file by CMake.
+interfaces and code paths to use.  They are defined in the glfw_config.h header file,
+which is generated from the `glfw_config.h.in` file by CMake.
 
 Configuration macros the same style as tokens in the public interface, except
 with a leading underscore.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,7 @@ include_directories(${GLFW_SOURCE_DIR}/src
                     ${GLFW_BINARY_DIR}/src
                     ${glfw_INCLUDE_DIRS})
 
-set(common_HEADERS ${GLFW_BINARY_DIR}/src/config.h internal.h
+set(common_HEADERS ${GLFW_BINARY_DIR}/src/glfw_config.h internal.h
                    ${GLFW_SOURCE_DIR}/include/GLFW/glfw3.h
                    ${GLFW_SOURCE_DIR}/include/GLFW/glfw3native.h)
 set(common_SOURCES clipboard.c context.c gamma.c init.c input.c joystick.c

--- a/src/glfw_config.h.in
+++ b/src/glfw_config.h.in
@@ -23,13 +23,13 @@
 //    distribution.
 //
 //========================================================================
-// As config.h.in, this file is used by CMake to produce the config.h shared
+// As glfw_config.h.in, this file is used by CMake to produce the config.h shared
 // configuration header file.  If you are adding a feature requiring
 // conditional compilation, this is the proper place to add the macros.
 //========================================================================
-// As config.h, this file defines compile-time build options and macros for
+// As glfw_config.h, this file defines compile-time build options and macros for
 // all platforms supported by GLFW.  As this is a generated file, don't modify
-// it.  Instead, you should modify the config.h.in file.
+// it.  Instead, you should modify the glfw_config.h.in file.
 //========================================================================
 
 // Define this to 1 if building GLFW for X11

--- a/src/internal.h
+++ b/src/internal.h
@@ -29,7 +29,7 @@
 #define _internal_h_
 
 
-#include "config.h"
+#include "glfw_config.h"
 
 #if defined(_GLFW_USE_OPENGL)
  // This is the default for glfw3.h


### PR DESCRIPTION
I currently build my code along with glfw and other third-party libraries.  There are multiple config.h files generated and in certain situations glfw ends up including the wrong one .  In my personal copy of GLFW, I have already renamed GLFW's config.h.in to glfw_config.h.in to disambiguate the filename.  Since I prefer to avoid diverging from upstream as much as possible and in the hope that this change is not controversial I am issuing a pull request for your consideration.  Thanks.
