### PR TITLE
Avoid small memory leak

### DIFF
--- a/src/x11_init.c
+++ b/src/x11_init.c
@@ -311,6 +311,7 @@ static void createKeyTables(void)
 
         XkbFreeNames(desc, XkbKeyNamesMask, True);
         XkbFreeClientMap(desc, 0, True);
+        XkbFreeKeyboard(desc, 0, True);
     }
 
     for (scancode = 0;  scancode < 256;  scancode++)


### PR DESCRIPTION
add `XkbFreeKeyboard(desc, 0, True);` to avoid valgrind complaining about loss record from XkbGetMap