### PR TITLE
Properly restore previous context on OS X Yosemite

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -1061,12 +1061,16 @@ void _glfwPlatformShowWindow(_GLFWwindow* window)
     //       should probably not be done every time any window is shown
     [NSApp activateIgnoringOtherApps:YES];
 
+    _GLFWwindow* previous = _glfwPlatformGetCurrentContext();
     [window->ns.object makeKeyAndOrderFront:nil];
+    _glfwPlatformMakeContextCurrent(previous);
 }
 
 void _glfwPlatformUnhideWindow(_GLFWwindow* window)
 {
+    _GLFWwindow* previous = _glfwPlatformGetCurrentContext();
     [window->ns.object orderFront:nil];
+    _glfwPlatformMakeContextCurrent(previous);
 }
 
 void _glfwPlatformHideWindow(_GLFWwindow* window)

--- a/src/window.c
+++ b/src/window.c
@@ -238,9 +238,6 @@ GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height,
     glClear(GL_COLOR_BUFFER_BIT);
     _glfwPlatformSwapBuffers(window);
 
-    // Restore the previously current context (or NULL)
-    _glfwPlatformMakeContextCurrent(previous);
-
     if (wndconfig.monitor)
     {
         int width, height;
@@ -261,6 +258,9 @@ GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height,
                 _glfwPlatformUnhideWindow(window);
         }
     }
+
+    // Restore the previously current context (or NULL)
+    _glfwPlatformMakeContextCurrent(previous);
 
     return (GLFWwindow*) window;
 }

--- a/src/window.c
+++ b/src/window.c
@@ -238,6 +238,9 @@ GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height,
     glClear(GL_COLOR_BUFFER_BIT);
     _glfwPlatformSwapBuffers(window);
 
+    // Restore the previously current context (or NULL)
+    _glfwPlatformMakeContextCurrent(previous);
+
     if (wndconfig.monitor)
     {
         int width, height;
@@ -258,9 +261,6 @@ GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height,
                 _glfwPlatformUnhideWindow(window);
         }
     }
-
-    // Restore the previously current context (or NULL)
-    _glfwPlatformMakeContextCurrent(previous);
 
     return (GLFWwindow*) window;
 }


### PR DESCRIPTION
This is a fix to issue #500.

_glfwPlatformShowWindow(window) and _glfwPlatformUnhideWindow(window)
implicitly make the context of window current on OS X Yosemite, which
undoes _glfwPlatformMakeContextCurrent(previous).  To properly restore
the previous context, we call _glfwPlatformMakeContextCurrent(previous)
just before glfwCreateWindow() returns.