### PR TITLE
Travis Ci(unix and osx build) and AppVeyor(windows) badges in Readme.md

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,12 @@ language: cpp
 
 os:
 - linux
-- osx
 
 sudo: true
+
+before_install:
+- sh install-deps.sh
 
 install:
 - cmake .
 - make
-- sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ os:
 
 sudo: true
 
-before_install:
+before_script:
 - sh install-deps.sh
 
-install:
+script:
 - cmake .
 - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: cpp
+
+os:
+- linux
+- osx
+
+sudo: true
+
+install:
+- cmake .
+- make
+- sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: cpp
 
 os:
 - linux
+- osx
 
 sudo: true
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GLFW
 [![Build Status](https://travis-ci.org/boddicheg/glfw.svg?branch=multi-platform)](https://travis-ci.org/boddicheg/glfw)
-
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/boddicheg/glfw?branch=multi-platform&svg=true)](https://ci.appveyor.com/project/boddicheg/glfw)
 ## Introduction
 
 GLFW is a free, Open Source, multi-platform library for OpenGL and OpenGL ES

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # GLFW
+[![Build Status](https://travis-ci.org/boddicheg/glfw.svg?branch=multi-platform)](https://travis-ci.org/boddicheg/glfw)
 
 ## Introduction
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
 build_script:
 - mkdir build
 - cd build
-- cmake
+- cmake .

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,4 @@
+build_script:
+- mkdir build
+- cd build
+- cmake

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,3 +2,4 @@ build_script:
 - mkdir build
 - cd build
 - cmake ..
+- cmake --build .

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
 build_script:
 - mkdir build
 - cd build
-- cmake .
+- cmake ..

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -1,5 +1,5 @@
 wget http://www.cmake.org/files/v2.8/cmake-2.8.12.tar.gz
-tar xzf http://www.cmake.org/files/v2.8/cmake-2.8.12.tar.gz
+tar xzf cmake-2.8.12.tar.gz
 cd cmake-2.8.12
 cmake .
 make

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -3,4 +3,4 @@ tar xzf cmake-2.8.12.tar.gz
 cd cmake-2.8.12
 cmake .
 make
-make install
+sudo make install

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -1,0 +1,6 @@
+wget http://www.cmake.org/files/v2.8/cmake-2.8.12.tar.gz
+tar xzf http://www.cmake.org/files/v2.8/cmake-2.8.12.tar.gz
+cd cmake-2.8.12
+cmake .
+make
+make install


### PR DESCRIPTION
Add badges like this:

[![Build Status](https://travis-ci.org/boddicheg/glfw.svg?branch=multi-platform)](https://travis-ci.org/boddicheg/glfw) [![Build Status](https://ci.appveyor.com/api/projects/status/github/boddicheg/glfw?branch=multi-platform&svg=true)](https://ci.appveyor.com/project/boddicheg/glfw)

to Readme.md with current build status on osx, linux and windows.
If this pull request will be accepted, after every commit in master branch this badges will be updated according current build status.

[Example](https://github.com/boddicheg/glfw/tree/multi-platform)

P.S: both badges are clickable
Thanks!

