### PR TITLE
Set window Background to black

### DIFF
--- a/examples/boing.c
+++ b/examples/boing.c
@@ -201,7 +201,7 @@ void init( void )
    /*
     * Clear background.
     */
-   glClearColor( 0.55f, 0.55f, 0.55f, 0.f );
+   glClearColor( 0.55f, 0.55f, 0.55f, 0.5f );
 
    glShadeModel( GL_FLAT );
 }

--- a/examples/gears.c
+++ b/examples/gears.c
@@ -278,6 +278,8 @@ static void init(int argc, char *argv[])
   glEnable(GL_LIGHT0);
   glEnable(GL_DEPTH_TEST);
 
+  glClearColor(0.f, 0.f, 0.f, 0.7f);
+
   /* make the gears */
   gear1 = glGenLists(1);
   glNewList(gear1, GL_COMPILE);

--- a/examples/heightmap.c
+++ b/examples/heightmap.c
@@ -562,7 +562,7 @@ int main(int argc, char** argv)
 
     /* setup the scene ready for rendering */
     glViewport(0, 0, 800, 600);
-    glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+    glClearColor(0.f, 0.f, 0.f, 1.f);
 
     /* main loop */
     frame = 0;

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -60,6 +60,8 @@ int main(void)
 
     glfwSetKeyCallback(window, key_callback);
 
+    glClearColor(0.f, 0.f, 0.f, 0.7f);
+
     while (!glfwWindowShouldClose(window))
     {
         float ratio;

--- a/examples/wave.c
+++ b/examples/wave.c
@@ -185,7 +185,7 @@ void init_opengl(void)
     glPointSize(2.0);
 
     // Background color is black
-    glClearColor(0, 0, 0, 0);
+    glClearColor(0.f, 0.f, 0.f, 1.f);
 }
 
 

--- a/src/window.c
+++ b/src/window.c
@@ -239,11 +239,6 @@ GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height,
         return NULL;
     }
 
-    // Clearing the front buffer to black to avoid garbage pixels left over
-    // from previous uses of our bit of VRAM
-    glClear(GL_COLOR_BUFFER_BIT);
-    _glfwPlatformSwapBuffers(window);
-
     // Restore the previously current context (or NULL)
     _glfwPlatformMakeContextCurrent(previous);
 

--- a/tests/accuracy.c
+++ b/tests/accuracy.c
@@ -107,6 +107,8 @@ int main(void)
 
     set_swap_interval(window, swap_interval);
 
