### PR TITLE
Add WS_VISIBLE to fix mode change issues with focus

### DIFF
--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -1213,10 +1213,8 @@ void _glfwPlatformSetWindowMonitor(_GLFWwindow* window,
         window->win32.dwStyle = getWindowStyle(&wndconfig);
         window->win32.dwExStyle = getWindowExStyle(&wndconfig);
 
-        DWORD styleMod   = (window->visible || monitor) ? WS_VISIBLE : 0;
-
         SetWindowLongPtr(window->win32.handle,
-                         GWL_STYLE, window->win32.dwStyle | styleMod);
+                         GWL_STYLE, window->win32.dwStyle | WS_VISIBLE);
         SetWindowLongPtr(window->win32.handle,
                          GWL_EXSTYLE, window->win32.dwExStyle);
     }


### PR DESCRIPTION
Currently SetWindowMonitor can cause the applications window to loose focus when going from windowed to fullscreen. Adding WS_VISIBLE resolves this, and should not have any negative side effects that I am aware of.
