### PR TITLE
Implement touch events on Wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ skills.
  - Cameron King
  - Peter Knut
  - Eric Larson
+ - Quinten Lansu
  - Robin Leffmann
  - Glenn Lewis
  - Shane Liesegang

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -214,18 +214,18 @@ extern "C" {
 #define GLFW_VERSION_REVISION       2
 /*! @} */
 
-/*! @name Key and button actions
+/*! @name Key, button and touch actions
  *  @{ */
-/*! @brief The key or mouse button was released.
+/*! @brief The key or button was released or the touch ended.
  *
- *  The key or mouse button was released.
+ *  The key or button was released or the touch ended.
  *
  *  @ingroup input
  */
 #define GLFW_RELEASE                0
-/*! @brief The key or mouse button was pressed.
+/*! @brief The key or button was pressed or the touch started.
  *
- *  The key or mouse button was pressed.
+ *  The key or button was pressed or the touch started.
  *
  *  @ingroup input
  */
@@ -237,6 +237,10 @@ extern "C" {
  *  @ingroup input
  */
 #define GLFW_REPEAT                 2
+/*! @brief The touch was moved.
+ *  @ingroup input
+ */
+#define GLFW_MOVE                   3
 /*! @} */
 
 /*! @defgroup keys Keyboard keys
@@ -962,26 +966,17 @@ typedef void (* GLFWcharmodsfun)(GLFWwindow*,unsigned int,int);
  */
 typedef void (* GLFWdropfun)(GLFWwindow*,int,const char**);
 
-/*! @brief The function signature for touch start/end callbacks.
+/*! @brief The function signature for touch callbacks.
  *  @param[in] window The window that received the event.
- *  @param[in] touch The touch that started or ended.
- *  @param[in] action One of @ref GLFW_PRESS or @ref GLFW_RELEASE.
- *  @ingroup input
- *
- *  @sa glfwSetTouchCallback
- */
-typedef void (* GLFWtouchfun)(GLFWwindow*,int,int);
-
-/*! @brief The function signature for touch position callbacks.
- *  @param[in] window The window that received the event.
- *  @param[in] touch The touch that moved.
+ *  @param[in] touch The touch that triggered the event.
+ *  @param[in] action One of @ref GLFW_PRESS, @c GLFW_MOVE or @ref GLFW_RELEASE.
  *  @param[in] xpos The new x-coordinate of the touch.
  *  @param[in] ypos The new y-coordinate of the touch.
  *  @ingroup input
  *
- *  @sa glfwSetTouchPosCallback
+ *  @sa glfwSetTouchCallback
  */
-typedef void (* GLFWtouchposfun)(GLFWwindow*,int,double,double);
+typedef void (* GLFWtouchfun)(GLFWwindow*,int,int,double,double);
 
 /*! @brief The function signature for monitor configuration callbacks.
  *
@@ -2969,10 +2964,10 @@ GLFWAPI GLFWscrollfun glfwSetScrollCallback(GLFWwindow* window, GLFWscrollfun cb
  */
 GLFWAPI GLFWdropfun glfwSetDropCallback(GLFWwindow* window, GLFWdropfun cbfun);
 
-/*! @brief Sets the touch start/end callback.
+/*! @brief Sets the touch callback.
  *
  *  This function sets the touch callback, which is called when a touch is
- *  started or ended.
+ *  started, ended or moved.
  *
  *  @param[in] window The window whose callback to set.
  *  @param[in] cbfun The new scroll callback, or `NULL` to remove the currently
@@ -2983,21 +2978,6 @@ GLFWAPI GLFWdropfun glfwSetDropCallback(GLFWwindow* window, GLFWdropfun cbfun);
  *  @ingroup input
  */
 GLFWAPI GLFWtouchfun glfwSetTouchCallback(GLFWwindow* window, GLFWtouchfun cbfun);
-
-/*! @brief Sets the touch position callback.
- *
- *  This function sets the touch position callback, which is called when a touch
- *  moves.
- *
- *  @param[in] window The window whose callback to set.
- *  @param[in] cbfun The new scroll callback, or `NULL` to remove the currently
- *  set callback.
- *  @return The previously set callback, or `NULL` if no callback was set or an
- *  error occurred.
- *
- *  @ingroup input
- */
-GLFWAPI GLFWtouchposfun glfwSetTouchPosCallback(GLFWwindow* window, GLFWtouchposfun cbfun);
 
 /*! @brief Returns whether the specified joystick is present.
  *

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -638,6 +638,7 @@ extern "C" {
 #define GLFW_CURSOR                 0x00033001
 #define GLFW_STICKY_KEYS            0x00033002
 #define GLFW_STICKY_MOUSE_BUTTONS   0x00033003
+#define GLFW_TOUCH                  0x00030004
 
 #define GLFW_CURSOR_NORMAL          0x00034001
 #define GLFW_CURSOR_HIDDEN          0x00034002
@@ -960,6 +961,27 @@ typedef void (* GLFWcharmodsfun)(GLFWwindow*,unsigned int,int);
  *  @ingroup input
  */
 typedef void (* GLFWdropfun)(GLFWwindow*,int,const char**);
+
+/*! @brief The function signature for touch start/end callbacks.
+ *  @param[in] window The window that received the event.
+ *  @param[in] touch The touch that started or ended.
+ *  @param[in] action One of @ref GLFW_PRESS or @ref GLFW_RELEASE.
+ *  @ingroup input
+ *
+ *  @sa glfwSetTouchCallback
+ */
+typedef void (* GLFWtouchfun)(GLFWwindow*,int,int);
+
+/*! @brief The function signature for touch position callbacks.
+ *  @param[in] window The window that received the event.
+ *  @param[in] touch The touch that moved.
+ *  @param[in] xpos The new x-coordinate of the touch.
+ *  @param[in] ypos The new y-coordinate of the touch.
+ *  @ingroup input
+ *
+ *  @sa glfwSetTouchPosCallback
+ */
+typedef void (* GLFWtouchposfun)(GLFWwindow*,int,double,double);
 
 /*! @brief The function signature for monitor configuration callbacks.
  *
@@ -2946,6 +2968,36 @@ GLFWAPI GLFWscrollfun glfwSetScrollCallback(GLFWwindow* window, GLFWscrollfun cb
  *  @ingroup input
  */
 GLFWAPI GLFWdropfun glfwSetDropCallback(GLFWwindow* window, GLFWdropfun cbfun);
+
+/*! @brief Sets the touch start/end callback.
+ *
+ *  This function sets the touch callback, which is called when a touch is
+ *  started or ended.
+ *
+ *  @param[in] window The window whose callback to set.
+ *  @param[in] cbfun The new scroll callback, or `NULL` to remove the currently
+ *  set callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or an
+ *  error occurred.
+ *
+ *  @ingroup input
+ */
+GLFWAPI GLFWtouchfun glfwSetTouchCallback(GLFWwindow* window, GLFWtouchfun cbfun);
+
+/*! @brief Sets the touch position callback.
+ *
+ *  This function sets the touch position callback, which is called when a touch
+ *  moves.
+ *
+ *  @param[in] window The window whose callback to set.
+ *  @param[in] cbfun The new scroll callback, or `NULL` to remove the currently
+ *  set callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or an
+ *  error occurred.
+ *
+ *  @ingroup input
+ */
+GLFWAPI GLFWtouchposfun glfwSetTouchPosCallback(GLFWwindow* window, GLFWtouchposfun cbfun);
 
 /*! @brief Returns whether the specified joystick is present.
  *

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -1147,6 +1147,10 @@ void _glfwPlatformGetCursorPos(_GLFWwindow* window, double* xpos, double* ypos)
         *ypos = contentRect.size.height - pos.y - 1;
 }
 
+void _glfwPlatformSetTouchInput(_GLFWwindow* window, int enabled)
+{
+}
+
 void _glfwPlatformSetCursorPos(_GLFWwindow* window, double x, double y)
 {
     updateModeCursor(window);

--- a/src/input.c
+++ b/src/input.c
@@ -33,7 +33,7 @@
 #endif
 
 // Internal key state used for sticky keys
-#define _GLFW_STICK 3
+#define _GLFW_STICK 4
 
 
 // Sets the cursor mode for the specified window
@@ -234,16 +234,10 @@ void _glfwInputDrop(_GLFWwindow* window, int count, const char** paths)
         window->callbacks.drop((GLFWwindow*) window, count, paths);
 }
 
-void _glfwInputTouch(_GLFWwindow* window, int touch, int action)
+void _glfwInputTouch(_GLFWwindow* window, int touch, int action, double xpos, double ypos)
 {
     if (window->callbacks.touch)
-        window->callbacks.touch((GLFWwindow*) window, touch, action);
-}
-
-void _glfwInputTouchPos(_GLFWwindow* window, int touch, double xpos, double ypos)
-{
-    if (window->callbacks.touchPos)
-        window->callbacks.touchPos((GLFWwindow*) window, touch, xpos, ypos);
+        window->callbacks.touch((GLFWwindow*) window, touch, action, xpos, ypos);
 }
 
 
@@ -613,14 +607,6 @@ GLFWAPI GLFWtouchfun glfwSetTouchCallback(GLFWwindow* handle, GLFWtouchfun cbfun
     _GLFWwindow* window = (_GLFWwindow*) handle;
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
     _GLFW_SWAP_POINTERS(window->callbacks.touch, cbfun);
-    return cbfun;
-}
-
-GLFWAPI GLFWtouchposfun glfwSetTouchPosCallback(GLFWwindow* handle, GLFWtouchposfun cbfun)
-{
-    _GLFWwindow* window = (_GLFWwindow*) handle;
-    _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
-    _GLFW_SWAP_POINTERS(window->callbacks.touchPos, cbfun);
     return cbfun;
 }
 

--- a/src/input.c
+++ b/src/input.c
@@ -126,6 +126,18 @@ static void setStickyMouseButtons(_GLFWwindow* window, int enabled)
     window->stickyMouseButtons = enabled;
 }
 
+// Set touch input for the specified window
+//
+static void setTouchInput(_GLFWwindow* window, int enabled)
+{
+    if (window->touchInput == enabled)
+        return;
+
+    _glfwPlatformSetTouchInput(window, enabled);
+
+    window->touchInput = enabled;
+}
+
 
 //////////////////////////////////////////////////////////////////////////
 //////                         GLFW event API                       //////
@@ -222,6 +234,18 @@ void _glfwInputDrop(_GLFWwindow* window, int count, const char** paths)
         window->callbacks.drop((GLFWwindow*) window, count, paths);
 }
 
+void _glfwInputTouch(_GLFWwindow* window, int touch, int action)
+{
+    if (window->callbacks.touch)
+        window->callbacks.touch((GLFWwindow*) window, touch, action);
+}
+
+void _glfwInputTouchPos(_GLFWwindow* window, int touch, double xpos, double ypos)
+{
+    if (window->callbacks.touchPos)
+        window->callbacks.touchPos((GLFWwindow*) window, touch, xpos, ypos);
+}
+
 
 //////////////////////////////////////////////////////////////////////////
 //////                        GLFW public API                       //////
@@ -241,6 +265,8 @@ GLFWAPI int glfwGetInputMode(GLFWwindow* handle, int mode)
             return window->stickyKeys;
         case GLFW_STICKY_MOUSE_BUTTONS:
             return window->stickyMouseButtons;
+        case GLFW_TOUCH:
+            return window->touchInput;
         default:
             _glfwInputError(GLFW_INVALID_ENUM, "Invalid input mode");
             return 0;
@@ -263,6 +289,9 @@ GLFWAPI void glfwSetInputMode(GLFWwindow* handle, int mode, int value)
             break;
         case GLFW_STICKY_MOUSE_BUTTONS:
             setStickyMouseButtons(window, value ? GL_TRUE : GL_FALSE);
+            break;
+        case GLFW_TOUCH:
+            setTouchInput(window, value ? GL_TRUE : GL_FALSE);
             break;
         default:
             _glfwInputError(GLFW_INVALID_ENUM, "Invalid input mode");
@@ -577,6 +606,22 @@ GLFWAPI const char* glfwGetJoystickName(int joy)
     }
 
     return _glfwPlatformGetJoystickName(joy);
+}
+
+GLFWAPI GLFWtouchfun glfwSetTouchCallback(GLFWwindow* handle, GLFWtouchfun cbfun)
+{
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
+    _GLFW_SWAP_POINTERS(window->callbacks.touch, cbfun);
+    return cbfun;
+}
+
+GLFWAPI GLFWtouchposfun glfwSetTouchPosCallback(GLFWwindow* handle, GLFWtouchposfun cbfun)
+{
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
+    _GLFW_SWAP_POINTERS(window->callbacks.touchPos, cbfun);
+    return cbfun;
 }
 
 GLFWAPI void glfwSetClipboardString(GLFWwindow* handle, const char* string)

--- a/src/internal.h
+++ b/src/internal.h
@@ -280,7 +280,6 @@ struct _GLFWwindow
         GLFWcharmodsfun         charmods;
         GLFWdropfun             drop;
         GLFWtouchfun            touch;
-        GLFWtouchposfun         touchPos;
     } callbacks;
 
     // This is defined in the window API's platform.h
@@ -767,19 +766,12 @@ void _glfwInputCursorEnter(_GLFWwindow* window, int entered);
 /*! @brief Notifies shared code of a touch start/end event.
  *  @param[in] window The window that received the event.
  *  @param[in] touch The touch that started or ended.
- *  @param[in] action One of @c GLFW_PRESS or @c GLFW_RELEASE.
- *  @ingroup event
- */
-void _glfwInputTouch(_GLFWwindow* window, int touch, int action);
-
-/*! @brief Notifies shared code of a touch movement event.
- *  @param[in] window The window that received the event.
- *  @param[in] touch The touch that moved.
+ *  @param[in] action One of @c GLFW_PRESS, @c GLFW_MOVE or @c GLFW_RELEASE.
  *  @param[in] xpos The new x-coordinate of the touch.
  *  @param[in] ypos The new y-coordinate of the touch.
  *  @ingroup event
  */
-void _glfwInputTouchPos(_GLFWwindow* window, int touch, double xpos, double ypos);
+void _glfwInputTouch(_GLFWwindow* window, int touch, int action, double xpos, double ypos);
 
 /*! @ingroup event
  */

--- a/src/internal.h
+++ b/src/internal.h
@@ -244,6 +244,7 @@ struct _GLFWwindow
     GLboolean           stickyKeys;
     GLboolean           stickyMouseButtons;
     double              cursorPosX, cursorPosY;
+    GLboolean           touchInput;
     int                 cursorMode;
     char                mouseButtons[GLFW_MOUSE_BUTTON_LAST + 1];
     char                keys[GLFW_KEY_LAST + 1];
@@ -278,6 +279,8 @@ struct _GLFWwindow
         GLFWcharfun             character;
         GLFWcharmodsfun         charmods;
         GLFWdropfun             drop;
+        GLFWtouchfun            touch;
+        GLFWtouchposfun         touchPos;
     } callbacks;
 
     // This is defined in the window API's platform.h
@@ -394,6 +397,14 @@ void _glfwPlatformTerminate(void);
  *  @note The returned string must not change for the duration of the program.
  */
 const char* _glfwPlatformGetVersionString(void);
+
+/*! @brief Sets whether touch input is enabled for the specified window.
+ *  @param[in] window The window whose touch input status to change.
+ *  @param[in] enabled @c GL_TRUE to enable touch input, or @c GL_FALSE to
+ *  disable it.
+ *  @ingroup platform
+ */
+void _glfwPlatformSetTouchInput(_GLFWwindow* window, int enabled);
 
 /*! @copydoc glfwGetCursorPos
  *  @ingroup platform
@@ -752,6 +763,23 @@ void _glfwInputCursorMotion(_GLFWwindow* window, double x, double y);
  *  @ingroup event
  */
 void _glfwInputCursorEnter(_GLFWwindow* window, int entered);
+
+/*! @brief Notifies shared code of a touch start/end event.
+ *  @param[in] window The window that received the event.
+ *  @param[in] touch The touch that started or ended.
+ *  @param[in] action One of @c GLFW_PRESS or @c GLFW_RELEASE.
+ *  @ingroup event
+ */
+void _glfwInputTouch(_GLFWwindow* window, int touch, int action);
+
+/*! @brief Notifies shared code of a touch movement event.
+ *  @param[in] window The window that received the event.
+ *  @param[in] touch The touch that moved.
+ *  @param[in] xpos The new x-coordinate of the touch.
+ *  @param[in] ypos The new y-coordinate of the touch.
+ *  @ingroup event
+ */
+void _glfwInputTouchPos(_GLFWwindow* window, int touch, double xpos, double ypos);
 
 /*! @ingroup event
  */

--- a/src/win32_init.c
+++ b/src/win32_init.c
@@ -96,6 +96,22 @@ static GLboolean initLibraries(void)
             GetProcAddress(_glfw.win32.user32.instance, "SetProcessDPIAware");
         _glfw.win32.user32.ChangeWindowMessageFilterEx = (CHANGEWINDOWMESSAGEFILTEREX_T)
             GetProcAddress(_glfw.win32.user32.instance, "ChangeWindowMessageFilterEx");
+        _glfw.win32.user32.GetTouchInputInfo = (GETTOUCHINPUTINFO_T)
+            GetProcAddress(_glfw.win32.user32.instance, "GetTouchInputInfo");
+        _glfw.win32.user32.CloseTouchInputHandle = (CLOSETOUCHINPUTHANDLE_T)
+            GetProcAddress(_glfw.win32.user32.instance, "CloseTouchInputHandle");
+        _glfw.win32.user32.RegisterTouchWindow = (REGISTERTOUCHWINDOW_T)
+            GetProcAddress(_glfw.win32.user32.instance, "RegisterTouchWindow");
+        _glfw.win32.user32.UnregisterTouchWindow = (UNREGISTERTOUCHWINDOW_T)
+            GetProcAddress(_glfw.win32.user32.instance, "UnregisterTouchWindow");
+    }
+
+    if (_glfw.win32.user32.GetTouchInputInfo &&
+        _glfw.win32.user32.CloseTouchInputHandle &&
+        _glfw.win32.user32.RegisterTouchWindow &&
+        _glfw.win32.user32.UnregisterTouchWindow)
+    {
+        _glfw.win32.touch.available = GL_TRUE;
     }
 
     _glfw.win32.dwmapi.instance = LoadLibraryW(L"dwmapi.dll");

