### PR TITLE
Use the same error callback in the simple sample as in wave and heightmap

### DIFF
--- a/examples/simple.c
+++ b/examples/simple.c
@@ -32,7 +32,7 @@
 
 static void error_callback(int error, const char* description)
 {
-    fputs(description, stderr);
+    fprintf(stderr, "Error: %s\n", description);
 }
 
 static void key_callback(GLFWwindow* window, int key, int scancode, int action, int mods)


### PR DESCRIPTION
Besides improving consistency, this also ensures that error messages end with newlines.