### PR TITLE
Upstream biicode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ tests/title
 tests/version
 tests/windows
 
+bii
+bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -545,6 +545,11 @@ configure_file("${GLFW_SOURCE_DIR}/src/glfw3.pc.in"
 #--------------------------------------------------------------------
 add_subdirectory(src)
 
+IF(BIICODE)
+    INCLUDE(biicode.cmake)
+    return ()
+ENDIF()
+
 if (GLFW_BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
@@ -583,4 +588,3 @@ if (GLFW_INSTALL)
                           "${GLFW_BINARY_DIR}/cmake_uninstall.cmake")
     endif()
 endif()
-

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ See the
 guide in the GLFW documentation.
 
 
+### Using GLFW with biicode
+
+GLFW is available at [biicode](http://www.biicode.com) C/C++ dependency
+manager, you can find the [block here](http://www.biicode.com/diego/glfw), and
+[examples of use here](http://docs.biicode.com/c++/examples/glfw.html)
+
+
 ## Reporting bugs
 
 Bugs are reported to our [issue tracker](https://github.com/glfw/glfw/issues).

--- a/biicode.cmake
+++ b/biicode.cmake
@@ -1,0 +1,26 @@
+INIT_BIICODE_BLOCK()
+
+#Biicode defines its own targets. Include src CMakeLists to load variables
+#with the adequate source files depending on the system
+
+FOREACH(var ${BII_LIB_SRC})
+    STRING(REGEX MATCH "deps/.*\\.c" item ${var})
+    IF(item)
+        LIST(APPEND glfw_deps_SOURCES ${var})
+    ENDIF()
+ENDFOREACH()
+SET(BII_LIB_SRC)
+SET(BII_LIB_DEPS glfw ${glfw_LIBRARIES})
+
+if(glfw_deps_SOURCES)
+    SET(BII_BLOCK_TARGET "${BII_BLOCK_USER}_${BII_BLOCK_NAME}_interface")
+    ADD_LIBRARY(glfw_deps ${glfw_deps_SOURCES})
+    target_include_directories(glfw_deps PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/deps)
+    SET(BII_LIB_DEPS ${BII_LIB_DEPS} glfw_deps)
+endif()
+
+# This defines the library (static), tests and examples executables
+ADD_BIICODE_TARGETS()
+
+# to make transitive the location of includes
+target_include_directories(${BII_LIB_TARGET} INTERFACE ${GLFW_BINARY_DIR}/src)

--- a/biicode.conf
+++ b/biicode.conf
@@ -16,3 +16,7 @@
 	deps/getopt.c + deps/getopt.h
 	tests/* + deps/getopt.h
 	examples/* + deps/getopt.h
+	examples/boing.c - tests/*
+
+[tests]
+    tests/*

--- a/biicode.conf
+++ b/biicode.conf
@@ -1,0 +1,18 @@
+# Biicode configuration file
+[requirements]
+
+[parent]
+	diego/glfw: 2
+
+[paths]
+	# locations in which biicode should look for includes
+	deps
+	include
+
+[dependencies]
+	# The main headers depend on all sources, and the src/CMakeLists.txt
+	*glfw*.h + include/* src/* CMake/* *.in COPYING.txt
+	# This has to be made explicit to avoid detection of dependency to system getopt.h
+	deps/getopt.c + deps/getopt.h
+	tests/* + deps/getopt.h
+	examples/* + deps/getopt.h


### PR DESCRIPTION
This PR modifies (non-intrusively) the CMakeLists in order to use the www.biicode.com dependency manager.
It also adds a couple of files under the "bii" subfolder.
Included a .travis.yml proposal for initially handling travis-ci builds.

Please check:
- Biicode block: http://www.biicode.com/diego/glfw
- Biicode documentation: http://docs.biicode.com/c++/examples/glfw.html
- Github fork: https://github.com/drodri/glfw
- Travis build: https://travis-ci.org/drodri/glfw