### PR TITLE
Add mods parameter to character callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The following dependencies are needed by the examples and test programs:
 
 ## Changelog
 
+ - Added `mods` parameter to character callback
  - Added `GLFWcursor` custom system cursor handle
  - Added `glfwCreateCursor`, `glfwDestroyCursor` and `glfwSetCursor` for
    managing custom system cursors

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -776,12 +776,14 @@ typedef void (* GLFWkeyfun)(GLFWwindow*,int,int,int,int);
  *
  *  @param[in] window The window that received the event.
  *  @param[in] codepoint The Unicode code point of the character.
+ *  @param[in] mods Bit field describing which [modifier keys](@ref mods) were
+ *  held down.
  *
  *  @sa glfwSetCharCallback
  *
  *  @ingroup input
  */
-typedef void (* GLFWcharfun)(GLFWwindow*,unsigned int);
+typedef void (* GLFWcharfun)(GLFWwindow*,unsigned int,int);
 
 
 /*! @brief The function signature for file drop callbacks.

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -611,7 +611,7 @@ static int translateKey(unsigned int key)
     NSUInteger i, length = [characters length];
 
     for (i = 0;  i < length;  i++)
-        _glfwInputChar(window, [characters characterAtIndex:i]);
+        _glfwInputChar(window, [characters characterAtIndex:i], mods);
 }
 
 - (void)flagsChanged:(NSEvent *)event

--- a/src/input.c
+++ b/src/input.c
@@ -153,13 +153,13 @@ void _glfwInputKey(_GLFWwindow* window, int key, int scancode, int action, int m
         window->callbacks.key((GLFWwindow*) window, key, scancode, action, mods);
 }
 
-void _glfwInputChar(_GLFWwindow* window, unsigned int codepoint)
+void _glfwInputChar(_GLFWwindow* window, unsigned int codepoint, int mods)
 {
     if (codepoint < 32 || (codepoint > 126 && codepoint < 160))
         return;
 
     if (window->callbacks.character)
-        window->callbacks.character((GLFWwindow*) window, codepoint);
+        window->callbacks.character((GLFWwindow*) window, codepoint, mods);
 }
 
 void _glfwInputScroll(_GLFWwindow* window, double xoffset, double yoffset)

--- a/src/internal.h
+++ b/src/internal.h
@@ -682,9 +682,10 @@ void _glfwInputKey(_GLFWwindow* window, int key, int scancode, int action, int m
 /*! @brief Notifies shared code of a Unicode character input event.
  *  @param[in] window The window that received the event.
  *  @param[in] codepoint The Unicode code point of the input character.
+ *  @param[in] mods The modifiers pressed when the event was generated.
  *  @ingroup event
  */
-void _glfwInputChar(_GLFWwindow* window, unsigned int codepoint);
+void _glfwInputChar(_GLFWwindow* window, unsigned int codepoint, int mods);
 
 /*! @brief Notifies shared code of a scroll event.
  *  @param[in] window The window that received the event.

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -528,7 +528,7 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
         case WM_CHAR:
         case WM_SYSCHAR:
         {
-            _glfwInputChar(window, (unsigned int) wParam);
+            _glfwInputChar(window, (unsigned int) wParam, getKeyMods());
             return 0;
         }
 
@@ -543,7 +543,7 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
                 return TRUE;
             }
 
-            _glfwInputChar(window, (unsigned int) wParam);
+            _glfwInputChar(window, (unsigned int) wParam, getKeyMods());
             return FALSE;
         }
 

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -605,7 +605,7 @@ static void processEvent(XEvent *event)
             _glfwInputKey(window, key, event->xkey.keycode, GLFW_PRESS, mods);
 
             if (character != -1)
-                _glfwInputChar(window, character);
+                _glfwInputChar(window, character, mods);
 
             break;
         }

--- a/tests/events.c
+++ b/tests/events.c
@@ -388,12 +388,18 @@ static void key_callback(GLFWwindow* window, int key, int scancode, int action, 
     }
 }
 
-static void char_callback(GLFWwindow* window, unsigned int codepoint)
+static void char_callback(GLFWwindow* window, unsigned int codepoint, int mods)
 {
     Slot* slot = glfwGetWindowUserPointer(window);
-    printf("%08x to %i at %0.3f: Character 0x%08x (%s) input\n",
+
+    printf("%08x to %i at %0.3f: Character 0x%08x (%s)",
            counter++, slot->number, glfwGetTime(), codepoint,
            get_character_string(codepoint));
+
+    if (mods)
+        printf(" (with%s)", get_mods_name(mods));
+
+    printf(" input\n");
 }
 
 static void drop_callback(GLFWwindow* window, int count, const char** names)


### PR DESCRIPTION
This is needed to correctly and **_reliably_** distinguish character events from mod+key combinations, due to the change in #40.

See the relevant discussion [here](https://github.com/glfw/glfw/commit/9c20737b60037dbbda5552a45b5af9e1314cc701#commitcomment-4744485) for context of why this is needed, and why there is no possible way to have fully reliable character input with the current API (if there is, I'd love to be corrected).

Before:

```
0000001b to 1 at 3.602: Key 0x0058 Scancode 0x0007 (X) (with super) was pressed
0000001c to 1 at 3.602: Character 0x00000078 (x) input
0000001d to 1 at 3.742: Key 0x0058 Scancode 0x0007 (X) (with super) was released
```

There was no way to reliably ignore the x character input when Cmd+X (shortcut for Cut) is pressed.

After:

```
0000001b to 1 at 3.602: Key 0x0058 Scancode 0x0007 (X) (with super) was pressed
0000001c to 1 at 3.602: Character 0x00000078 (x) (with super) input
0000001d to 1 at 3.742: Key 0x0058 Scancode 0x0007 (X) (with super) was released
```

Now it's easy to ignore the character x from being typed when the user presses Cmd+X.
