### PR TITLE
Fix CMake modules to find EGL, GLESv1 and GLESv2 on Windows.

### DIFF
--- a/CMake/modules/FindEGL.cmake
+++ b/CMake/modules/FindEGL.cmake
@@ -6,7 +6,7 @@
 
 find_path(EGL_INCLUDE_DIR NAMES EGL/egl.h PATHS /opt/vc/include)
 
-set(EGL_NAMES ${EGL_NAMES} egl EGL)
+set(EGL_NAMES ${EGL_NAMES} egl EGL libEGL)
 find_library(EGL_LIBRARY NAMES ${EGL_NAMES} PATHS /opt/vc/lib)
 
 include(FindPackageHandleStandardArgs)

--- a/CMake/modules/FindGLESv1.cmake
+++ b/CMake/modules/FindGLESv1.cmake
@@ -6,7 +6,7 @@
 
 find_path(GLESv1_INCLUDE_DIR NAMES GLES/gl.h PATHS /opt/vc/include)
 
-set(GLESv1_NAMES ${GLESv1_NAMES} GLESv1_CM)
+set(GLESv1_NAMES ${GLESv1_NAMES} GLESv1_CM libGLES_CM)
 find_library(GLESv1_LIBRARY NAMES ${GLESv1_NAMES} PATHS /opt/vc/lib)
 
 include(FindPackageHandleStandardArgs)

--- a/CMake/modules/FindGLESv2.cmake
+++ b/CMake/modules/FindGLESv2.cmake
@@ -6,7 +6,7 @@
 
 find_path(GLESv2_INCLUDE_DIR NAMES GLES2/gl2.h PATHS /opt/vc/include)
 
-set(GLESv2_NAMES ${GLESv2_NAMES} GLESv2)
+set(GLESv2_NAMES ${GLESv2_NAMES} GLESv2 libGLESv2)
 find_library(GLESv2_LIBRARY NAMES ${GLESv2_NAMES} PATHS /opt/vc/lib)
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
Some OpenGL ES / EGL Windows implementations name the dlls "libGLES_CM.dll", "libGLESv2.dll" and "libEGL.dll". This includes PowerVR's, Adreno's and ARM Mali's implementations. The current CMake modules don't find these libraries. The proposed fix searches for those names too.