### PR TITLE
Use inotify_rm_watch rather than close to remove joystick watch

### DIFF
--- a/src/linux_joystick.c
+++ b/src/linux_joystick.c
@@ -277,11 +277,13 @@ void _glfwTerminateJoysticks(void)
 
     regfree(&_glfw.linux_js.regex);
 
-    if (_glfw.linux_js.watch > 0)
-        close(_glfw.linux_js.watch);
-
     if (_glfw.linux_js.inotify > 0)
+    {
+        if (_glfw.linux_js.watch > 0)
+            inotify_rm_watch(_glfw.linux_js.inotify, _glfw.linux_js.watch);
+
         close(_glfw.linux_js.inotify);
+    }
 #endif // __linux__
 }
 


### PR DESCRIPTION
The Linux joystick watch is added with inotify_add_watch(), so it should be removed with the corresponding inotify_rm_watch(). The call to close() caused log messages to stop being printed to the screen on my system.