--- a/src/win32_init.c
+++ b/src/win32_init.c
@@ -90,21 +90,21 @@ static GLboolean initLibraries(void)
     }
 
     _glfw.win32.user32.instance = LoadLibraryW(L"user32.dll");
-    if (_glfw.win32.user32.instance)
-    {
-        _glfw.win32.user32.SetProcessDPIAware = (SETPROCESSDPIAWARE_T)
-            GetProcAddress(_glfw.win32.user32.instance, "SetProcessDPIAware");
-        _glfw.win32.user32.ChangeWindowMessageFilterEx = (CHANGEWINDOWMESSAGEFILTEREX_T)
-            GetProcAddress(_glfw.win32.user32.instance, "ChangeWindowMessageFilterEx");
-        _glfw.win32.user32.GetTouchInputInfo = (GETTOUCHINPUTINFO_T)
-            GetProcAddress(_glfw.win32.user32.instance, "GetTouchInputInfo");
-        _glfw.win32.user32.CloseTouchInputHandle = (CLOSETOUCHINPUTHANDLE_T)
-            GetProcAddress(_glfw.win32.user32.instance, "CloseTouchInputHandle");
-        _glfw.win32.user32.RegisterTouchWindow = (REGISTERTOUCHWINDOW_T)
-            GetProcAddress(_glfw.win32.user32.instance, "RegisterTouchWindow");
-        _glfw.win32.user32.UnregisterTouchWindow = (UNREGISTERTOUCHWINDOW_T)
-            GetProcAddress(_glfw.win32.user32.instance, "UnregisterTouchWindow");
-    }
+    if (!_glfw.win32.user32.instance)
+        return GL_FALSE;
+
+    _glfw.win32.user32.SetProcessDPIAware = (SETPROCESSDPIAWARE_T)
+        GetProcAddress(_glfw.win32.user32.instance, "SetProcessDPIAware");
+    _glfw.win32.user32.ChangeWindowMessageFilterEx = (CHANGEWINDOWMESSAGEFILTEREX_T)
+        GetProcAddress(_glfw.win32.user32.instance, "ChangeWindowMessageFilterEx");
+    _glfw.win32.user32.GetTouchInputInfo = (GETTOUCHINPUTINFO_T)
+        GetProcAddress(_glfw.win32.user32.instance, "GetTouchInputInfo");
+    _glfw.win32.user32.CloseTouchInputHandle = (CLOSETOUCHINPUTHANDLE_T)
+        GetProcAddress(_glfw.win32.user32.instance, "CloseTouchInputHandle");
+    _glfw.win32.user32.RegisterTouchWindow = (REGISTERTOUCHWINDOW_T)
+        GetProcAddress(_glfw.win32.user32.instance, "RegisterTouchWindow");
+    _glfw.win32.user32.UnregisterTouchWindow = (UNREGISTERTOUCHWINDOW_T)
+        GetProcAddress(_glfw.win32.user32.instance, "UnregisterTouchWindow");
 
     if (_glfw.win32.user32.GetTouchInputInfo &&
         _glfw.win32.user32.CloseTouchInputHandle &&

--- a/src/win32_platform.h
+++ b/src/win32_platform.h
@@ -99,6 +99,34 @@ typedef struct tagCHANGEFILTERSTRUCT
 #endif
 #endif /*Windows 7*/
 
+#if WINVER < 0x0601
+
+#define WM_TOUCH 0x0240
+
+DECLARE_HANDLE(HTOUCHINPUT);
+
+typedef struct tagTOUCHINPUT
+{
+    LONG x;
+    LONG y;
+    HANDLE hSource;
+    DWORD dwID;
+    DWORD dwFlags;
+    DWORD dwMask;
+    DWORD dwTime;
+    ULONG_PTR dwExtraInfo;
+    DWORD cxContact;
+    DWORD cyContext;
+} TOUCHINPUT, *PTOUCHINPUT;
+
+#define TOUCH_COORD_TO_PIXEL(x) ((x) / 100)
+
+#define TOUCHEVENTF_MOVE    0x0001
+#define TOUCHEVENTF_DOWN    0x0002
+#define TOUCHEVENTF_UP      0x0004
+
+#endif /*WINVER < 0x0601*/
+
 // winmm.dll function pointer typedefs
 typedef MMRESULT (WINAPI * JOYGETDEVCAPS_T)(UINT,LPJOYCAPS,UINT);
 typedef MMRESULT (WINAPI * JOYGETPOS_T)(UINT,LPJOYINFO);
@@ -112,8 +140,16 @@ typedef DWORD (WINAPI * TIMEGETTIME_T)(void);
 // user32.dll function pointer typedefs
 typedef BOOL (WINAPI * SETPROCESSDPIAWARE_T)(void);
 typedef BOOL (WINAPI * CHANGEWINDOWMESSAGEFILTEREX_T)(HWND,UINT,DWORD,PCHANGEFILTERSTRUCT);
+typedef BOOL (WINAPI * GETTOUCHINPUTINFO_T)(HTOUCHINPUT,UINT,PTOUCHINPUT,int);
+typedef BOOL (WINAPI * CLOSETOUCHINPUTHANDLE_T)(HTOUCHINPUT);
+typedef BOOL (WINAPI * REGISTERTOUCHWINDOW_T)(HWND,LONG);
+typedef BOOL (WINAPI * UNREGISTERTOUCHWINDOW_T)(HWND);
 #define _glfw_SetProcessDPIAware _glfw.win32.user32.SetProcessDPIAware
 #define _glfw_ChangeWindowMessageFilterEx _glfw.win32.user32.ChangeWindowMessageFilterEx
+#define _glfw_GetTouchInputInfo     _glfw.win32.user32.GetTouchInputInfo
+#define _glfw_CloseTouchInputHandle _glfw.win32.user32.CloseTouchInputHandle
+#define _glfw_RegisterTouchWindow   _glfw.win32.user32.RegisterTouchWindow
+#define _glfw_UnregisterTouchWindow _glfw.win32.user32.UnregisterTouchWindow
 
 // dwmapi.dll function pointer typedefs
 typedef HRESULT (WINAPI * DWMISCOMPOSITIONENABLED_T)(BOOL*);
@@ -184,7 +220,15 @@ typedef struct _GLFWlibraryWin32
         HINSTANCE       instance;
         SETPROCESSDPIAWARE_T SetProcessDPIAware;
         CHANGEWINDOWMESSAGEFILTEREX_T ChangeWindowMessageFilterEx;
+        GETTOUCHINPUTINFO_T     GetTouchInputInfo;
+        CLOSETOUCHINPUTHANDLE_T CloseTouchInputHandle;
+        REGISTERTOUCHWINDOW_T   RegisterTouchWindow;
+        UNREGISTERTOUCHWINDOW_T UnregisterTouchWindow;
     } user32;
