### PR TITLE
Not checking for internal window pointer when making the context current

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -530,9 +530,6 @@ GLFWAPI void glfwMakeContextCurrent(GLFWwindow* handle)
 
     _GLFW_REQUIRE_INIT();
 
-    if (_glfwPlatformGetCurrentContext() == window)
-        return;
-
     _glfwPlatformMakeContextCurrent(window);
 }
 


### PR DESCRIPTION
Removed the check for internal window pointer, because if some part of the GUI (like NSOpenPanel on OS X) changes current OpenGL context, glfwMakeContextCurrent does not set it back to the glfw's one.