### PR TITLE
Fix Wayland refresh rate

### DIFF
--- a/src/wl_monitor.c
+++ b/src/wl_monitor.c
@@ -69,7 +69,7 @@ static void mode(void* data,
 
     mode.base.width = width;
     mode.base.height = height;
-    mode.base.refreshRate = refresh;
+    mode.base.refreshRate = refresh / 1000;
     mode.flags = flags;
 
     if (monitor->wl.modesCount + 1 >= monitor->wl.modesSize)


### PR DESCRIPTION
The compositor exposes it in mHz instead of Hz as GLFW, so we have to divide it by 1000.