+
+    struct {
+        GLboolean       available;
+    } touch;
 
     // dwmapi.dll
     struct {

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -542,7 +542,9 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
 
                 for (i = 0;  i < count;  i++)
                 {
+                    int action;
                     POINT pos;
+
                     pos.x = TOUCH_COORD_TO_PIXEL(inputs[i].x) - xpos;
                     pos.y = TOUCH_COORD_TO_PIXEL(inputs[i].y) - ypos;
 
@@ -554,19 +556,16 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
                     }
 
                     if (inputs[i].dwFlags & TOUCHEVENTF_DOWN)
-                        _glfwInputTouch(window, (int) inputs[i].dwID, GLFW_PRESS);
+                        action = GLFW_PRESS;
+                    else if (inputs[i].dwFlags & TOUCHEVENTF_UP)
+                        action = GLFW_RELEASE;
+                    else
+                        action = GLFW_MOVE;
 
-                    if (inputs[i].dwFlags & TOUCHEVENTF_DOWN ||
-                        inputs[i].dwFlags & TOUCHEVENTF_UP ||
-                        inputs[i].dwFlags & TOUCHEVENTF_MOVE)
-                    {
-                        _glfwInputTouchPos(window, (int) inputs[i].dwID,
-                                           inputs[i].x / 100.0 - xpos,
-                                           inputs[i].y / 100.0 - ypos);
-                    }
-
-                    if (inputs[i].dwFlags & TOUCHEVENTF_UP)
-                        _glfwInputTouch(window, (int) inputs[i].dwID, GLFW_RELEASE);
+                    _glfwInputTouch(window,
+                                    (int) inputs[i].dwID, action,
+                                    inputs[i].x / 100.0 - xpos,
+                                    inputs[i].y / 100.0 - ypos);
                 }
 
                 _glfw_CloseTouchInputHandle((HTOUCHINPUT) lParam);

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -527,10 +527,13 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
             TOUCHINPUT* inputs;
             UINT count = LOWORD(wParam);
 
