### PR TITLE
Add support for a wait/hourglass cursor

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -684,6 +684,11 @@ extern "C" {
  *  The vertical resize arrow shape.
  */
 #define GLFW_VRESIZE_CURSOR         0x00036006
+/*! @brief The wait/hourglass shape.
+ *
+ *  The wait/hourglass shape.
+ */
+#define GLFW_WAIT_CURSOR         0x00036007
 /*! @} */
 
 #define GLFW_CONNECTED              0x00040001

--- a/src/input.c
+++ b/src/input.c
@@ -389,7 +389,8 @@ GLFWAPI GLFWcursor* glfwCreateStandardCursor(int shape)
         shape != GLFW_CROSSHAIR_CURSOR &&
         shape != GLFW_HAND_CURSOR &&
         shape != GLFW_HRESIZE_CURSOR &&
-        shape != GLFW_VRESIZE_CURSOR)
+        shape != GLFW_VRESIZE_CURSOR &&
+        shape != GLFW_WAIT_CURSOR)
     {
         _glfwInputError(GLFW_INVALID_ENUM, "Invalid standard cursor");
         return NULL;

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -148,6 +148,8 @@ static LPWSTR translateCursorShape(int shape)
             return IDC_SIZEWE;
         case GLFW_VRESIZE_CURSOR:
             return IDC_SIZENS;
+        case GLFW_WAIT_CURSOR:
+            return IDC_WAIT;
     }
 
     return NULL;

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -123,6 +123,8 @@ static int translateCursorShape(int shape)
             return XC_sb_h_double_arrow;
         case GLFW_VRESIZE_CURSOR:
             return XC_sb_v_double_arrow;
+        case GLFW_WAIT_CURSOR:
+            return XC_watch;
     }
 
     return 0;


### PR DESCRIPTION
This adds support for the wait/hourglass cursor with a Windows implementation using ICL_WAIT and using XC_watch on X11.