### PR TITLE
Partially revert 37c93ba0, fixes #664

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,6 +356,16 @@ foreach(arg ${glfw_PKG_LIBS})
 endforeach()
 
 #--------------------------------------------------------------------
+# Choose library output name
+#--------------------------------------------------------------------
+if (BUILD_SHARED_LIBS AND UNIX)
+    # On Unix-like systems, shared libraries can use the soname system.
+    set(GLFW_LIB_NAME glfw)
+else()
+    set(GLFW_LIB_NAME glfw3)
+endif()
+
+#--------------------------------------------------------------------
 # Create generated files
 #--------------------------------------------------------------------
 include(CMakePackageConfigHelpers)


### PR DESCRIPTION
GLFW_LIB_NAME is required for the generation of the glfw3.pc pkg-config file, so add it back.