+            if (!_glfw.win32.touch.available)
+                return 0;
+
             inputs = (TOUCHINPUT*) malloc(sizeof(TOUCHINPUT) * count);
 
-            if (GetTouchInputInfo((HTOUCHINPUT) lParam,
-                                  count, inputs, sizeof(TOUCHINPUT)))
+            if (_glfw_GetTouchInputInfo((HTOUCHINPUT) lParam,
+                                        count, inputs, sizeof(TOUCHINPUT)))
             {
                 int i, width, height;
 
@@ -564,7 +567,7 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
                     }
                 }
 
-                CloseTouchInputHandle((HTOUCHINPUT) lParam);
+                _glfw_CloseTouchInputHandle((HTOUCHINPUT) lParam);
             }
 
             free(inputs);
@@ -1095,10 +1098,13 @@ void _glfwPlatformPostEmptyEvent(void)
 
 void _glfwPlatformSetTouchInput(_GLFWwindow* window, int enabled)
 {
+    if (!_glfw.win32.touch.available)
+        return;
+
     if (enabled)
-        RegisterTouchWindow(window->win32.handle, 0);
+        _glfw_RegisterTouchWindow(window->win32.handle, 0);
     else
-        UnregisterTouchWindow(window->win32.handle);
+        _glfw_UnregisterTouchWindow(window->win32.handle);
 }
 
 void _glfwPlatformGetCursorPos(_GLFWwindow* window, double* xpos, double* ypos)

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -535,20 +535,18 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
             if (_glfw_GetTouchInputInfo((HTOUCHINPUT) lParam,
                                         count, inputs, sizeof(TOUCHINPUT)))
             {
-                int i, width, height;
+                int i, width, height, xpos, ypos;
 
                 _glfwPlatformGetWindowSize(window, &width, &height);
+                _glfwPlatformGetWindowPos(window, &xpos, &ypos);
 
                 for (i = 0;  i < count;  i++)
                 {
                     POINT pos;
+                    pos.x = TOUCH_COORD_TO_PIXEL(inputs[i].x) - xpos;
+                    pos.y = TOUCH_COORD_TO_PIXEL(inputs[i].y) - ypos;
 
                     // Discard any points that lie outside of the client area
-
-                    pos.x = TOUCH_COORD_TO_PIXEL(inputs[i].x);
-                    pos.y = TOUCH_COORD_TO_PIXEL(inputs[i].y);
-                    ScreenToClient(window->win32.handle, &pos);
-
                     if (pos.x < 0 || pos.x >= width ||
                         pos.y < 0 || pos.y >= height)
                     {
@@ -562,8 +560,8 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
                     else if (inputs[i].dwFlags & TOUCHEVENTF_MOVE)
                     {
                         _glfwInputTouchPos(window, (int) inputs[i].dwID,
-                                           inputs[i].x / 100.0,
-                                           inputs[i].y / 100.0);
+                                           inputs[i].x / 100.0 - xpos,
+                                           inputs[i].y / 100.0 - ypos);
                     }
                 }
 

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -555,14 +555,18 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
 
                     if (inputs[i].dwFlags & TOUCHEVENTF_DOWN)
                         _glfwInputTouch(window, (int) inputs[i].dwID, GLFW_PRESS);
-                    else if (inputs[i].dwFlags & TOUCHEVENTF_UP)
-                        _glfwInputTouch(window, (int) inputs[i].dwID, GLFW_RELEASE);
-                    else if (inputs[i].dwFlags & TOUCHEVENTF_MOVE)
+
+                    if (inputs[i].dwFlags & TOUCHEVENTF_DOWN ||
+                        inputs[i].dwFlags & TOUCHEVENTF_UP ||
+                        inputs[i].dwFlags & TOUCHEVENTF_MOVE)
                     {
                         _glfwInputTouchPos(window, (int) inputs[i].dwID,
                                            inputs[i].x / 100.0 - xpos,
                                            inputs[i].y / 100.0 - ypos);
                     }
+
+                    if (inputs[i].dwFlags & TOUCHEVENTF_UP)
+                        _glfwInputTouch(window, (int) inputs[i].dwID, GLFW_RELEASE);
                 }
 
                 _glfw_CloseTouchInputHandle((HTOUCHINPUT) lParam);

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -457,6 +457,155 @@ static const struct wl_keyboard_listener keyboardListener = {
     keyboardHandleModifiers,
 };
 
