### PR TITLE
Clear all buffer to black in glfwCreateWindow

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -200,10 +200,10 @@ GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height,
         return NULL;
     }
 
-    // Clearing the front buffer to black to avoid garbage pixels left over
-    // from previous uses of our bit of VRAM
+    // Clear the buffers to black to avoid left over garbage pixels in VRAM
     window->Clear(GL_COLOR_BUFFER_BIT);
     _glfwPlatformSwapBuffers(window);
+    window->Clear(GL_COLOR_BUFFER_BIT);
 
     // Restore the previously current context (or NULL)
     _glfwPlatformMakeContextCurrent(previous);


### PR DESCRIPTION
This eliminates flashing in OS X when running a barebones GLFW example app that doesn't do any rendering.

Newer users are sometimes confused by the flashing when they run the [GLFW.jl sample code](https://github.com/JuliaGL/GLFW.jl#simple-window-example), which is based off the [C version](http://www.glfw.org/documentation.html).