### PR TITLE
Fix SetProcessDpiAwareness case mismatch

### DIFF
--- a/src/win32_init.c
+++ b/src/win32_init.c
@@ -102,8 +102,8 @@ static GLFWbool loadLibraries(void)
     _glfw.win32.shcore.instance = LoadLibraryA("shcore.dll");
     if (_glfw.win32.shcore.instance)
     {
-        _glfw.win32.shcore.SetProcessDPIAwareness = (SETPROCESSDPIAWARENESS_T)
-            GetProcAddress(_glfw.win32.shcore.instance, "SetProcessDPIAwareness");
+        _glfw.win32.shcore.SetProcessDpiAwareness = (SETPROCESSDPIAWARENESS_T)
+            GetProcAddress(_glfw.win32.shcore.instance, "SetProcessDpiAwareness");
     }
 
     return GLFW_TRUE;
@@ -357,8 +357,8 @@ int _glfwPlatformInit(void)
 
     createKeyTables();
 
-    if (_glfw_SetProcessDPIAwareness)
-        _glfw_SetProcessDPIAwareness(PROCESS_PER_MONITOR_DPI_AWARE);
+    if (_glfw_SetProcessDpiAwareness)
+        _glfw_SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE);
     else if (_glfw_SetProcessDPIAware)
         _glfw_SetProcessDPIAware();
 

--- a/src/win32_platform.h
+++ b/src/win32_platform.h
@@ -138,7 +138,7 @@ typedef HRESULT (WINAPI * DWMFLUSH_T)(VOID);
 
 // shcore.dll function pointer typedefs
 typedef HRESULT (WINAPI * SETPROCESSDPIAWARENESS_T)(PROCESS_DPI_AWARENESS);
-#define _glfw_SetProcessDPIAwareness _glfw.win32.shcore.SetProcessDPIAwareness
+#define _glfw_SetProcessDpiAwareness _glfw.win32.shcore.SetProcessDpiAwareness
 
 #include "win32_joystick.h"
 
@@ -218,7 +218,7 @@ typedef struct _GLFWlibraryWin32
     // shcore.dll
     struct {
         HINSTANCE       instance;
-        SETPROCESSDPIAWARENESS_T SetProcessDPIAwareness;
+        SETPROCESSDPIAWARENESS_T SetProcessDpiAwareness;
     } shcore;
 
 } _GLFWlibraryWin32;


### PR DESCRIPTION
This patch corrects the [SetProcessDpiAwareness](https://msdn.microsoft.com/en-us/library/windows/desktop/dn302122(v=vs.85).aspx) function name.