### PR TITLE
Implement wl_surface retrieval from a GLFWwindow on Wayland

### DIFF
--- a/include/GLFW/glfw3native.h
+++ b/include/GLFW/glfw3native.h
@@ -86,6 +86,8 @@ extern "C" {
 #elif defined(GLFW_EXPOSE_NATIVE_X11)
  #include <X11/Xlib.h>
  #include <X11/extensions/Xrandr.h>
+#elif defined(GLFW_EXPOSE_NATIVE_WAYLAND)
+ #include <wayland-client-protocol.h>
 #else
  #error "No window API selected"
 #endif
@@ -299,6 +301,23 @@ GLFWAPI Window glfwGetX11Window(GLFWwindow* window);
  *  @ingroup native
  */
 GLFWAPI GLXContext glfwGetGLXContext(GLFWwindow* window);
+#endif
+
+#if defined(GLFW_EXPOSE_NATIVE_WAYLAND)
+/*! @brief Returns the `struct wl_surface*` of the specified window.
+ *
+ *  @return The `struct wl_surface*` of the specified window, or `NULL` if an
+ *  [error](@ref error_handling) occurred.
+ *
+ *  @par Thread Safety
+ *  This function may be called from any thread.  Access is not synchronized.
+ *
+ *  @par History
+ *  Added in GLFW 3.2.
+ *
+ *  @ingroup native
+ */
+GLFWAPI struct wl_surface* glfwGetWaylandSurface(GLFWwindow* window);
 #endif
 
 #if defined(GLFW_EXPOSE_NATIVE_EGL)

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -529,3 +529,15 @@ const char* _glfwPlatformGetClipboardString(_GLFWwindow* window)
     return NULL;
 }
 
+
+//////////////////////////////////////////////////////////////////////////
+//////                        GLFW native API                       //////
+//////////////////////////////////////////////////////////////////////////
+
+GLFWAPI struct wl_surface* glfwGetWaylandSurface(GLFWwindow* handle)
+{
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
+    return window->wl.surface;
+}
+


### PR DESCRIPTION
This allows for wayland-specific changes to the surface object, like manipulation of opaque and input regions, or even submission of a totally different wl_buffer to the surface, not necessarily generated from OpenGL.

Partially fixes #419.