### PR TITLE
fixing build errors with Clang C++ on Linux

### DIFF
--- a/src/glx_context.c
+++ b/src/glx_context.c
@@ -77,7 +77,7 @@ static GLboolean chooseFBConfig(const _GLFWfbconfig* desired, GLXFBConfig* resul
         return GL_FALSE;
     }
 
-    usableConfigs = calloc(nativeCount, sizeof(_GLFWfbconfig));
+    usableConfigs = (_GLFWfbconfig*)calloc(nativeCount, sizeof(_GLFWfbconfig));
     usableCount = 0;
 
     for (i = 0;  i < nativeCount;  i++)

--- a/src/input.c
+++ b/src/input.c
@@ -369,7 +369,7 @@ GLFWAPI GLFWcursor* glfwCreateCursor(const GLFWimage* image, int xhot, int yhot)
 
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
 
-    cursor = calloc(1, sizeof(_GLFWcursor));
+    cursor = (_GLFWcursor*)calloc(1, sizeof(_GLFWcursor));
     cursor->next = _glfw.cursorListHead;
     _glfw.cursorListHead = cursor;
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -28,6 +28,10 @@
 #ifndef _internal_h_
 #define _internal_h_
 
+#ifdef __cplusplus
+#include <utility> // for std::swap
+#endif
+
 
 #if defined(_GLFW_USE_CONFIG_H)
  #include "glfw_config.h"
@@ -127,6 +131,7 @@ typedef struct _GLFWcursor      _GLFWcursor;
     }
 
 // Swaps the provided pointers
+#if 0
 #define _GLFW_SWAP_POINTERS(x, y) \
     {                             \
         void* t;                  \
@@ -134,7 +139,9 @@ typedef struct _GLFWcursor      _GLFWcursor;
         x = y;                    \
         y = t;                    \
     }
-
+#else
+#define _GLFW_SWAP_POINTERS(x, y) std::swap(x, y)
+#endif
 
 //========================================================================
 // Platform-independent structures

--- a/src/linux_joystick.c
+++ b/src/linux_joystick.c
@@ -78,8 +78,8 @@ static int openJoystickDevice(int joy, const char* path)
     ioctl(fd, JSIOCGBUTTONS, &buttonCount);
     _glfw.linux_js[joy].buttonCount = (int) buttonCount;
 
