### PR TITLE
Fix bug for fullscreen window on Yosemite with multiple monitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ GLFW bundles a number of dependencies in the `deps/` directory.
 
 ## Changelog
 
+ - Bugfix: Initialization failed on headless systems
+
 
 ## Contact
 

--- a/src/cocoa_init.m
+++ b/src/cocoa_init.m
@@ -269,4 +269,3 @@ const char* _glfwPlatformGetVersionString(void)
 
     return version;
 }
-

--- a/src/cocoa_monitor.m
+++ b/src/cocoa_monitor.m
@@ -286,7 +286,6 @@ _GLFWmonitor** _glfwPlatformGetMonitors(int* count)
 
         monitor = _glfwAllocMonitor(name, size.width, size.height);
         monitor->ns.displayID = displays[i];
-        monitor->ns.screen = [screens objectAtIndex:j];
 
         free(name);
 
@@ -427,4 +426,3 @@ GLFWAPI CGDirectDisplayID glfwGetCocoaMonitor(GLFWmonitor* handle)
     _GLFW_REQUIRE_INIT_OR_RETURN(kCGNullDirectDisplay);
     return monitor->ns.displayID;
 }
-

--- a/src/cocoa_platform.h
+++ b/src/cocoa_platform.h
@@ -92,7 +92,6 @@ typedef struct _GLFWmonitorNS
 {
     CGDirectDisplayID   displayID;
     CGDisplayModeRef    previousMode;
-    id                  screen;
 
 } _GLFWmonitorNS;
 

--- a/src/init.c
+++ b/src/init.c
@@ -129,13 +129,6 @@ GLFWAPI int glfwInit(void)
     }
 
     _glfw.monitors = _glfwPlatformGetMonitors(&_glfw.monitorCount);
-    if (!_glfw.monitorCount)
-    {
-        _glfwInputError(GLFW_PLATFORM_ERROR, "No monitors found");
-        _glfwPlatformTerminate();
-        return GL_FALSE;
-    }
-
     _glfwInitialized = GL_TRUE;
 
     // Not all window hints have zero as their default value

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -305,6 +305,10 @@ GLFWAPI GLFWmonitor** glfwGetMonitors(int* count)
 GLFWAPI GLFWmonitor* glfwGetPrimaryMonitor(void)
 {
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
+
+    if (!_glfw.monitorCount)
+        return NULL;
+
     return (GLFWmonitor*) _glfw.monitors[0];
 }
 


### PR DESCRIPTION
This is a quick-and-dirty fix to issue #492.  It checks if

	window->monitor->ns.screen

points to a valid screen, and update it when necessary.