### PR TITLE
Fixed page header background image location

### DIFF
--- a/docs/extra.css
+++ b/docs/extra.css
@@ -11,7 +11,7 @@ html {
 
 .glfwheader a#glfwhome {
 	line-height:64px;
-	padding-right:48pxpx;
+	padding-right:48px;
 	float:left;
 	color:hsl(0,0%,40%);
 	font-size:2.5em;


### PR DESCRIPTION
Fixed a typo in doxygen documentations header background image location.
