### PR TITLE
Fixed win32 issue with Fullscreen to Window retaining HWND_TOPMOST.

### DIFF
--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -1242,9 +1242,9 @@ void _glfwPlatformSetWindowMonitor(_GLFWwindow* window,
         int fullWidth, fullHeight;
         getFullWindowSize(window, width, height, &fullWidth, &fullHeight);
 
-        SetWindowPos(window->win32.handle, HWND_TOPMOST,
+        SetWindowPos(window->win32.handle, HWND_NOTOPMOST,
                      0, 0, fullWidth, fullHeight,
-                     SWP_NOMOVE | SWP_NOZORDER | SWP_FRAMECHANGED);
+                     SWP_NOMOVE | SWP_FRAMECHANGED);
     }
 }
 


### PR DESCRIPTION
HWND_NOTOPMOST used to set as highest non top window, and removed SWP_NOZORDER to ensure the HWND_NOTOPMOST parameter is used.

This prevents the windowed mode view from obscuring other windows even when these windows have the focus.
