### PR TITLE
Make the window auxiliary

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -844,7 +844,7 @@ static GLFWbool createWindow(_GLFWwindow* window,
     }
 
     if (wndconfig->resizable)
-        [window->ns.object setCollectionBehavior:NSWindowCollectionBehaviorFullScreenPrimary];
+        [window->ns.object setCollectionBehavior:NSWindowCollectionBehaviorFullScreenAuxiliary];
 
     if (wndconfig->monitor)
     {


### PR DESCRIPTION
As OSX fullscreen (by pressing the green button) is not supported by GLFW (windowDidEnterFullScreen: and windowDidExitFullScreen: callbacks), I suggest making the GLFW window auxiliary (that forbids user to enter the fullscreen manually) and allow entering fullscreen only programmatically (as it is on other platforms).