### PR TITLE
Fixes for memory leaks

### DIFF
--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -612,6 +612,8 @@ void _glfwPlatformTerminate(void)
         wl_display_flush(_glfw.wl.display);
     if (_glfw.wl.display)
         wl_display_disconnect(_glfw.wl.display);
+    if (_glfw.wl.monitors)
+        free(_glfw.wl.monitors);
 }
 
 const char* _glfwPlatformGetVersionString(void)

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -627,6 +627,8 @@ void _glfwPlatformTerminate(void)
         }
         free(_glfw.wl.monitors);
     }
+
+    xkb_context_unref(_glfw.wl.xkb.context);
 }
 
 const char* _glfwPlatformGetVersionString(void)

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -612,8 +612,21 @@ void _glfwPlatformTerminate(void)
         wl_display_flush(_glfw.wl.display);
     if (_glfw.wl.display)
         wl_display_disconnect(_glfw.wl.display);
+
     if (_glfw.wl.monitors)
+    {
+        int i;
+        for (i = 0; i < _glfw.wl.monitorsCount; ++i)
+        {
+            if (_glfw.wl.monitors[i])
+            {
+                if (_glfw.wl.monitors[i]->wl.modes)
+                    free(_glfw.wl.monitors[i]->wl.modes);
+                free(_glfw.wl.monitors[i]);
+            }
+        }
         free(_glfw.wl.monitors);
+    }
 }
 
 const char* _glfwPlatformGetVersionString(void)

--- a/src/wl_monitor.c
+++ b/src/wl_monitor.c
@@ -180,10 +180,9 @@ _GLFWmonitor** _glfwPlatformGetMonitors(int* count)
         _GLFWmonitor* origMonitor = _glfw.wl.monitors[i];
         monitor = calloc(1, sizeof(_GLFWmonitor));
 
-        monitor->modes =
-            _glfwPlatformGetVideoModes(origMonitor,
-                                       &origMonitor->wl.modesCount);
         *monitor = *_glfw.wl.monitors[i];
+        monitor->modes = _glfwPlatformGetVideoModes(origMonitor, &origMonitor->wl.modesCount);
+        monitor->modeCount = origMonitor->wl.modesCount;
         monitors[i] = monitor;
     }
 


### PR DESCRIPTION
Some core resources not freed when glfw terminates:
monitors, modes, xkb