### PR TITLE
Flip X11 horizontal scroll axis

### DIFF
--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -607,9 +607,9 @@ static void processEvent(XEvent *event)
             else if (event->xbutton.button == Button5)
                 _glfwInputScroll(window, 0.0, -1.0);
             else if (event->xbutton.button == Button6)
-                _glfwInputScroll(window, -1.0, 0.0);
-            else if (event->xbutton.button == Button7)
                 _glfwInputScroll(window, 1.0, 0.0);
+            else if (event->xbutton.button == Button7)
+                _glfwInputScroll(window, -1.0, 0.0);
 
             else
             {


### PR DESCRIPTION
This makes it consistent relative to the vertical scroll axis (and other platforms).

Ok, I realize that there are two possible cases here. Either my X11 software configuration for two-finger scrolling is wrong, or the GLFW behavior is wrong. But the horizontal scroll axis scrolling is definitely inverted for me, whereas vertical is fine.

My setup: Ubuntu 13.10 x64 booted from a live USB, with default settings, Natural Scrolling enabled (it doesn't make a difference because it inverts both horizontal and vertical scrolling together). The OS config seems to be okay, because both H + V scrolling work fine in Firefox, Text Editor apps.

I tested the ./tests/events app on OS X, and scrolling towards the top left or bottom right corners results in the vertical and horizontal axes having the same sign. On X11, that's the case after applying this patch.

I tried looking for the definitive mapping of X11 buttons 4, 5, 6, 7 to axes, but there doesn't seem to be one...

However, it does seem more natural to have them in the following consistent order:

// Vertical (positive, followed by negative)
Button 4 -> +1.0
Button 5 -> -1.0

// Horizontal (positive, followed by negative)
Button 6 -> +1.0
Button 7 -> -1.0

The PR is for your convenience only. You should investigate the issue, and if you confirm that the X11 horizontal scrolling axis is indeed flipped, the PR makes it easier to fix.
