### PR TITLE
Better IME support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,4 +82,4 @@ tests/timeout
 tests/title
 tests/vulkan
 tests/windows
-
+tests/ime

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,6 +205,7 @@ endif()
 if (_GLFW_WIN32)
 
     list(APPEND glfw_PKG_LIBS "-lgdi32")
+    list(APPEND glfw_LIBRARIES "imm32")
 
     if (GLFW_USE_HYBRID_HPG)
         set(_GLFW_USE_HYBRID_HPG 1)
@@ -298,12 +299,13 @@ if (_GLFW_COCOA)
 
     list(APPEND glfw_LIBRARIES
         "-framework Cocoa"
+        "-framework Carbon"
         "-framework IOKit"
         "-framework CoreFoundation"
         "-framework CoreVideo")
 
     set(glfw_PKG_DEPS "")
-    set(glfw_PKG_LIBS "-framework Cocoa -framework IOKit -framework CoreFoundation -framework CoreVideo")
+    set(glfw_PKG_LIBS "-framework Cocoa -framework Carbon -framework IOKit -framework CoreFoundation -framework CoreVideo")
 endif()
 
 #--------------------------------------------------------------------

--- a/docs/input.dox
+++ b/docs/input.dox
@@ -214,6 +214,96 @@ void character_callback(GLFWwindow* window, unsigned int codepoint)
 }
 @endcode
 
