### PR TITLE
Cleaning conditional directives that break statements.

### DIFF
--- a/src/egl_context.c
+++ b/src/egl_context.c
@@ -500,11 +500,13 @@ int _glfwCreateContext(_GLFWwindow* window,
 //
 void _glfwDestroyContext(_GLFWwindow* window)
 {
+    int test = 1;
 #if defined(_GLFW_X11)
     // NOTE: Do not unload libGL.so.1 while the X11 display is still open,
     //       as it will make XCloseDisplay segfault
-    if (window->context.api != GLFW_OPENGL_API)
+    test = window->context.api != GLFW_OPENGL_API;
 #endif // _GLFW_X11
+    if (test)
     {
         if (window->context.egl.client)
         {


### PR DESCRIPTION
  A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

    https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
    https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.