### PR TITLE
Fixing small memory leak in Cocoa

### DIFF
--- a/src/cocoa_joystick.m
+++ b/src/cocoa_joystick.m
@@ -343,6 +343,7 @@ void _glfwInitJoysticks(void)
             {
                 // This device is not relevant to GLFW
                 CFRelease(valueRef);
+                CFRelease(propsRef);
                 continue;
             }
 
@@ -360,6 +361,7 @@ void _glfwInitJoysticks(void)
             {
                 // This device is not relevant to GLFW
                 CFRelease(valueRef);
+                CFRelease(propsRef);
                 continue;
             }
 
@@ -376,7 +378,11 @@ void _glfwInitJoysticks(void)
                                                    &score);
 
         if (kIOReturnSuccess != result)
+        {
+            CFRelease(valueRef);
+            CFRelease(propsRef);
             return;
+        }
 
         plugInResult = (*ppPlugInInterface)->QueryInterface(
                             ppPlugInInterface,
@@ -384,7 +390,11 @@ void _glfwInitJoysticks(void)
                             (void *) &(joystick->interface));
 
         if (plugInResult != S_OK)
+        {
+            CFRelease(valueRef);
+            CFRelease(propsRef);
             return;
+        }
 
         (*ppPlugInInterface)->Release(ppPlugInInterface);
 
@@ -419,6 +429,7 @@ void _glfwInitJoysticks(void)
                                  (void*) joystick);
             CFRelease(valueRef);
         }
+        CFRelease(propsRef);
 
         joystick->axes = calloc(CFArrayGetCount(joystick->axisElements),
                                          sizeof(float));


### PR DESCRIPTION
This only showed up when I set up a test harness doing several hundred setup/teardowns of my engine (which involved equally many calls to `glfwInit` and `glfwTerminate`). It's a pretty minor thing, obviously, and not likely to be noticed since I imagine most apps don't do multiple invocations like that, but every little bit helps. :) 

I'm also seeing a memory leak reported from the `calloc` calls in `_glfwPlatformGetMonitors`, but I haven't been able to track that down since as far as I can tell all that memory is appropriately freed in `_glfwDestroyMonitor(s)`.
