### PR TITLE
Add GLFW includes to target_include_directories

### DIFF
--- a/docs/build.dox
+++ b/docs/build.dox
@@ -158,13 +158,6 @@ will add the `glfw` target and the necessary cache variables to your project.
 add_subdirectory(path/to/glfw)
 @endcode
 
-To be able to include the GLFW header from your code, you need to tell the
-compiler where to find it.
-
-@code{.cmake}
-include_directories(path/to/glfw/include)
-@endcode
-
 Once GLFW has been added to the project, the `GLFW_LIBRARIES` cache variable
 contains all link-time dependencies of GLFW as it is currently configured.  To
 link against GLFW, link against them and the `glfw` target.
@@ -172,6 +165,8 @@ link against GLFW, link against them and the `glfw` target.
 @code{.cmake}
 target_link_libraries(myapp glfw ${GLFW_LIBRARIES})
 @endcode
+
+This also makes the GLFW header available for inclusion from your code.
 
 Note that `GLFW_LIBRARIES` does not include GLU, as GLFW does not use it.  If
 your application needs GLU, you can add it to the list of dependencies with the

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,6 +64,9 @@ target_include_directories(glfw PRIVATE
                            "${GLFW_BINARY_DIR}/src"
                            ${glfw_INCLUDE_DIRS})
 
+# Make the public GLFW includes available for users of the GLFW library.
+target_include_directories(glfw PUBLIC "${GLFW_SOURCE_DIR}/include")
+
 # HACK: When building on MinGW, WINVER and UNICODE need to be defined before
 # the inclusion of stddef.h (by glfw3.h), which is itself included before
 # win32_platform.h.  We define them here until a saner solution can be found


### PR DESCRIPTION
This makes it easier to build GLFW as a sub-project of another CMake based project. Instead of having to use include_directories(path/to/glfw/include) the project using GLFW will get the correct include path by just doing target_link_libraries(myapp glfw ${GLFW_LIBRARIES}).

Note: I'm still learning CMake, so I hope that this is the correct solution.

@elmindreda - Does this look OK? This would also change the documentation: In http://www.glfw.org/docs/latest/build.html#build_link_cmake_source, the step about "To be able to include the GLFW header from your code..." can be removed.