+static void touchHandleDown(void* data,
+                            struct wl_touch* touch,
+                            uint32_t serial,
+                            uint32_t time,
+                            struct wl_surface* surface,
+                            int32_t id,
+                            wl_fixed_t x,
+                            wl_fixed_t y)
+{
+    double xpos, ypos;
+    int i, found = -1;
+
+    if (!_glfw.wl.touchEnabled)
+        return;
+
+    _GLFWwindow* window = wl_surface_get_user_data(surface);
+
+    xpos = wl_fixed_to_double(x);
+    ypos = wl_fixed_to_double(y);
+
+    // Searching for an empty slot for our new contact point
+    for (i = 0; i < _glfw.wl.touchSize; ++i)
+    {
+        if (_glfw.wl.touchIDs[i] < 0)
+        {
+            found = i;
+            break;
+        }
+    }
+
+    // None found, so let’s increase the size of both buffers
+    if (found < 0)
+    {
+        int* ids = _glfw.wl.touchIDs;
+        _GLFWwindow** focuses = _glfw.wl.touchFocuses;
+        int size = _glfw.wl.touchSize * 2;
+
+        ids = realloc(ids, size * sizeof(int));
+        focuses = realloc(focuses, size * sizeof(_GLFWwindow*));
+
+        for (i = _glfw.wl.touchSize; i < size; ++i)
+            ids[i] = -1;
+
+        found = _glfw.wl.touchSize;
+        _glfw.wl.touchIDs = ids;
+        _glfw.wl.touchFocuses = focuses;
+        _glfw.wl.touchSize = size;
+    }
+
+    // Add our new contact point to the buffers and notify the common code
+    _glfw.wl.touchIDs[found] = id;
+    _glfw.wl.touchFocuses[found] = window;
+    _glfwInputTouch(window, id, GLFW_PRESS, xpos, ypos);
+}
+
+static void touchHandleUp(void* data,
+                          struct wl_touch* touch,
+                          uint32_t serial,
+                          uint32_t time,
+                          int32_t id)
+{
+    int i;
+
+    if (!_glfw.wl.touchEnabled)
+        return;
+
+    for (i = 0; i < _glfw.wl.touchSize; ++i)
+    {
+        if (_glfw.wl.touchIDs[i] == id)
+        {
+            _GLFWwindow* window = _glfw.wl.touchFocuses[i];
+
+            if (!window)
+                return;
+
+            _glfwInputTouch(window, id, GLFW_RELEASE, 0., 0.);
+            _glfw.wl.touchFocuses[i] = NULL;
+            _glfw.wl.touchIDs[i] = -1;
+            return;
+        }
+    }
+}
+
+static void touchHandleMotion(void* data,
+                              struct wl_touch* touch,
+                              uint32_t time,
+                              int32_t id,
+                              wl_fixed_t x,
+                              wl_fixed_t y)
+{
+    double xpos, ypos;
+    int i;
+
+    if (!_glfw.wl.touchEnabled)
+        return;
+
+    xpos = wl_fixed_to_double(x);
+    ypos = wl_fixed_to_double(y);
+
+    for (i = 0; i < _glfw.wl.touchSize; ++i)
+    {
+        if (_glfw.wl.touchIDs[i] == id)
+        {
+            _GLFWwindow* window = _glfw.wl.touchFocuses[i];
+
+            if (!window)
+                return;
+
+            _glfwInputTouch(window, id, GLFW_MOVE, xpos, ypos);
+            return;
+        }
+    }
+}
+
+static void touchHandleFrame(void* data,
+                             struct wl_touch* touch)
+{
+}
+
+static void touchHandleCancel(void* data,
+                              struct wl_touch* touch)
+{
+    int i;
+
+    if (!_glfw.wl.touchEnabled)
+        return;
+
+    for (i = 0; i < _glfw.wl.touchSize; ++i)
+    {
+        if (_glfw.wl.touchIDs[i] < 0)
+            continue;
+
+        int id = _glfw.wl.touchIDs[i];
+        _GLFWwindow* window = _glfw.wl.touchFocuses[i];
+
+        _glfwInputTouch(window, id, GLFW_RELEASE, 0., 0.);
+        _glfw.wl.touchFocuses[i] = NULL;
+        _glfw.wl.touchIDs[i] = -1;
+    }
+}
+
+static const struct wl_touch_listener touchListener = {
+    touchHandleDown,
+    touchHandleUp,
+    touchHandleMotion,
+    touchHandleFrame,
+    touchHandleCancel,
+};
+
 static void seatHandleCapabilities(void* data,
                                    struct wl_seat* seat,
                                    enum wl_seat_capability caps)
