### PR TITLE
Don't delete the POSIX TLS key if it hasn't been created yet

### DIFF
--- a/src/posix_tls.c
+++ b/src/posix_tls.c
@@ -41,12 +41,17 @@ int _glfwCreateContextTLS(void)
         return GLFW_FALSE;
     }
 
+    _glfw.posix_tls.allocated = GLFW_TRUE;
     return GLFW_TRUE;
 }
 
 void _glfwDestroyContextTLS(void)
 {
-    pthread_key_delete(_glfw.posix_tls.context);
+    if (_glfw.posix_tls.allocated)
+    {
+        pthread_key_delete(_glfw.posix_tls.context);
+        _glfw.posix_tls.allocated = GLFW_FALSE;
+    }
 }
 
 void _glfwSetContextTLS(_GLFWwindow* context)

--- a/src/posix_tls.h
+++ b/src/posix_tls.h
@@ -37,6 +37,7 @@
 //
 typedef struct _GLFWtlsPOSIX
 {
+    GLFWbool        allocated;
     pthread_key_t   context;
 
 } _GLFWtlsPOSIX;


### PR DESCRIPTION
0 (the initial value of `context`) is a valid TLS key, so doing this can delete someone else's key.