### PR TITLE
Fixed link error introduced by previous commit

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -186,13 +186,14 @@ static NSRect convertRectToBacking(_GLFWwindow* window, NSRect contentRect)
 - (void)windowDidBecomeKey:(NSNotification *)notification
 {
     _glfwInputWindowFocus(window, GL_TRUE);
-    _glfwPlatformSetCursorMode(window, window->cursorMode);
+    _glfwPlatformApplyCursorMode(window, window->cursorMode);
 }
 
 - (void)windowDidResignKey:(NSNotification *)notification
 {
     _glfwInputWindowFocus(window, GL_FALSE);
-    _glfwPlatformSetCursorMode(window, GLFW_CURSOR_NORMAL);
+    window->cursorMode = GLFW_CURSOR_NORMAL;
+    _glfwPlatformApplyCursorMode(window);
 }
 
 @end


### PR DESCRIPTION
After the last commit GLFW was failing to link because __glfwPlatformSetCursorMode is undefined on OS X, so I changed the calls to use __glfwPlatformApplyCursorMode instead which links ok. Examples work fine.
