### PR TITLE
Add accelerated transparent window support for Windows Vista and up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Debug
 Release
 MinSizeRel
 RelWithDebInfo
+*.VC.opendb
 
 # CMake files
 Makefile

--- a/examples/gears.c
+++ b/examples/gears.c
@@ -314,6 +314,7 @@ int main(int argc, char *argv[])
     glfwWindowHint(GLFW_DEPTH_BITS, 16);
     glfwWindowHint(GLFW_ALPHA_BITS, 8);
     glfwWindowHint(GLFW_TRANSPARENT, GLFW_TRUE);
+    glfwWindowHint(GLFW_DECORATED, GLFW_FALSE);
 
     window = glfwCreateWindow( 300, 300, "Gears", NULL, NULL );
     if (!window)

--- a/src/win32_init.c
+++ b/src/win32_init.c
@@ -97,6 +97,8 @@ static GLFWbool loadLibraries(void)
             GetProcAddress(_glfw.win32.dwmapi.instance, "DwmIsCompositionEnabled");
         _glfw.win32.dwmapi.DwmFlush = (DWMFLUSH_T)
             GetProcAddress(_glfw.win32.dwmapi.instance, "DwmFlush");
+        _glfw.win32.dwmapi.DwmEnableBlurBehindWindow = (DWMENABLEBLURBEHINDWINDOW_T)
+            GetProcAddress(_glfw.win32.dwmapi.instance, "DwmEnableBlurBehindWindow");
     }
 
     _glfw.win32.shcore.instance = LoadLibraryA("shcore.dll");

--- a/src/win32_platform.h
+++ b/src/win32_platform.h
@@ -120,21 +120,32 @@ typedef enum PROCESS_DPI_AWARENESS
 } PROCESS_DPI_AWARENESS;
 #endif /*DPI_ENUMS_DECLARED*/
 
+typedef struct _DWM_BLURBEHIND
+{
+    DWORD dwFlags;
+    BOOL fEnable;
+    HRGN hRgnBlur;
+    BOOL fTransitionOnMaximized;
+} DWM_BLURBEHIND, *PDWM_BLURBEHIND;
+
 // winmm.dll function pointer typedefs
 typedef MMRESULT (WINAPI * JOYGETDEVCAPS_T)(UINT,LPJOYCAPS,UINT);
 typedef MMRESULT (WINAPI * JOYGETPOS_T)(UINT,LPJOYINFO);
 typedef MMRESULT (WINAPI * JOYGETPOSEX_T)(UINT,LPJOYINFOEX);
 typedef DWORD (WINAPI * TIMEGETTIME_T)(void);
+typedef HRESULT(WINAPI * DWMENABLEBLURBEHINDWINDOW_T)(HWND, const DWM_BLURBEHIND*);
 #define _glfw_joyGetDevCaps _glfw.win32.winmm.joyGetDevCaps
 #define _glfw_joyGetPos _glfw.win32.winmm.joyGetPos
 #define _glfw_joyGetPosEx _glfw.win32.winmm.joyGetPosEx
 #define _glfw_timeGetTime _glfw.win32.winmm.timeGetTime
+#define _glfw_DwmEnableBlurBehindWindow _glfw.win32.dwmapi.DwmEnableBlurBehindWindow
 
 // user32.dll function pointer typedefs
 typedef BOOL (WINAPI * SETPROCESSDPIAWARE_T)(void);
 typedef BOOL (WINAPI * CHANGEWINDOWMESSAGEFILTEREX_T)(HWND,UINT,DWORD,PCHANGEFILTERSTRUCT);
 #define _glfw_SetProcessDPIAware _glfw.win32.user32.SetProcessDPIAware
 #define _glfw_ChangeWindowMessageFilterEx _glfw.win32.user32.ChangeWindowMessageFilterEx
+#define _glfw_DwmEnableBlurBehindWindow _glfw.win32.dwmapi.DwmEnableBlurBehindWindow
 
 // dwmapi.dll function pointer typedefs
 typedef HRESULT (WINAPI * DWMISCOMPOSITIONENABLED_T)(BOOL*);
@@ -237,6 +248,7 @@ typedef struct _GLFWlibraryWin32
         HINSTANCE       instance;
         DWMISCOMPOSITIONENABLED_T DwmIsCompositionEnabled;
         DWMFLUSH_T      DwmFlush;
+        DWMENABLEBLURBEHINDWINDOW_T DwmEnableBlurBehindWindow;
     } dwmapi;
 
     // shcore.dll

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -732,6 +732,19 @@ static int createWindow(_GLFWwindow* window, const _GLFWwndconfig* wndconfig)
     window->win32.numer     = GLFW_DONT_CARE;
     window->win32.denom     = GLFW_DONT_CARE;
 
+    // Accelerated transparent windows
+    // It currently doesn't support decorated windows.
+    // If decorated is required we just return an opaque window.
+    // Since DwmEnableBlurBehindWindow is supported since Vista,
+    // previous versions will simply get an opaque window.
+    if (!window->decorated && _glfw_DwmEnableBlurBehindWindow && window->transparent) {
+        DWM_BLURBEHIND bb = { 0 };
+        bb.dwFlags = 3; // DWM_BB_ENABLE | DWM_BB_BLURREGION
+        bb.hRgnBlur = CreateRectRgn(0, 0, -1, -1); // an invalid hRgnBlur makes the the window transparent
+        bb.fEnable = TRUE;
+        _glfw_DwmEnableBlurBehindWindow(window->win32.handle, &bb);
+    }
+
     return GLFW_TRUE;
 }
 


### PR DESCRIPTION
Because `DwmEnableBlurBehindWindow` is supported since Vista, previous versions will simply get an opaque window.

It currently doesn't support setting a decorated window at the same time. If the decorated window hint is set to true, we just return an opaque window. It probably isn't a big issue since transparent windows are usually used for overlays or unconventional window shapes. This issue could actually be fixed by adding support for Windows XP and choose the non accelerated path instead, when decoration is required. A solution for accelerated transparent window with decoration probably does exist but I haven't been able to find it.