### PR TITLE
Wayland: Create the surface before the context

### DIFF
--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -238,14 +238,14 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
                               const _GLFWctxconfig* ctxconfig,
                               const _GLFWfbconfig* fbconfig)
 {
+    if (!createSurface(window, wndconfig))
+        return GLFW_FALSE;
+
     if (ctxconfig->api != GLFW_NO_API)
     {
         if (!_glfwCreateContext(window, ctxconfig, fbconfig))
             return GLFW_FALSE;
     }
-
-    if (!createSurface(window, wndconfig))
-        return GLFW_FALSE;
 
     if (wndconfig->monitor)
     {


### PR DESCRIPTION
This fixes a regression introduced in 496f559c where a context would be created for a NULL egl_surface, which subsequently fails.