### PR TITLE
Fixed dead keys in X11

### DIFF
--- a/src/x11_platform.h
+++ b/src/x11_platform.h
@@ -92,6 +92,8 @@ typedef struct _GLFWwindowX11
     // The last position the cursor was warped to by GLFW
     int             warpPosX, warpPosY;
 
+    // The window's input context
+    XIC ic;
 } _GLFWwindowX11;
 
 
@@ -199,6 +201,9 @@ typedef struct _GLFWlibraryX11
         int         buttonCount;
         char*       name;
     } joystick[GLFW_JOYSTICK_LAST + 1];
+    
+    // Input method and context
+    XIM im;
 
 } _GLFWlibraryX11;
 


### PR DESCRIPTION
### Patch Description

On X11, dead keys on international keyboards were previously more or less ignored when pressed. On Win32, dead keys are really handled like dead keys, meaning pressing the accent key does not create a character but rather modifies the following character (i.E. e becomes é).

With this patch, the library will now try to create an X input context to handle dead keys properly on international keyboards.

This makes it possible to enter for example an é on a German keyboard without further effort and with the same look-and-feel as the user is used to in most other applications.
A fallback mechanism is provided in case the client does not support X input method / context creation.
In that case, the library will behave as it did before.

Tested with:
- OpenSUSE 12.2 with X.Org 1.12.3
- Fedora 19 with X.Org 1.14.3
#### Known Problems:

The X Server generates a "ghost" KeyPress event with keycode 0 after the character was successfully composed. Sending this event to translateChar generates the final Unicode data, so the purpose of this event is seemingly to signal the X client that the character is now composed and to give the client the chance to retrieve its Unicode characters.
glfw maps this to GLFW_KEY_UNKNOWN, so users will probably ignore it anyway, but of course it is not a very clean solution. I'm not sure if it is possible to get completely rid of this behaviour without risking to miss "real" KeyPress events.
### Screenshots

Notice the accent over the a's of the character events.

Old:
![image](https://f.cloud.github.com/assets/5623987/1277358/8f8c5bc0-2ebe-11e3-9235-33c14a7b48fb.png)

New:
![image](https://f.cloud.github.com/assets/5623987/1277354/5c622360-2ebe-11e3-808b-c92b11c83ade.png)