@@ -481,6 +630,17 @@ static void seatHandleCapabilities(void* data,
     {
         wl_keyboard_destroy(_glfw.wl.keyboard);
         _glfw.wl.keyboard = NULL;
+    }
+
+    if ((caps & WL_SEAT_CAPABILITY_TOUCH) && !_glfw.wl.touch)
+    {
+        _glfw.wl.touch = wl_seat_get_touch(seat);
+        wl_touch_add_listener(_glfw.wl.touch, &touchListener, NULL);
+    }
+    else if (!(caps & WL_SEAT_CAPABILITY_TOUCH) && _glfw.wl.touch)
+    {
+        wl_touch_destroy(_glfw.wl.touch);
+        _glfw.wl.touch = NULL;
     }
 }
 
@@ -577,6 +737,13 @@ int _glfwPlatformInit(void)
     _glfwInitTimer();
     _glfwInitJoysticks();
 
+    _glfw.wl.touchFocuses = calloc(4, sizeof(_GLFWwindow*));
+    _glfw.wl.touchIDs = calloc(4, sizeof(int));
+    _glfw.wl.touchSize = 4;
+
+    for (int i = 0; i < _glfw.wl.touchSize; ++i)
+        _glfw.wl.touchIDs[i] = -1;
+
     if (_glfw.wl.pointer && _glfw.wl.shm)
     {
         _glfw.wl.cursorTheme = wl_cursor_theme_load(NULL, 32, _glfw.wl.shm);
@@ -606,6 +773,10 @@ void _glfwPlatformTerminate(void)
     _glfwTerminateContextAPI();
     _glfwTerminateJoysticks();
 
+    if (_glfw.wl.touchFocuses)
+        free(_glfw.wl.touchFocuses);
+    if (_glfw.wl.touchIDs)
+        free(_glfw.wl.touchIDs);
     if (_glfw.wl.cursorTheme)
         wl_cursor_theme_destroy(_glfw.wl.cursorTheme);
     if (_glfw.wl.cursorSurface)

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -82,6 +82,7 @@ typedef struct _GLFWlibraryWayland
     struct wl_seat*             seat;
     struct wl_pointer*          pointer;
     struct wl_keyboard*         keyboard;
+    struct wl_touch*            touch;
 
     struct wl_cursor_theme*     cursorTheme;
     struct wl_cursor*           defaultCursor;
@@ -105,6 +106,11 @@ typedef struct _GLFWlibraryWayland
 
     _GLFWwindow*                pointerFocus;
     _GLFWwindow*                keyboardFocus;
+
+    int*                        touchIDs;
+    _GLFWwindow**               touchFocuses;
+    int                         touchSize;
+    int                         touchEnabled;
 
 } _GLFWlibraryWayland;
 

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -377,6 +377,11 @@ void _glfwPlatformPostEmptyEvent(void)
     wl_display_sync(_glfw.wl.display);
 }
 
