### PR TITLE
glfwinfo would not compile after a specific commit to modify includes.

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -118,10 +118,13 @@ extern "C" {
    #include <OpenGL/gl3ext.h>
   #endif
  #elif !defined(GLFW_INCLUDE_NONE)
-  #if !defined(GLFW_INCLUDE_GLEXT)
+  #if defined(GLFW_INCLUDE_GLEXT)
    #define GL_GLEXT_LEGACY
   #endif
   #include <OpenGL/gl.h>
+  #if defined(GLFW_INCLUDE_GLEXT)
+    #include<GL/glext.h>
+  #endif
  #endif
  #if defined(GLFW_INCLUDE_GLU)
   #include <OpenGL/glu.h>


### PR DESCRIPTION
Previous commit 37e13361f535674f2d6551bcf89bad4203873b66 caused tests/glfwinfo.c to not compile on my mac computer. With these changes everything compiles.