+@subsection preedit IME Support
+
+All desktop operating systems support IME (Input Method Editor) to input characters
+that are not mapped with physical keys. IME have been popular among Eeastern Asian people.
+And some operating systems start supporting voice input via IME mechanism.
+
+GLFW provides IME support functions to help
+you implement better text input features. You should add suitable visualization code for
+preedit text.
+
+IME works in front of actual character input events (@ref input_char).
+If your application uses text input and you want to support IME,
+you should register preedit callback to receive preedit text before committed.
+
+@code
+glfwSetPreeditCallback(window, preedit_callback);
+@endcode
+
+The callback function receives chunk of text and focused block information.
+
+@code
+static void preedit_callback(GLFWwindow* window, int strLength, unsigned int* string, int blockLength, int* blocks, int focusedBlock) {
+}
+@endcode
+
+strLength and string parameter reprsent whole preedit text. Each character of the preedit string is a codepoint like @ref input_char.
+
+If you want to type the text "寿司(sushi)", Usually the callback is called several times like the following sequence:
+
+-# key event: s
+-# preedit: [string: "ｓ", block: [1], focusedBlock: 0]
+-# key event: u
+-# preedit: [string: "す", block: [1], focusedBlock: 0]
+-# key event: s
+-# preedit: [string: "すｓ", block: [2], focusedBlock: 0]
+-# key event: h
+-# preedit: [string: "すｓｈ", block: [2], focusedBlock: 0]
+-# key event: i
+-# preedit: [string: "すし", block: [2], focusedBlock: 0]
+-# key event: ' '
+-# preedit: [string: "寿司", block: [2], focusedBlock: 0]
+-# char: '寿'
+-# char: '司'
+-# preedit: [string: "", block: [], focusedBlock: 0]
+
+If preedit text includes several semantic blocks, preedit callbacks returns several blocks after a space key pressed:
+
+-# preedit: [string: "わたしはすしをたべます", block: [11], focusedBlock: 0]
+-# preedit: [string: "私は寿司を食べます", block: [2, 7], focusedBlock: 1]
+
+"blocks" is a list of block length. The above case, it contains the following blocks and second block is focused.
+
+- 私は
+- [寿司を食べます]
+
+commited text(passed via regular @ref input_char event), unfocused block, focused block should have different text style.
+
+
+GLFW provides helper function to teach suitable position of the candidate window to window system.
+Window system decides the best position from text cursor geometry (x, y coords and height). You should call this function
+in the above preedit text callback function.
+
+@code
+glfwSetPreeditCursorPos(window, x, y, h);
+glfwGetPreeditCursorPos(window, &x, &y, &h);
+@endcode
+
+Sometimes IME task is interrupted by user or application. There are several functions to support these situation.
+You can receive notification about IME status change(on/off) by using the following function:
+
+@code
+glfwSetIMEStatusCallback(window, imestatus_callback);
+@endcode
+
+imestatus_callback has simple sigunature like this:
+
+@code
+static void imestatus_callback(GLFWwindow* window) {
+}
+@endcode
+
+You can implement the code that resets or commits preedit text when IME status is changed and preedit text is not empty.
+
+When the focus is gone from text box, you can use the following functions to reset IME status:
+
+@code
+void glfwResetPreeditText(GLFWwindow* window);
+void glfwSetIMEStatus(GLFWwindow* window, int active)
+int glfwGetIMEStatus(GLFWwindow* window)
+@endcode
 
 @subsection input_key_name Key names
 

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -1003,6 +1003,7 @@ extern "C" {
 #define GLFW_STICKY_MOUSE_BUTTONS   0x00033003
 #define GLFW_LOCK_KEY_MODS          0x00033004
 #define GLFW_RAW_MOUSE_MOTION       0x00033005
+#define GLFW_IME                    0x00033006
 
 #define GLFW_CURSOR_NORMAL          0x00034001
 #define GLFW_CURSOR_HIDDEN          0x00034002
@@ -1457,6 +1458,37 @@ typedef void (* GLFWcharfun)(GLFWwindow*,unsigned int);
  *  @ingroup input
  */
 typedef void (* GLFWcharmodsfun)(GLFWwindow*,unsigned int,int);
+
+/*! @brief The function signature for preedit callbacks.
+ *
+ *  This is the function signature for preedit callback functions.
+ *
+ *  @param[in] window The window that received the event.
+ *  @param[in] length Preedit string length.
+ *  @param[in] string Preedit string.
+ *  @param[in] count Attributed block count.
+ *  @param[in] blocksizes List of attributed block size.
+ *  @param[in] focusedblock Focused block index.
+ *
+ *  @sa @ref preedit
+ *  @sa glfwSetPreeditCallback
+ *
+ *  @ingroup input
+ */
+typedef void (* GLFWpreeditfun)(GLFWwindow*,int,unsigned int*,int,int*,int);
+
+/*! @brief The function signature for IME status change callbacks.
+ *
+ *  This is the function signature for IME status change callback functions.
+ *
+ *  @param[in] window The window that received the event.
+ *
+ *  @sa @ref preedit
+ *  @sa glfwSetIMEStatusCallback
+ *
+ *  @ingroup monitor
+ */
+typedef void (* GLFWimestatusfun)(GLFWwindow*);
 
 /*! @brief The function signature for file drop callbacks.
  *
@@ -3844,13 +3876,13 @@ GLFWAPI void glfwPostEmptyEvent(void);
  *
  *  This function returns the value of an input option for the specified window.
  *  The mode must be one of @ref GLFW_CURSOR, @ref GLFW_STICKY_KEYS,
- *  @ref GLFW_STICKY_MOUSE_BUTTONS, @ref GLFW_LOCK_KEY_MODS or
- *  @ref GLFW_RAW_MOUSE_MOTION.
+ *  @ref GLFW_STICKY_MOUSE_BUTTONS, @ref GLFW_LOCK_KEY_MODS, 
+ *  @ref GLFW_RAW_MOUSE_MOTION or @ref GLFW_IME.
  *
  *  @param[in] window The window to query.
  *  @param[in] mode One of `GLFW_CURSOR`, `GLFW_STICKY_KEYS`,
- *  `GLFW_STICKY_MOUSE_BUTTONS`, `GLFW_LOCK_KEY_MODS` or
- *  `GLFW_RAW_MOUSE_MOTION`.
+ *  `GLFW_STICKY_MOUSE_BUTTONS`, `GLFW_LOCK_KEY_MODS`
+ *  `GLFW_RAW_MOUSE_MOTION` or `GLFW_IME`.
  *
  *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
  *  GLFW_INVALID_ENUM.
@@ -3869,8 +3901,8 @@ GLFWAPI int glfwGetInputMode(GLFWwindow* window, int mode);
  *
  *  This function sets an input mode option for the specified window.  The mode
  *  must be one of @ref GLFW_CURSOR, @ref GLFW_STICKY_KEYS,
- *  @ref GLFW_STICKY_MOUSE_BUTTONS, @ref GLFW_LOCK_KEY_MODS or
- *  @ref GLFW_RAW_MOUSE_MOTION.
+ *  @ref GLFW_STICKY_MOUSE_BUTTONS, @ref GLFW_LOCK_KEY_MODS,
+ *  @ref GLFW_RAW_MOUSE_MOTION or @ref GLFW_IME.
  *
  *  If the mode is `GLFW_CURSOR`, the value must be one of the following cursor
  *  modes:
@@ -3908,10 +3940,13 @@ GLFWAPI int glfwGetInputMode(GLFWwindow* window, int mode);
  *  attempting to set this will emit @ref GLFW_PLATFORM_ERROR.  Call @ref
  *  glfwRawMouseMotionSupported to check for support.
  *
+ *  If the mode is `GLFW_IME`, the value must be either `GLFW_TRUE` to turn on IME,
+ *  or `GLFW_FALSE` to turn off it.
+ *
  *  @param[in] window The window whose input mode to set.
  *  @param[in] mode One of `GLFW_CURSOR`, `GLFW_STICKY_KEYS`,
- *  `GLFW_STICKY_MOUSE_BUTTONS`, `GLFW_LOCK_KEY_MODS` or
- *  `GLFW_RAW_MOUSE_MOTION`.
+ *  `GLFW_STICKY_MOUSE_BUTTONS`, `GLFW_LOCK_KEY_MODS`,
+ *  `GLFW_RAW_MOUSE_MOTION` or `GLFW_IME`.
  *  @param[in] value The new value of the specified input mode.
  *
  *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
@@ -4308,6 +4343,67 @@ GLFWAPI void glfwDestroyCursor(GLFWcursor* cursor);
  */
 GLFWAPI void glfwSetCursor(GLFWwindow* window, GLFWcursor* cursor);
 
+/*! @brief Retrieves the position of the text cursor relative to the client area of window.
+ *
+ *  This function returns position hint to decide the candidate window.
+ *
+ *  @param[in] window The window to set the text cursor for.
+ *  @param[out] x The text cursor x position (relative position from window coordinates).
+ *  @param[out] y The text cursor y position (relative position from window coordinates).
+ *  @param[out] h The text cursor height.
+ *
+ *  @par Thread Safety
+ *  This function may only be called from the main thread.
+ *
+ *  @sa @ref input_char
+ *
+ *  @since Added in GLFW 3.X.
+ *
+ *  @ingroup input
+ */
+GLFWAPI void glfwGetPreeditCursorPos(GLFWwindow* window, int *x, int *y, int *h);
+
+/*! @brief Notify the text cursor position to window system to decide the candidate window position.
+ *
+ *  This function teach position hint to decide the candidate window. The candidate window
+ *  is a part of IME(Input Method Editor) and show several candidate strings.
+ *
+ *  Windows sytems decide proper pisition from text cursor geometry.
+ *  You should call this function in preedit callback.
+ *
+ *  @param[in] window The window to set the text cursor for.
+ *  @param[in] x The text cursor x position (relative position from window coordinates).
+ *  @param[in] y The text cursor y position (relative position from window coordinates).
+ *  @param[in] h The text cursor height.
+ *
+ *  @par Thread Safety
+ *  This function may only be called from the main thread.
+ *
+ *  @sa @ref input_char
+ *
+ *  @since Added in GLFW 3.X.
+ *
+ *  @ingroup input
+ */
+GLFWAPI void glfwSetPreeditCursorPos(GLFWwindow* window, int x, int y, int h);
+
+/*! @brief Reset IME input status.
+ *
+ *  This function resets IME's preedit text.
+ *
+ *  @param[in] window The window.
+ *
+ *  @par Thread Safety
+ *  This function may only be called from the main thread.
+ *
+ *  @sa @ref preedit
+ *
+ *  @since Added in GLFW 3.X.
+ *
+ *  @ingroup input
+ */
+GLFWAPI void glfwResetPreeditText(GLFWwindow* window);
+
 /*! @brief Sets the key callback.
  *
  *  This function sets the key callback of the specified window, which is called
@@ -4421,6 +4517,58 @@ GLFWAPI GLFWcharfun glfwSetCharCallback(GLFWwindow* window, GLFWcharfun cbfun);
  *  @ingroup input
  */
 GLFWAPI GLFWcharmodsfun glfwSetCharModsCallback(GLFWwindow* window, GLFWcharmodsfun cbfun);
+
+/*! @brief Sets the preedit callback.
+ *
+ *  This function sets the  preedit callback of the specified
+ *  window, which is called when an IME is processing text before commited.
+ *
+ *  Callback receives relative position of input cursor inside preedit text and
+ *  attributed text blocks. This callback is used for on-the-spot text editing
+ *  with IME.
+ *
+ *  @param[in] window The window whose callback to set.
+ *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
+ *  callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or an
+ *  error occurred.
+ *
+ *  @par Thread Safety
+ *  This function may only be called from the main thread.
+ *
+ *  @sa @ref input_char
+ *
+ *  @since Added in GLFW 3.X
+ *
+ *  @ingroup input
+ */
+GLFWAPI GLFWpreeditfun glfwSetPreeditCallback(GLFWwindow* window, GLFWpreeditfun cbfun);
+
+/*! @brief Sets the IME status change callback.
+ *
+ *  This function sets the  preedit callback of the specified
+ *  window, which is called when an IME is processing text before commited.
+ *
+ *  Callback receives relative position of input cursor inside preedit text and
+ *  attributed text blocks. This callback is used for on-the-spot text editing
+ *  with IME.
+ *
+ *  @param[in] window The window whose callback to set.
+ *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
+ *  callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or an
+ *  error occurred.
+ *
+ *  @par Thread Safety
+ *  This function may only be called from the main thread.
+ *
+ *  @sa @ref input_char
+ *
+ *  @since Added in GLFW 3.X
+ *
+ *  @ingroup input
+ */
+GLFWAPI GLFWimestatusfun glfwSetIMEStatusCallback(GLFWwindow* window, GLFWimestatusfun cbfun);
 
 /*! @brief Sets the mouse button callback.
  *

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -344,8 +344,11 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
         _glfwUpdateDisplayLinkDisplayNSGL(window);
 }
 
-@end
+- (void)imeStatusChangeNotified:(NSNotification *)notification {
+    _glfwInputIMEStatus(window);
+}
 
+@end
 
 //------------------------------------------------------------------------
 // Content view class for the GLFW window
@@ -712,6 +715,56 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
         markedText = [[NSMutableAttributedString alloc] initWithAttributedString:string];
     else
         markedText = [[NSMutableAttributedString alloc] initWithString:string];
+    NSString* markedTextString = markedText.string;
+
+    NSUInteger i, length = [markedTextString length];
+    int ctext = window->ctext;
+    while (ctext < length+1) {
+        ctext = (ctext == 0) ? 1 : ctext*2;
+    }
+    if (ctext != window->ctext) {
+        unsigned int* preeditText = realloc(window->preeditText, sizeof(unsigned int)*ctext);
+        if (preeditText == NULL) {
+            return;
+        }
+        window->preeditText = preeditText;
+        window->ctext = ctext;
+    }
+    window->ntext = length;
+    window->preeditText[length] = 0;
+    for (i = 0;  i < length;  i++)
+    {
+        const unichar codepoint = [markedTextString characterAtIndex:i];
+        window->preeditText[i] = codepoint;
+    }
+    int focusedBlock = 0;
+    NSInteger offset = 0;
+    window->nblocks = 0;
+    while (offset < length) {
+        NSRange effectiveRange;
+        NSDictionary *attributes = [markedText attributesAtIndex:offset effectiveRange:&effectiveRange];
+        
+        if (window->nblocks == window->cblocks) {
+            int cblocks = window->cblocks * 2;
+            int* blocks = realloc(window->preeditAttributeBlocks, sizeof(int)*cblocks);
+            if (blocks == NULL) {
+                return;
+            }
+            window->preeditAttributeBlocks = blocks;
+            window->cblocks = cblocks;
+        }
+        window->preeditAttributeBlocks[window->nblocks] = effectiveRange.length;
+        offset += effectiveRange.length;
+        if (effectiveRange.length == 0) {
+            break;
+        }
+        NSNumber* underline = (NSNumber*) [attributes objectForKey:@"NSUnderline"];
+        if ([underline intValue] != 1) {
+            focusedBlock = window->nblocks;
+        }
+        window->nblocks++;
+    }
+    _glfwInputPreedit(window, focusedBlock);
 }
 
 - (void)unmarkText
@@ -959,6 +1012,11 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
         acquireMonitor(window);
     }
 
+    [[NSNotificationCenter defaultCenter]
+        addObserver: window->ns.delegate
+        selector:@selector(imeStatusChangeNotified:)
+        name:NSTextInputContextKeyboardSelectionDidChangeNotification
+        object: nil];
     return GLFW_TRUE;
 
     } // autoreleasepool
@@ -970,6 +1028,8 @@ void _glfwPlatformDestroyWindow(_GLFWwindow* window)
 
     if (_glfw.ns.disabledCursorWindow == window)
         _glfw.ns.disabledCursorWindow = NULL;
+
+    [[NSNotificationCenter defaultCenter] removeObserver: window->ns.delegate];
 
     [window->ns.object orderOut:nil];
 
@@ -1776,6 +1836,49 @@ VkResult _glfwPlatformCreateWindowSurface(VkInstance instance,
     } // autoreleasepool
 }
 
+void _glfwPlatformResetPreeditText(_GLFWwindow* window)
+{
+    NSTextInputContext *context = [NSTextInputContext currentInputContext];
+    [context discardMarkedText];
+    [window->ns.view unmarkText];
+}
+
+void _glfwPlatformSetIMEStatus(_GLFWwindow* window, int active)
+{
+    // Mac OS has several input sources.
+    // this code assumes input methods not in ascii capable inputs using IME.
+    NSArray* asciiInputSources = CFBridgingRelease(TISCreateASCIICapableInputSourceList());
+    TISInputSourceRef asciiSource = (__bridge TISInputSourceRef)([asciiInputSources firstObject]);
+    if (active) {
+        NSArray* allInputSources = CFBridgingRelease(TISCreateInputSourceList(NULL, false));
+        NSString* asciiSourceID = (__bridge NSString *)(TISGetInputSourceProperty(asciiSource, kTISPropertyInputSourceID));
+        int i;
+        int count = [allInputSources count];
+        for (i = 0; i < count; i++) {
+            TISInputSourceRef source = (__bridge TISInputSourceRef)([allInputSources objectAtIndex: i]);
+            NSString* sourceID = (__bridge NSString *)(TISGetInputSourceProperty(source, kTISPropertyInputSourceID));
+            if ([asciiSourceID compare: sourceID] != NSOrderedSame) {
+                TISSelectInputSource(source);
+                break;
+            }
+        }
+    } else if (asciiSource) {
+        TISSelectInputSource(asciiSource);
+    }
+}
+
+int _glfwPlatformGetIMEStatus(_GLFWwindow* window)
+{
+    TISInputSourceRef currentSource = TISCopyCurrentKeyboardInputSource();
+    NSString* currentSourceID = (__bridge NSString *)(TISGetInputSourceProperty(currentSource, kTISPropertyInputSourceID));
+    NSArray* asciiInputSources = CFBridgingRelease(TISCreateASCIICapableInputSourceList());
+    TISInputSourceRef asciiSource = (__bridge TISInputSourceRef)([asciiInputSources firstObject]);
+    if (asciiSource) {
+        NSString* asciiSourceID = (__bridge NSString *)(TISGetInputSourceProperty(asciiSource, kTISPropertyInputSourceID));
+        return ([asciiSourceID compare: currentSourceID] == NSOrderedSame) ? GLFW_FALSE : GLFW_TRUE;
+    }
+    return GLFW_FALSE;
+}
 
 //////////////////////////////////////////////////////////////////////////
 //////                        GLFW native API                       //////

--- a/src/input.c
+++ b/src/input.c
@@ -305,6 +305,20 @@ void _glfwInputChar(_GLFWwindow* window, unsigned int codepoint, int mods, GLFWb
     }
 }
 
+void _glfwInputPreedit(_GLFWwindow* window, int focusedBlock)
+{
+    if (window->callbacks.preedit) {
+        window->callbacks.preedit((GLFWwindow*) window, window->ntext, window->preeditText, window->nblocks, window->preeditAttributeBlocks, focusedBlock);
+    }
+}
+
+void _glfwInputIMEStatus(_GLFWwindow* window)
+{
+    if (window->callbacks.imestatus) {
+        window->callbacks.imestatus((GLFWwindow*) window);
+    }
+}
+
 // Notifies shared code of a scroll event
 //
 void _glfwInputScroll(_GLFWwindow* window, double xoffset, double yoffset)
@@ -487,7 +501,8 @@ GLFWAPI int glfwGetInputMode(GLFWwindow* handle, int mode)
             return window->lockKeyMods;
         case GLFW_RAW_MOUSE_MOTION:
             return window->rawMouseMotion;
-    }
+        case GLFW_IME:
+            return _glfwPlatformGetIMEStatus(window);    }
 
     _glfwInputError(GLFW_INVALID_ENUM, "Invalid input mode 0x%08X", mode);
     return 0;
@@ -582,7 +597,10 @@ GLFWAPI void glfwSetInputMode(GLFWwindow* handle, int mode, int value)
         window->rawMouseMotion = value;
         _glfwPlatformSetRawMouseMotion(window, value);
     }
-    else
+    else if (mode == GLFW_IME)
+    {
+        _glfwPlatformSetIMEStatus(window, value ? GLFW_TRUE : GLFW_FALSE);
+    } else
         _glfwInputError(GLFW_INVALID_ENUM, "Invalid input mode 0x%08X", mode);
 }
 
@@ -824,6 +842,30 @@ GLFWAPI void glfwSetCursor(GLFWwindow* windowHandle, GLFWcursor* cursorHandle)
     _glfwPlatformSetCursor(window, cursor);
 }
 
+GLFWAPI void glfwGetPreeditCursorPos(GLFWwindow* handle, int *x, int *y, int *h)
+{
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    if (x)
+        *x = window->preeditCursorPosX;
+    if (y)
+        *y = window->preeditCursorPosY;
+    if (h)
+        *h = window->preeditCursorHeight;
+}
+
+GLFWAPI void glfwSetPreeditCursorPos(GLFWwindow* handle, int x, int y, int h)
+{
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    window->preeditCursorPosX = x;
+    window->preeditCursorPosY = y;
+    window->preeditCursorHeight = h;
+}
+
+GLFWAPI void glfwResetPreeditText(GLFWwindow* handle) {
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _glfwPlatformResetPreeditText(window);
+}
+
 GLFWAPI GLFWkeyfun glfwSetKeyCallback(GLFWwindow* handle, GLFWkeyfun cbfun)
 {
     _GLFWwindow* window = (_GLFWwindow*) handle;
@@ -851,6 +893,22 @@ GLFWAPI GLFWcharmodsfun glfwSetCharModsCallback(GLFWwindow* handle, GLFWcharmods
 
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
     _GLFW_SWAP_POINTERS(window->callbacks.charmods, cbfun);
+    return cbfun;
+}
+
+GLFWAPI GLFWpreeditfun glfwSetPreeditCallback(GLFWwindow* handle, GLFWpreeditfun cbfun)
+{
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
+    _GLFW_SWAP_POINTERS(window->callbacks.preedit, cbfun);
+    return cbfun;
+}
+
+GLFWAPI GLFWimestatusfun glfwSetIMEStatusCallback(GLFWwindow* handle, GLFWimestatusfun cbfun)
+{
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
+    _GLFW_SWAP_POINTERS(window->callbacks.imestatus, cbfun);
     return cbfun;
 }
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -392,6 +392,15 @@ struct _GLFWwindow
     double              virtualCursorPosX, virtualCursorPosY;
     GLFWbool            rawMouseMotion;
 
+    // Preedit texts
+    unsigned int*       preeditText;
+    int                 ntext;
+    int                 ctext;
+    int*                preeditAttributeBlocks;
+    int                 nblocks;
+    int                 cblocks;
+    int                 preeditCursorPosX, preeditCursorPosY, preeditCursorHeight;
+
     _GLFWcontext        context;
 
     struct {
@@ -411,6 +420,8 @@ struct _GLFWwindow
         GLFWkeyfun              key;
         GLFWcharfun             character;
         GLFWcharmodsfun         charmods;
+        GLFWpreeditfun          preedit;
+        GLFWimestatusfun        imestatus;
         GLFWdropfun             drop;
     } callbacks;
 
@@ -716,6 +727,8 @@ void _glfwInputKey(_GLFWwindow* window,
                    int key, int scancode, int action, int mods);
 void _glfwInputChar(_GLFWwindow* window,
                     unsigned int codepoint, int mods, GLFWbool plain);
+void _glfwInputPreedit(_GLFWwindow* window, int focusedBlock);
+void _glfwInputIMEStatus(_GLFWwindow* window);
 void _glfwInputScroll(_GLFWwindow* window, double xoffset, double yoffset);
 void _glfwInputMouseClick(_GLFWwindow* window, int button, int action, int mods);
 void _glfwInputCursorPos(_GLFWwindow* window, double xpos, double ypos);
@@ -736,6 +749,9 @@ void _glfwInputError(int code, const char* format, ...)
 void _glfwInputError(int code, const char* format, ...);
 #endif
 
+void _glfwPlatformResetPreeditText(_GLFWwindow* window);
+void _glfwPlatformSetIMEStatus(_GLFWwindow* window, int active);
+int  _glfwPlatformGetIMEStatus(_GLFWwindow* window);
 
 //////////////////////////////////////////////////////////////////////////
 //////                       GLFW internal API                      //////

--- a/src/window.c
+++ b/src/window.c
@@ -230,6 +230,9 @@ GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height,
     {
         if (wndconfig.centerCursor)
             _glfwCenterCursorInContentArea(window);
+        window->preeditCursorPosX = 0;
+        window->preeditCursorPosY = height;
+        window->preeditCursorHeight = 0;
     }
     else
     {
@@ -239,6 +242,9 @@ GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height,
             if (wndconfig.focused)
                 _glfwPlatformFocusWindow(window);
         }
+        window->preeditCursorPosX = 0;
+        window->preeditCursorPosY = height;
+        window->preeditCursorHeight = 0;
     }
 
     return (GLFWwindow*) window;
@@ -465,7 +471,11 @@ GLFWAPI void glfwDestroyWindow(GLFWwindow* handle)
 
         *prev = window->next;
     }
-
+    // Clear memory for preedit text
+    if (window->preeditText)
+        free(window->preeditText);
+    if (window->preeditAttributeBlocks)
+        free(window->preeditAttributeBlocks);
     free(window);
 }
 

--- a/src/x11_platform.h
+++ b/src/x11_platform.h
@@ -201,6 +201,16 @@ typedef struct _GLFWwindowX11
     // The time of the last KeyPress event
     Time            lastKeyTime;
 
+    // Preedit callbacks
+    XIMCallback preeditStartCallback;
+    XIMCallback preeditDoneCallback;
+    XIMCallback preeditDrawCallback;
+    XIMCallback preeditCaretCallback;
+    XIMCallback statusStartCallback;
+    XIMCallback statusDoneCallback;
+    XIMCallback statusDrawCallback;
+
+    int imeFocus;
 } _GLFWwindowX11;
 
 // X11-specific global data

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -50,6 +50,9 @@
 
 #define _GLFW_XDND_VERSION 5
 
+#if defined(X_HAVE_UTF8_STRING)
+static unsigned int decodeUTF8(const char** s);
+#endif
 
 // Wait for data to arrive using select
 // This avoids blocking other threads via the per-display Xlib lock that also
@@ -587,6 +590,196 @@ static void enableCursor(_GLFWwindow* window)
     updateCursorImage(window);
 }
 
+// Update cursor position to decide candidate window
+static void _ximChangeCursorPosition(XIC xic, _GLFWwindow* window)
+{
+    XVaNestedList preedit_attr;
+    XPoint        spot;
+
+    spot.x = window->preeditCursorPosX;
+    spot.y = window->preeditCursorPosY + window->preeditCursorHeight;
+    preedit_attr = XVaCreateNestedList(0, XNSpotLocation, &spot, NULL);
+    XSetICValues(xic, XNPreeditAttributes, preedit_attr, NULL);
+    XFree(preedit_attr);
+}
+
+// IME Start callback (do nothing)
+static void _ximPreeditStartCallback(XIC xic, XPointer clientData, XPointer callData)
+{
+}
+
+// IME Done callback (do nothing)
+static void _ximPreeditDoneCallback(XIC xic, XPointer clientData, XPointer callData)
+{
+}
+
+// IME Draw callback
+static void _ximPreeditDrawCallback(XIC xic, XPointer clientData, XIMPreeditDrawCallbackStruct *callData)
+{
+    int i, j, length, ctext, rstart, rend;
+    XIMText* text;
+    const char* src;
+    unsigned int codePoint;
+    unsigned int* preeditText;
+    XIMFeedback f;
+    _GLFWwindow* window = (_GLFWwindow*)clientData;
+
+    // keep cursor position to reduce API call
+    int cursorX = window->preeditCursorPosX;
+    int cursorY = window->preeditCursorPosY;
+    int cursorHeight = window->preeditCursorHeight;
+
+    if (!callData->text) {
+        // preedit text is empty
+        window->ntext = 0;
+        window->nblocks = 0;
+        _glfwInputPreedit(window, 0);
+        return;
+    } else {
+        text = callData->text;
+        length = callData->chg_length;
+        if (text->encoding_is_wchar) {
+            // wchar is not supported
+            return;
+        }
+        ctext = window->ctext;
+        while (ctext < length+1) {
+            ctext = (ctext == 0) ? 1 : ctext * 2;
+        }
+        if (ctext != window->ctext) {
+            preeditText = realloc(window->preeditText, sizeof(unsigned int)*ctext);
+            if (preeditText == NULL) {
+                return;
+            }
+            window->preeditText = preeditText;
+            window->ctext = ctext;
+        }
+        window->ntext = length;
+        window->preeditText[length] = 0;
+        if (window->cblocks == 0) {
+            window->preeditAttributeBlocks = malloc(sizeof(int)*4);
+            window->cblocks = 4;
+        }
+        src = text->string.multi_byte;
+        rend = 0;
+        rstart = length;
+        for (i = 0, j = 0; i < text->length; i++) {
+            #if defined(X_HAVE_UTF8_STRING)
+            codePoint = decodeUTF8(&src);
+            #else
+            codePoint = *src;
+            src++;
+            #endif
+            if (i < callData->chg_first || callData->chg_first+length < i) {
+                continue;
+            }
+            window->preeditText[j++] = codePoint;
+            f = text->feedback[i];
+            if ((f & XIMReverse) || (f & XIMHighlight)) {
+                rend = i;
+                if (i < rstart) {
+                    rstart = i;
+                }
+            }
+        }
+        if (rstart == length) {
+            window->nblocks = 1;
+            window->preeditAttributeBlocks[0] = length;
+            window->preeditAttributeBlocks[1] = 0;
+            _glfwInputPreedit(window, 0);
+        } else if (rstart == 0) {
+            if (rend == length -1) {
+                window->nblocks = 1;
+                window->preeditAttributeBlocks[0] = length;
+                window->preeditAttributeBlocks[1] = 0;
+                _glfwInputPreedit(window, 0);
+            } else {
+                window->nblocks = 2;
+                window->preeditAttributeBlocks[0] = rend + 1;
+                window->preeditAttributeBlocks[1] = length - rend - 1;
+                window->preeditAttributeBlocks[2] = 0;
+                _glfwInputPreedit(window, 0);
+            }
+        } else if (rend == length -1) {
+            window->nblocks = 2;
+            window->preeditAttributeBlocks[0] = rstart;
+            window->preeditAttributeBlocks[1] = length - rstart;
+            window->preeditAttributeBlocks[2] = 0;
+            _glfwInputPreedit(window, 1);
+        } else {
+            window->nblocks = 3;
+            window->preeditAttributeBlocks[0] = rstart;
+            window->preeditAttributeBlocks[1] = rend - rstart + 1;
+            window->preeditAttributeBlocks[2] = length - rend - 1;
+            window->preeditAttributeBlocks[3] = 0;
+            _glfwInputPreedit(window, 1);
+        }
+        if ((cursorX != window->preeditCursorPosX)
+                || (cursorY != window->preeditCursorPosY)
+                || (cursorHeight != window->preeditCursorHeight)) {
+            _ximChangeCursorPosition(xic, window);
+        }
+    }
+}
+
+// IME Caret callback (do nothing)
+static void _ximPreeditCaretCallback(XIC xic, XPointer clientData, XPointer callData)
+{
+}
+
+static void _ximStatusStartCallback(XIC xic, XPointer clientData, XPointer callData)
+{
+    _GLFWwindow* window = (_GLFWwindow*)clientData;
+    window->x11.imeFocus = GLFW_TRUE;
+}
+
+static void _ximStatusDoneCallback(XIC xic, XPointer clientData, XPointer callData)
+{
+    _GLFWwindow* window = (_GLFWwindow*)clientData;
+    window->x11.imeFocus = GLFW_FALSE;
+}
+
+static void _ximStatusDrawCallback(XIC xic, XPointer clientData, XIMStatusDrawCallbackStruct* callData)
+{
+    _GLFWwindow* window = (_GLFWwindow*)clientData;
+    _glfwInputIMEStatus(window);
+}
+
+// Create XIM Preedit callback
+static XVaNestedList _createXIMPreeditCallbacks(_GLFWwindow* window)
+{
+    window->x11.preeditStartCallback.client_data = (XPointer)window;
+    window->x11.preeditStartCallback.callback = (XIMProc)_ximPreeditStartCallback;
+    window->x11.preeditDoneCallback.client_data = (XPointer)window;
+    window->x11.preeditDoneCallback.callback = (XIMProc)_ximPreeditDoneCallback;
+    window->x11.preeditDrawCallback.client_data = (XPointer)window;
+    window->x11.preeditDrawCallback.callback = (XIMProc)_ximPreeditDrawCallback;
+    window->x11.preeditCaretCallback.client_data = (XPointer)window;
+    window->x11.preeditCaretCallback.callback = (XIMProc)_ximPreeditCaretCallback;
+    return XVaCreateNestedList (0,
+        XNPreeditStartCallback, &window->x11.preeditStartCallback.client_data,
+        XNPreeditDoneCallback, &window->x11.preeditDoneCallback.client_data,
+        XNPreeditDrawCallback, &window->x11.preeditDrawCallback.client_data,
+        XNPreeditCaretCallback, &window->x11.preeditCaretCallback.client_data,
+        NULL);
+}
+
+// Create XIM status callback
+static XVaNestedList _createXIMStatusCallbacks(_GLFWwindow* window)
+{
+    window->x11.statusStartCallback.client_data = (XPointer)window;
+    window->x11.statusStartCallback.callback = (XIMProc)_ximStatusStartCallback;
+    window->x11.statusDoneCallback.client_data = (XPointer)window;
+    window->x11.statusDoneCallback.callback = (XIMProc)_ximStatusDoneCallback;
+    window->x11.statusDrawCallback.client_data = (XPointer)window;
+    window->x11.statusDrawCallback.callback = (XIMProc)_ximStatusDrawCallback;
+    return XVaCreateNestedList (0,
+        XNStatusStartCallback, &window->x11.statusStartCallback.client_data,
+        XNStatusDoneCallback, &window->x11.statusDoneCallback.client_data,
+        XNStatusDrawCallback, &window->x11.statusDrawCallback.client_data,
+        NULL);
+}
+
 // Create the X11 window (and its colormap)
 //
 static GLFWbool createNativeWindow(_GLFWwindow* window,
@@ -774,14 +967,23 @@ static GLFWbool createNativeWindow(_GLFWwindow* window,
 
     if (_glfw.x11.im)
     {
+        XVaNestedList preeditList = _createXIMPreeditCallbacks(window);
+        XVaNestedList statusList = _createXIMStatusCallbacks(window);
         window->x11.ic = XCreateIC(_glfw.x11.im,
                                    XNInputStyle,
-                                   XIMPreeditNothing | XIMStatusNothing,
+                                   XIMPreeditCallbacks | XIMStatusCallbacks,
                                    XNClientWindow,
                                    window->x11.handle,
                                    XNFocusWindow,
                                    window->x11.handle,
+                                   XNPreeditAttributes,
+                                   preeditList,
+                                   XNStatusAttributes,
+                                   statusList,
                                    NULL);
+        XFree(preeditList);
+        XFree(statusList);
+        window->x11.imeFocus = GLFW_FALSE;
     }
 
     _glfwPlatformGetWindowPos(window, &window->x11.xpos, &window->x11.ypos);
@@ -3046,6 +3248,46 @@ VkResult _glfwPlatformCreateWindowSurface(VkInstance instance,
     }
 }
 
+void _glfwPlatformResetPreeditText(_GLFWwindow* window) {
+    XIC ic = window->x11.ic;
+
+    /* restore conversion state after resetting ic later */
+    XIMPreeditState preedit_state = XIMPreeditUnKnown;
+    XVaNestedList preedit_attr;
+    char* result;
+
+    if (window->ntext == 0)
+        return;
+
+    preedit_attr = XVaCreateNestedList(0, XNPreeditState, &preedit_state, NULL);
+    XGetICValues(ic, XNPreeditAttributes, preedit_attr, NULL);
+    XFree(preedit_attr);
+
+    result = XmbResetIC(ic);
+
+    preedit_attr = XVaCreateNestedList(0, XNPreeditState, preedit_state, NULL);
+    XSetICValues(ic, XNPreeditAttributes, preedit_attr, NULL);
+    XFree(preedit_attr);
+
+    window->ntext = 0;
+    window->nblocks = 0;
+    _glfwInputPreedit(window, 0);
+
+    XFree (result);
+}
+
+void _glfwPlatformSetIMEStatus(_GLFWwindow* window, int active) {
+    XIC ic = window->x11.ic;
+    if (active) {
+        XSetICFocus(ic);
+    } else {
+        XUnsetICFocus(ic);
+    }
+}
+
+int  _glfwPlatformGetIMEStatus(_GLFWwindow* window) {
+    return window->x11.imeFocus;
+}
 
 //////////////////////////////////////////////////////////////////////////
 //////                        GLFW native API                       //////

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(iconify iconify.c ${GETOPT} ${GLAD})
 add_executable(monitors monitors.c ${GETOPT} ${GLAD})
 add_executable(reopen reopen.c ${GLAD})
 add_executable(cursor cursor.c ${GLAD})