+    glClearColor(0.f, 0.f, 0.f, 1.f);
+
     while (!glfwWindowShouldClose(window))
     {
         glClear(GL_COLOR_BUFFER_BIT);

--- a/tests/clipboard.c
+++ b/tests/clipboard.c
@@ -130,7 +130,7 @@ int main(int argc, char** argv)
     glOrtho(-1.f, 1.f, -1.f, 1.f, -1.f, 1.f);
     glMatrixMode(GL_MODELVIEW);
 
-    glClearColor(0.5f, 0.5f, 0.5f, 0);
+    glClearColor(0.5f, 0.5f, 0.5f, 1.f);
 
     while (!glfwWindowShouldClose(window))
     {

--- a/tests/cursoranim.c
+++ b/tests/cursoranim.c
@@ -111,6 +111,8 @@ int main(void)
 
     t0 = glfwGetTime();
 
+    glClearColor(0.f, 0.f, 0.f, 1.f);
+
     while (!glfwWindowShouldClose(window))
     {
         glClear(GL_COLOR_BUFFER_BIT);

--- a/tests/events.c
+++ b/tests/events.c
@@ -304,6 +304,7 @@ static void window_refresh_callback(GLFWwindow* window)
            counter++, slot->number, glfwGetTime());
 
     glfwMakeContextCurrent(window);
+    glClearColor(0.f, 0.f, 0.f, 1.f);
     glClear(GL_COLOR_BUFFER_BIT);
     glfwSwapBuffers(window);
 }

--- a/tests/fsaa.c
+++ b/tests/fsaa.c
@@ -127,6 +127,8 @@ int main(int argc, char** argv)
     glOrtho(0.f, 1.f, 0.f, 0.5f, 0.f, 1.f);
     glMatrixMode(GL_MODELVIEW);
 
+    glClearColor(0.f, 0.f, 0.f, 1.f);
+
     while (!glfwWindowShouldClose(window))
     {
         GLfloat time = (GLfloat) glfwGetTime();

--- a/tests/gamma.c
+++ b/tests/gamma.c
@@ -162,7 +162,7 @@ int main(int argc, char** argv)
     glOrtho(-1.f, 1.f, -1.f, 1.f, -1.f, 1.f);
     glMatrixMode(GL_MODELVIEW);
 
-    glClearColor(0.5f, 0.5f, 0.5f, 0);
+    glClearColor(0.5f, 0.5f, 0.5f, 1.f);
 
     while (!glfwWindowShouldClose(window))
     {

--- a/tests/iconify.c
+++ b/tests/iconify.c
@@ -165,11 +165,11 @@ int main(int argc, char** argv)
         glfwGetFramebufferSize(window, &width, &height);
 
         glScissor(0, 0, width, height);
-        glClearColor(0, 0, 0, 0);
+        glClearColor(0.f, 0.f, 0.f, 1.f);
         glClear(GL_COLOR_BUFFER_BIT);
 
         glScissor(0, 0, 640, 480);
-        glClearColor(1, 1, 1, 0);
+        glClearColor(1.f, 1.f, 1.f, 1.f);
         glClear(GL_COLOR_BUFFER_BIT);
 
         glfwSwapBuffers(window);

--- a/tests/joysticks.c
+++ b/tests/joysticks.c
@@ -217,6 +217,8 @@ int main(void)
     glfwMakeContextCurrent(window);
     glfwSwapInterval(1);
 
+    glClearColor(0.f, 0.f, 0.f, 1.f);
+
     while (!glfwWindowShouldClose(window))
     {
         glClear(GL_COLOR_BUFFER_BIT);

--- a/tests/modes.c
+++ b/tests/modes.c
@@ -151,6 +151,7 @@ static void test_modes(GLFWmonitor* monitor)
         glfwSwapInterval(1);
 
         glfwSetTime(0.0);
+        glClearColor(0.f, 0.f, 0.f, 1.f);
 
         while (glfwGetTime() < 5.0)
         {

--- a/tests/peter.c
+++ b/tests/peter.c
@@ -116,7 +116,7 @@ int main(void)
         exit(EXIT_FAILURE);
     }
 
-    glClearColor(0.f, 0.f, 0.f, 0.f);
+    glClearColor(0.f, 0.f, 0.f, 1.f);
 
     while (!glfwWindowShouldClose(window))
     {

--- a/tests/reopen.c
+++ b/tests/reopen.c
@@ -143,6 +143,7 @@ int main(int argc, char** argv)
         glMatrixMode(GL_MODELVIEW);
 
         glfwSetTime(0.0);
+        glClearColor(0.f, 0.f, 0.f, 1.f);
 
         while (glfwGetTime() < 5.0)
         {

--- a/tests/tearing.c
+++ b/tests/tearing.c
@@ -102,6 +102,8 @@ int main(void)
     glOrtho(-1.f, 1.f, -1.f, 1.f, 1.f, -1.f);
     glMatrixMode(GL_MODELVIEW);
 
+    glClearColor(0.f, 0.f, 0.f, 1.f);
+
     while (!glfwWindowShouldClose(window))
     {
         glClear(GL_COLOR_BUFFER_BIT);

--- a/tests/threads.c
+++ b/tests/threads.c
@@ -61,7 +61,7 @@ static int thread_main(void* data)
     while (running)
     {
         const float v = (float) fabs(sin(glfwGetTime() * 2.f));
-        glClearColor(thread->r * v, thread->g * v, thread->b * v, 0.f);
+        glClearColor(thread->r * v, thread->g * v, thread->b * v, 1.f);
 
         glClear(GL_COLOR_BUFFER_BIT);
         glfwSwapBuffers(thread->window);

--- a/tests/title.c
+++ b/tests/title.c
@@ -63,6 +63,8 @@ int main(void)
 
     glfwSetFramebufferSizeCallback(window, framebuffer_size_callback);
 
+    glClearColor(0.f, 0.f, 0.f, 1.f);
+
     while (!glfwWindowShouldClose(window))
     {
         glClear(GL_COLOR_BUFFER_BIT);

--- a/tests/windows.c
+++ b/tests/windows.c
@@ -85,7 +85,7 @@ int main(void)
         glClearColor((GLclampf) (i & 1),
                      (GLclampf) (i >> 1),
                      i ? 0.f : 1.f,
-                     0.f);
+                     1.f);
 
         glfwGetWindowFrameSize(windows[i], &left, &top, &right, &bottom);
         glfwSetWindowPos(windows[i],


### PR DESCRIPTION
The background was being set to transparent, for example on wayland you couldn't see the window if only the background was set with an alpha value of 0 . This patch sets the clear color of tests and examples to black (and some to a transparent black). It also removes the first frame that was being drawn when a window is created avoiding a initial blink.

Ricardo