### PR TITLE
null check

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -543,7 +543,7 @@ GLFWAPI void glfwMakeContextCurrent(GLFWwindow* handle)
 
     _GLFW_REQUIRE_INIT();
 
-    if (window->context.api == GLFW_NO_API)
+    if (window != NULL && window->context.api == GLFW_NO_API)
     {
         _glfwInputError(GLFW_NO_WINDOW_CONTEXT, NULL);
         return;


### PR DESCRIPTION
Append a code to check a null, because when window is null, it cause an error.