### PR TITLE
Create default monitor if Xrandr lookup fails

### DIFF
--- a/src/x11_gamma.c
+++ b/src/x11_gamma.c
@@ -51,7 +51,11 @@ void _glfwInitGammaRamp(void)
         XRRScreenResources* rr = XRRGetScreenResources(_glfw.x11.display,
                                                        _glfw.x11.root);
 
-        if (XRRGetCrtcGammaSize(_glfw.x11.display, rr->crtcs[0]) == 0)
+        if (rr->ncrtc == 0)
+        {
+            _glfw.x11.randr.gammaBroken = GL_TRUE;
+        }
+        else if (XRRGetCrtcGammaSize(_glfw.x11.display, rr->crtcs[0]) == 0)
         {
             // This is probably older Nvidia RandR with broken gamma support
             // Flag it as useless and try Xf86VidMode below, if available

--- a/src/x11_monitor.c
+++ b/src/x11_monitor.c
@@ -251,7 +251,8 @@ _GLFWmonitor** _glfwPlatformGetMonitors(int* count)
 
         *count = found;
     }
-    else
+
+    if (monitors == NULL)
     {
         monitors = calloc(1, sizeof(_GLFWmonitor*));
         monitors[0] = _glfwCreateMonitor("Display",


### PR DESCRIPTION
Allows glfwInit to succeed on headless systems. Useful for CI etc.