+void _glfwPlatformSetTouchInput(_GLFWwindow* window, int enabled)
+{
+    _glfw.wl.touchEnabled = enabled;
+}
+
 void _glfwPlatformGetCursorPos(_GLFWwindow* window, double* xpos, double* ypos)
 {
     if (xpos)

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -1756,6 +1756,10 @@ void _glfwPlatformPostEmptyEvent(void)
     XFlush(_glfw.x11.display);
 }
 
+void _glfwPlatformSetTouchInput(_GLFWwindow* window, int enabled)
+{
+}
+
 void _glfwPlatformGetCursorPos(_GLFWwindow* window, double* xpos, double* ypos)
 {
     Window root, child;

--- a/tests/events.c
+++ b/tests/events.c
@@ -49,6 +49,7 @@ typedef struct
     GLFWwindow* window;
     int number;
     int closeable;
+    int touch;
 } Slot;
 
 static void usage(void)
@@ -371,6 +372,15 @@ static void key_callback(GLFWwindow* window, int key, int scancode, int action, 
 
     switch (key)
     {
+        case GLFW_KEY_T:
+        {
+            slot->touch = !slot->touch;
+            glfwSetInputMode(window, GLFW_TOUCH, slot->touch);
+
+            printf("(( touch %s ))\n", slot->touch ? "enabled" : "disabled");
+            break;
+        }
+
         case GLFW_KEY_C:
         {
             slot->closeable = !slot->closeable;
@@ -517,6 +527,7 @@ int main(int argc, char** argv)
         char title[128];
 
         slots[i].closeable = GL_TRUE;
+        slots[i].touch = GL_FALSE;
         slots[i].number = i + 1;
 
         sprintf(title, "Event Linter (Window %i)", slots[i].number);

--- a/tests/events.c
+++ b/tests/events.c
@@ -437,6 +437,16 @@ static void monitor_callback(GLFWmonitor* monitor, int event)
     }
 }
 
+static void touch_callback(GLFWwindow* window, int touch, int action, double x, double y)
+{
+    printf("%08x at %0.3f: Touch %i %s at %0.3f %0.3f\n",
+           counter++,
+           glfwGetTime(),
+           touch,
+           get_action_name(action),
+           x, y);
+}
+
 int main(int argc, char** argv)
 {
     Slot* slots;
@@ -550,6 +560,7 @@ int main(int argc, char** argv)
         glfwSetCharCallback(slots[i].window, char_callback);
         glfwSetCharModsCallback(slots[i].window, char_mods_callback);
         glfwSetDropCallback(slots[i].window, drop_callback);
+        glfwSetTouchCallback(slots[i].window, touch_callback);
 
         glfwMakeContextCurrent(slots[i].window);
         glfwSwapInterval(1);

--- a/tests/events.c
+++ b/tests/events.c
@@ -203,6 +203,8 @@ static const char* get_action_name(int action)
             return "released";
         case GLFW_REPEAT:
             return "repeated";
+        case GLFW_MOVE:
+            return "moved";
     }
 
     return "caused unknown action";


### PR DESCRIPTION
This is totally untested, as I don’t have any touch device around, but should be pretty ok (at least it compiles).

I went with the assumption a negative id wasn’t a valid one, but it isn’t specified so it could be wrong, this is a point to verify.

Also, if glfwSetTouchInput() disables touch input while some contact points are still present, they will stay pressed “forever”.
