### PR TITLE
OS X Fix: NSWindow no Longer Crashes on Resize

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -648,6 +648,17 @@ static int translateKey(unsigned int key)
     return YES;
 }
 
+- (float)titleBarHeight
+{
+    NSRect frame = NSMakeRect (0, 0, 100, 100);
+    
+    NSRect contentRect;
+    contentRect = [NSWindow contentRectForFrameRect: frame
+                                          styleMask: NSTitledWindowMask];
+    
+    return (frame.size.height - contentRect.size.height);
+}
+
 @end
 
 
@@ -897,6 +908,10 @@ static GLboolean createWindow(_GLFWwindow* window,
     [window->ns.object setTitle:[NSString stringWithUTF8String:wndconfig->title]];
     [window->ns.object setDelegate:window->ns.delegate];
     [window->ns.object setAcceptsMouseMovedEvents:YES];
+
+    // OS X puts an application into "App Nap" if it's window size drops below 4-pixels.
+    NSUInteger minWindowHeight = 4;
+    [window->ns.object setMinSize:NSMakeSize(0, [window->ns.object titleBarHeight] + minWindowHeight)];
 
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
     if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_6)


### PR DESCRIPTION
*After doing research I found that Apple puts an NSWindow to sleep using (AppNap) after the window reaches below 4 pixels in height.
*GLFW will now set a minimum height with the OS X default title bar height taken into consideration; this resolves the issue.

Closes: #443