### PR TITLE
FIX: Should be null in case of no monitors

### DIFF
--- a/src/x11_monitor.c
+++ b/src/x11_monitor.c
@@ -201,7 +201,7 @@ void _glfwRestoreVideoMode(_GLFWmonitor* monitor)
 _GLFWmonitor** _glfwPlatformGetMonitors(int* count)
 {
     int i, j, k, found = 0;
-    _GLFWmonitor** monitors;
+    _GLFWmonitor** monitors = NULL;
 
     *count = 0;
 


### PR DESCRIPTION
Closes #497.

Saves from a segfault when no monitors are found (e.g., when using Xvfb).

FWIW this would have been caught if some basic tests were run using Travis, as would have #225. My offer to implement some basic Travis support still stands :)