### PR TITLE
Fix for MinGW compilation

### DIFF
--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -37,6 +37,9 @@
 
 #define _GLFW_WNDCLASSNAME L"GLFW30"
 
+#ifndef GET_XBUTTON_WPARAM
+#define GET_XBUTTON_WPARAM(w) (HIWORD(w))
+#endif
 
 // Returns the window style for the specified window
 //


### PR DESCRIPTION
The issue:

    libs/glfw/src/libglfw3.a(win32_window.c.obj):win32_window.c:(.text+0xa6e): undefined reference to `GET_XBUTTON_WPARAM'
    collect2.exe: error: ld returned 1 exit status