### PR TITLE
Fix build on Mac OS X 10.7 Lion.

### DIFF
--- a/src/cocoa_monitor.m
+++ b/src/cocoa_monitor.m
@@ -33,6 +33,7 @@
 #include <IOKit/graphics/IOGraphicsLib.h>
 #include <IOKit/graphics/IOGraphicsLib.h>
 #include <CoreVideo/CVBase.h>
+#include <CoreVideo/CVDisplayLink.h>
 
 
 // Get the name of the specified display

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -105,7 +105,7 @@ static float transformY(float y)
 static NSRect convertRectToBacking(_GLFWwindow* window, NSRect contentRect)
 {
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
-    if (floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_7)
+    if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_6)
         return [window->ns.view convertRectToBacking:contentRect];
     else
 #endif /*MAC_OS_X_VERSION_MAX_ALLOWED*/
@@ -635,7 +635,7 @@ static int translateKey(unsigned int key)
     double deltaX, deltaY;
 
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
-    if (floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_7)
+    if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_6)
     {
         deltaX = [event scrollingDeltaX];
         deltaY = [event scrollingDeltaY];
@@ -867,7 +867,7 @@ static GLboolean createWindow(_GLFWwindow* window,
     window->ns.view = [[GLFWContentView alloc] initWithGlfwWindow:window];
 
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
-    if (floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_7)
+    if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_6)
     {
         [window->ns.view setWantsBestResolutionOpenGLSurface:YES];
 
@@ -883,7 +883,7 @@ static GLboolean createWindow(_GLFWwindow* window,
     [window->ns.object center];
 
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
-    if (floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_7)
+    if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_6)
         [window->ns.object setRestorable:NO];
 #endif /*MAC_OS_X_VERSION_MAX_ALLOWED*/
 


### PR DESCRIPTION
`CVDisplayLinkRef` needs an extra header file, and `NSAppKitVersionNumber10_7`
wasn't added until 10.8so use `> NSAppKitVersionNumber10_6` instead.

Fixes #157
