### PR TITLE
move variable declaration outside for loop to make older compilers happy

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -701,13 +701,14 @@ static int translateKey(unsigned int key)
     {
         NSEnumerator* e = [files objectEnumerator];
         char** names = calloc(count, sizeof(char*));
+	int i;
 
-        for (int i = 0;  i < count;  i++)
+        for (i = 0;  i < count;  i++)
             names[i] = strdup([[e nextObject] UTF8String]);
 
         _glfwInputDrop(window, count, (const char**) names);
 
-        for (int i = 0;  i < count;  i++)
+        for (i = 0;  i < count;  i++)
             free(names[i]);
         free(names);
     }


### PR DESCRIPTION
This patch fixes an issue introduced in 8f349e84 (2013-12-22 @ 1:28:46 PM EST) where the "for" loop variable was declared inside the for loop itself instead of external to the loop as is required for compatibility with some older compilers (e.g., Apple's GCC 4.2 using on Mac OS X 10.5 and 10.6 latest Xcode). The fix just declares the loop variable external to the loop. - MLD
