### PR TITLE
Fix cursor positioning

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -1070,6 +1070,7 @@ void _glfwPlatformSetCursorPos(_GLFWwindow* window, double x, double y)
     {
         CGAssociateMouseAndMouseCursorPosition(true);
     }
+    setModeCursor(window, window->cursorMode);
 }
 
 void _glfwPlatformSetCursorMode(_GLFWwindow* window, int mode)

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -1058,6 +1058,10 @@ void _glfwPlatformSetCursorPos(_GLFWwindow* window, double x, double y)
         CGDisplayMoveCursorToPoint(window->monitor->ns.displayID,
                                    CGPointMake(x, y));
     }
+    else if ([window->ns.view isInFullScreenMode])
+    {
+        CGWarpMouseCursorPosition(CGPointMake(x, y));
+    }
     else
     {
         const NSRect contentRect = [window->ns.view frame];

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -60,6 +60,8 @@ static void enterFullscreenMode(_GLFWwindow* window)
 
     [window->ns.view enterFullScreenMode:window->monitor->ns.screen
                              withOptions:nil];
+    
+    _glfwInputWindowFocus(window, GL_TRUE);
 }
 
 // Leave fullscreen mode

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -1065,6 +1065,11 @@ void _glfwPlatformSetCursorPos(_GLFWwindow* window, double x, double y)
         CGWarpMouseCursorPosition(CGPointMake(globalPoint.x,
                                               transformY(globalPoint.y)));
     }
+    
+    if (window->cursorMode != GLFW_CURSOR_DISABLED)
+    {
+        CGAssociateMouseAndMouseCursorPosition(true);
+    }
 }
 
 void _glfwPlatformSetCursorMode(_GLFWwindow* window, int mode)

--- a/src/input.c
+++ b/src/input.c
@@ -48,6 +48,8 @@ static void setCursorMode(_GLFWwindow* window, int newMode)
     oldMode = window->cursorMode;
     if (oldMode == newMode)
         return;
+    
+    window->cursorMode = newMode;
 
     if (window == _glfw.focusedWindow)
     {
@@ -72,7 +74,6 @@ static void setCursorMode(_GLFWwindow* window, int newMode)
         _glfwPlatformSetCursorMode(window, newMode);
     }
 
-    window->cursorMode = newMode;
 }
 
 // Set sticky keys mode for the specified window


### PR DESCRIPTION
Hi,

glfwSetCursorPos was not working properly for OSX.

1 Calling glfwSetCursorPos and then glfwGetCursorPos did not return updated value under NORMAL and HIDDEN mode
2 In hidden mode when the cursor was outside of the window and glfwSetCursorPos moved it inside the window, then the cursor was not hidden
3 glfwSetCursorPos did not work in fullscreen mode since the window was not considered to be in focus. This should fix bug #142 
4 I noticed a weird behavior on MBP retina, when in fullscreen the glfwSetCursorPos was off by 200px. When I connected a monitor but still ran on the retina screen it wouldn't occur. No idea why, but calling CCWarpMouseCursorPosition directly (without conv. to screen coord) it worked. (UPDATE: this could be related to bug #4 )
5 If you set the cursor mode to normal and then to disabled then the cursor was not hidden.

I have verified the patch with MBP and MBP Retina, both running OSX 10.8 and with and without external monitor.

You can find the test program I used (/examples/mouse.c) in my branch osx_mouse_test. It will print out the cursor coordinates if the mouse position was changed and 1,2,3 will switch mouse modes, M will toggle set cursor pos.
https://github.com/andripalsson/glfw/tree/osx_mouse_test


/Andri
