### PR TITLE
wayland: Release input focus when window is destroyed

### DIFF
--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -33,7 +33,6 @@
 #include <sys/mman.h>
 #include <unistd.h>
 #include <wayland-client.h>
-#include <wayland-client-protocol.h>
 #include <wayland-cursor.h>
 
 #include "xkb_unicode.h"
@@ -56,7 +55,10 @@ static void pointerHandleLeave(void* data,
                                uint32_t serial,
                                struct wl_surface* surface)
 {
-    _GLFWwindow* window = wl_surface_get_user_data(surface);
+    _GLFWwindow* window = _glfw.wl.pointerFocus;
+
+    if (!window)
+        return;
 
     _glfw.wl.pointerFocus = NULL;
     _glfwInputCursorEnter(window, GL_FALSE);
@@ -69,6 +71,9 @@ static void pointerHandleMotion(void* data,
                                 wl_fixed_t sy)
 {
     _GLFWwindow* window = _glfw.wl.pointerFocus;
+
+    if (!window)
+        return;
 
     if (window->cursorMode == GLFW_CURSOR_DISABLED)
     {
@@ -93,6 +98,9 @@ static void pointerHandleButton(void* data,
     _GLFWwindow* window = _glfw.wl.pointerFocus;
     int glfwButton;
 
+    if (!window)
+        return;
+
     /* Makes left, right and middle 0, 1 and 2. Overall order follows evdev
      * codes. */
     glfwButton = button - BTN_LEFT;
@@ -114,6 +122,9 @@ static void pointerHandleAxis(void* data,
     _GLFWwindow* window = _glfw.wl.pointerFocus;
     double scroll_factor;
     double x, y;
+
+    if (!window)
+        return;
 
     /* Wayland scroll events are in pointer motion coordinate space (think
      * two finger scroll). The factor 10 is commonly used to convert to
@@ -223,6 +234,9 @@ static void keyboardHandleLeave(void* data,
                                 struct wl_surface* surface)
 {
     _GLFWwindow* window = _glfw.wl.keyboardFocus;
+
+    if (!window)
+        return;
 
     _glfw.wl.keyboardFocus = NULL;
     _glfwInputWindowFocus(window, GL_FALSE);
@@ -365,6 +379,9 @@ static void keyboardHandleKey(void* data,
     int action;
     const xkb_keysym_t *syms;
     _GLFWwindow* window = _glfw.wl.keyboardFocus;
+
+    if (!window)
+        return;
 
     keyCode = toGLFWKeyCode(key);
     action = state == WL_KEYBOARD_KEY_STATE_PRESSED

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -127,6 +127,17 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
 
 void _glfwPlatformDestroyWindow(_GLFWwindow* window)
 {
+    if (window == _glfw.wl.pointerFocus)
+    {
+        _glfw.wl.pointerFocus = NULL;
+        _glfwInputCursorEnter(window, GL_FALSE);
+    }
+    if (window == _glfw.wl.keyboardFocus)
+    {
+        _glfw.wl.keyboardFocus = NULL;
+        _glfwInputWindowFocus(window, GL_FALSE);
+    }
+
     _glfwDestroyContext(window);
 
     if (window->wl.native)


### PR DESCRIPTION
This fixes a seg. fault on the reopen test because events might occur after the window is destroyed (for example leave events).

also removed `wayland-client-protocol.h` because it's included in `wayland-client.h`
