### PR TITLE
Make glfwPostEmptyEvent thread-safe

### DIFF
--- a/src/x11_init.c
+++ b/src/x11_init.c
@@ -29,10 +29,12 @@
 
 #include <X11/Xresource.h>
 
+#include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>
 #include <stdio.h>
+#include <unistd.h>
 
 
 // Translate an X11 key code to a GLFW key code.
@@ -730,6 +732,8 @@ int _glfwPlatformInit(void)
     _glfw.x11.screen = DefaultScreen(_glfw.x11.display);
     _glfw.x11.root = RootWindow(_glfw.x11.display, _glfw.x11.screen);
     _glfw.x11.context = XUniqueContext();
+
+    pipe2(_glfw.x11.emptyEventFDs, O_CLOEXEC);
 
     if (!initExtensions())
         return GL_FALSE;

--- a/src/x11_platform.h
+++ b/src/x11_platform.h
@@ -121,6 +121,9 @@ typedef struct _GLFWlibraryX11
     // LUT for mapping X11 key codes to GLFW key codes
     int             keyCodeLUT[256];
 
+    // File descriptors for glfwPostEmptyEvent()
+    int             emptyEventFDs[2];
+
     // Window manager atoms
     Atom            WM_PROTOCOLS;
     Atom            WM_STATE;

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -43,6 +43,8 @@
 #define Button6            6
 #define Button7            7
 
+#define MAX(a,b)    ((a) > (b) ? (a) : (b))
+
 typedef struct
 {
     unsigned long flags;
@@ -1669,15 +1671,24 @@ void _glfwPlatformWaitEvents(void)
     {
         fd_set fds;
         const int fd = ConnectionNumber(_glfw.x11.display);
+        const int emptyEventFD = _glfw.x11.emptyEventFDs[0];
 
         FD_ZERO(&fds);
         FD_SET(fd, &fds);
+        FD_SET(emptyEventFD, &fds);
 
         // select(1) is used instead of an X function like XNextEvent, as the
         // wait inside those are guarded by the mutex protecting the display
-        // struct, locking out other threads from using X (including GLX)
-        if (select(fd + 1, &fds, NULL, NULL, NULL) < 0)
+        // struct, locking out other threads from using X (including GLX).
+        // Also, it lets us avoid synchronization on the display, which is
+        // important since glfwPostEmptyEvent() can be called from other
+        // threads.
+        if (select(MAX(fd, emptyEventFD) + 1, &fds, NULL, NULL, NULL) < 0)
             return;
+
+        char zero;
+        if (FD_ISSET(emptyEventFD, &fds))
+            read(emptyEventFD, &zero, 1);
     }
 
     _glfwPlatformPollEvents();
@@ -1685,17 +1696,8 @@ void _glfwPlatformWaitEvents(void)
 
 void _glfwPlatformPostEmptyEvent(void)
 {
-    XEvent event;
-    _GLFWwindow* window = _glfw.windowListHead;
-
-    memset(&event, 0, sizeof(event));
-    event.type = ClientMessage;
-    event.xclient.window = window->x11.handle;
-    event.xclient.format = 32; // Data is 32-bit longs
-    event.xclient.message_type = _glfw.x11._NULL;
-
-    XSendEvent(_glfw.x11.display, window->x11.handle, False, 0, &event);
-    XFlush(_glfw.x11.display);
+    char zero = 0;
+    write(_glfw.x11.emptyEventFDs[1], &zero, 1);
 }
 
 void _glfwPlatformSetCursorPos(_GLFWwindow* window, double x, double y)


### PR DESCRIPTION
The old code was not using `XSendEvent()` in a thread-safe manner, which could
cause messages to be corrupted. The thread-safe way to use `XSendEvent()` from
multiple threads would be to use `XLockDisplay()` and `XUnlockDisplay()` around
every call to Xlib. However, this would add unnecessary overhead to all X
communication. To avoid that, this patch changes the synchronization mechanism
of `glfwPostEmptyEvent()` on X11 from an X event to a send on a Unix pipe.
Because `glfwWaitEvents()` was already using `select()` for blocking, this
turned out to fit in quite naturally with the existing design and eliminates
the thread safety issues.