### PR TITLE
Make sure the cursor’s buffer is valid before destroying it

### DIFF
--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -522,7 +522,8 @@ void _glfwPlatformDestroyCursor(_GLFWcursor* cursor)
     if (cursor->wl.image)
         return;
 
-    wl_buffer_destroy(cursor->wl.buffer);
+    if (cursor->wl.buffer)
+        wl_buffer_destroy(cursor->wl.buffer);
 }
 
 void _glfwPlatformSetCursor(_GLFWwindow* window, _GLFWcursor* cursor)


### PR DESCRIPTION
The shape should never be an unknown value, but it is imo still better to check it really is. Another way would be to `abort()` in `translateCursorShape()`, which I find less elegant than this one.

The other change is there to handle the case where the cursor creation failed, so we don’t buffer_destroy NULL.