### PR TITLE
Fix Wayland pkg-config package name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,7 +296,7 @@ endif()
 #--------------------------------------------------------------------
 if (_GLFW_WAYLAND)
     find_package(Wayland REQUIRED)
-    set(GLFW_PKG_DEPS "${GLFW_PKG_DEPS} wayland")
+    set(GLFW_PKG_DEPS "${GLFW_PKG_DEPS} wayland-egl")
 
     list(APPEND glfw_INCLUDE_DIRS ${WAYLAND_INCLUDE_DIR})
     list(APPEND glfw_LIBRARIES ${WAYLAND_LIBRARIES})


### PR DESCRIPTION
wayland-egl also includes wayland-client the package wayland does not exist (anymore?)