+add_executable(ime ime.c ${GETOPT} ${GLAD})
 
 add_executable(empty WIN32 MACOSX_BUNDLE empty.c ${TINYCTHREAD} ${GLAD})
 add_executable(gamma WIN32 MACOSX_BUNDLE gamma.c ${GLAD})
@@ -49,7 +50,7 @@ endif()
 set(WINDOWS_BINARIES empty gamma icon inputlag joysticks opacity tearing
                      threads timeout title windows)
 set(CONSOLE_BINARIES clipboard events msaa glfwinfo iconify monitors reopen
-                     cursor)
+                     cursor ime)
 
 if (VULKAN_FOUND)
     add_executable(vulkan WIN32 vulkan.c ${ICON})


### PR DESCRIPTION
Add better IME support (#41) to implement on-the-spot IME conversion. My code is based on #643.

I added the following functions:
- glfwSetPreeditCallback() : callback function to notify preedit text
- glfwSetPreeditCursorPos() : teach text cursor position for IME windows
- glfwGetPreeditCursorPos() : get text cursor position for IME windows

They are not big changes. It keeps backward compatibility about API level.
To use IME feature, UI programmers should implement visualization code for preedit texts. 

I implemented platform specific code for Windows/X11/Mac OS X (not Wayland and Mir).