-    _glfw.linux_js[joy].axes = calloc(axisCount, sizeof(float));
-    _glfw.linux_js[joy].buttons = calloc(buttonCount, 1);
+    _glfw.linux_js[joy].axes = (float*)calloc(axisCount, sizeof(float));
+    _glfw.linux_js[joy].buttons = (unsigned char*)calloc(buttonCount, 1);
 
     _glfw.linux_js[joy].present = GL_TRUE;
 #endif // __linux__

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -38,8 +38,8 @@
 static int compareVideoModes(const void* firstPtr, const void* secondPtr)
 {
     int firstBPP, secondBPP, firstSize, secondSize;
-    const GLFWvidmode* first = firstPtr;
-    const GLFWvidmode* second = secondPtr;
+    const GLFWvidmode* first = (const GLFWvidmode*)firstPtr;
+    const GLFWvidmode* second = (const GLFWvidmode*)secondPtr;
 
     // First sort on color bits per pixel
     firstBPP = first->redBits + first->greenBits + first->blueBits;
@@ -164,7 +164,7 @@ void _glfwInputMonitorChange(void)
 
 _GLFWmonitor* _glfwAllocMonitor(const char* name, int widthMM, int heightMM)
 {
-    _GLFWmonitor* monitor = calloc(1, sizeof(_GLFWmonitor));
+    _GLFWmonitor* monitor = (_GLFWmonitor*)calloc(1, sizeof(_GLFWmonitor));
     monitor->name = strdup(name);
     monitor->widthMM = widthMM;
     monitor->heightMM = heightMM;
@@ -187,9 +187,9 @@ void _glfwFreeMonitor(_GLFWmonitor* monitor)
 
 void _glfwAllocGammaArrays(GLFWgammaramp* ramp, unsigned int size)
 {
-    ramp->red = calloc(size, sizeof(unsigned short));
-    ramp->green = calloc(size, sizeof(unsigned short));
-    ramp->blue = calloc(size, sizeof(unsigned short));
+    ramp->red = (unsigned short*)calloc(size, sizeof(unsigned short));
+    ramp->green = (unsigned short*)calloc(size, sizeof(unsigned short));
+    ramp->blue = (unsigned short*)calloc(size, sizeof(unsigned short));
     ramp->size = size;
 }
 

--- a/src/posix_tls.c
+++ b/src/posix_tls.c
@@ -61,6 +61,6 @@ void _glfwSetCurrentContext(_GLFWwindow* context)
 
 _GLFWwindow* _glfwPlatformGetCurrentContext(void)
 {
-    return pthread_getspecific(_glfw.posix_tls.context);
+    return (_GLFWwindow*)pthread_getspecific(_glfw.posix_tls.context);
 }
 

--- a/src/window.c
+++ b/src/window.c
@@ -183,7 +183,7 @@ GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height,
     if (!_glfwIsValidContextConfig(&ctxconfig))
         return NULL;
 
-    window = calloc(1, sizeof(_GLFWwindow));
+    window = (_GLFWwindow*)calloc(1, sizeof(_GLFWwindow));
     window->next = _glfw.windowListHead;
     _glfw.windowListHead = window;
 

--- a/src/x11_monitor.c
+++ b/src/x11_monitor.c
@@ -235,7 +235,7 @@ _GLFWmonitor** _glfwPlatformGetMonitors(int* count)
                 if (found == size)
                 {
                     size += 4;
-                    monitors = realloc(monitors, sizeof(_GLFWmonitor*) * size);
+                    monitors = (_GLFWmonitor**)realloc(monitors, sizeof(_GLFWmonitor*) * size);
                 }
 
                 monitors[found] = _glfwAllocMonitor(oi->name,
@@ -249,8 +249,9 @@ _GLFWmonitor** _glfwPlatformGetMonitors(int* count)
                 {
                     if (screens[k].x_org == ci->x &&
                         screens[k].y_org == ci->y &&
-                        screens[k].width == ci->width &&
-                        screens[k].height == ci->height)
+						// cast to int to avoid sign comparison warning
+                        screens[k].width == (int)ci->width &&
+                        screens[k].height == (int)ci->height)
                     {
                         monitors[found]->x11.index = k;
                         break;
@@ -283,7 +284,7 @@ _GLFWmonitor** _glfwPlatformGetMonitors(int* count)
 
     if (!monitors)
     {
-        monitors = calloc(1, sizeof(_GLFWmonitor*));
+        monitors = (_GLFWmonitor**)calloc(1, sizeof(_GLFWmonitor*));
         monitors[0] = _glfwAllocMonitor("Display",
                                         DisplayWidthMM(_glfw.x11.display,
                                                        _glfw.x11.screen),
@@ -340,7 +341,7 @@ GLFWvidmode* _glfwPlatformGetVideoModes(_GLFWmonitor* monitor, int* found)
         ci = XRRGetCrtcInfo(_glfw.x11.display, sr, monitor->x11.crtc);
         oi = XRRGetOutputInfo(_glfw.x11.display, sr, monitor->x11.output);
 
-        result = calloc(oi->nmode, sizeof(GLFWvidmode));
+        result = (GLFWvidmode*)calloc(oi->nmode, sizeof(GLFWvidmode));
 
         for (i = 0;  i < oi->nmode;  i++)
         {
@@ -373,7 +374,7 @@ GLFWvidmode* _glfwPlatformGetVideoModes(_GLFWmonitor* monitor, int* found)
     else
     {
         *found = 1;
-        result = calloc(1, sizeof(GLFWvidmode));
+        result = (GLFWvidmode*)calloc(1, sizeof(GLFWvidmode));
         _glfwPlatformGetVideoMode(monitor, result);
     }
 

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -157,8 +157,8 @@ static char** parseUriList(char* text, int* count)
 
         (*count)++;
 
-        char* name = calloc(strlen(line) + 1, 1);
-        names = realloc(names, *count * sizeof(char*));
+        char* name = (char*)calloc(strlen(line) + 1, 1);
+        names = (char**)realloc(names, *count * sizeof(char*));
         names[*count - 1] = name;
 
         while (*line)


### PR DESCRIPTION
- fixed invalid conversion by adding C casts. Also fixed the swap pointers thing with std::swap for C++.
- note: many more errors probably exist on the other platform files; I cannot
  test any of those now.
