### PR TITLE
Add support for wgl window transparency (Vista and later)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Debug
 Release
 MinSizeRel
 RelWithDebInfo
+*.VC.opendb
 
 # CMake files
 Makefile

--- a/examples/gears.c
+++ b/examples/gears.c
@@ -314,6 +314,7 @@ int main(int argc, char *argv[])
     glfwWindowHint(GLFW_DEPTH_BITS, 16);
     glfwWindowHint(GLFW_ALPHA_BITS, 8);
     glfwWindowHint(GLFW_TRANSPARENT, GLFW_TRUE);
+    glfwWindowHint(GLFW_DECORATED, GLFW_FALSE);
 
     window = glfwCreateWindow( 300, 300, "Gears", NULL, NULL );
     if (!window)

--- a/examples/gears.c
+++ b/examples/gears.c
@@ -298,17 +298,9 @@ static void init(void)
   glEnable(GL_NORMALIZE);
 }
 
-GLFWerrorfun ErrorFun(int i, const char* str) {
-    char buf[255];
-    sprintf(buf, "%d: %s", i, str);
-    MessageBoxA(0, buf, "Error", MB_ICONERROR | MB_OK);
-}
-
 /* program entry */
 int main(int argc, char *argv[])
 {
-    glfwSetErrorCallback(ErrorFun);
-
     GLFWwindow* window;
     int width, height;
 

--- a/examples/gears.c
+++ b/examples/gears.c
@@ -298,10 +298,17 @@ static void init(void)
   glEnable(GL_NORMALIZE);
 }
 
+GLFWerrorfun ErrorFun(int i, const char* str) {
+    char buf[255];
+    sprintf(buf, "%d: %s", i, str);
+    MessageBoxA(0, buf, "Error", MB_ICONERROR | MB_OK);
+}
 
 /* program entry */
 int main(int argc, char *argv[])
 {
+    glfwSetErrorCallback(ErrorFun);
+
     GLFWwindow* window;
     int width, height;
 
@@ -314,7 +321,7 @@ int main(int argc, char *argv[])
     glfwWindowHint(GLFW_DEPTH_BITS, 16);
     glfwWindowHint(GLFW_ALPHA_BITS, 8);
     glfwWindowHint(GLFW_TRANSPARENT, GLFW_TRUE);
-    glfwWindowHint(GLFW_DECORATED, GLFW_FALSE);
+    glfwWindowHint(GLFW_DECORATED, GLFW_TRUE);
 
     window = glfwCreateWindow( 300, 300, "Gears", NULL, NULL );
     if (!window)

--- a/src/wgl_context.c
+++ b/src/wgl_context.c
@@ -493,6 +493,28 @@ GLFWbool _glfwCreateContextWGL(_GLFWwindow* window,
         }
     }
 
+    if (window->transparent) {
+        if (!isCompositionEnabled || !_glfw_DwmEnableBlurBehindWindow) {
+            window->transparent = GLFW_FALSE;
+        }
+        else
+        {
+            HRESULT hr = S_OK;
+
+            DWM_BLURBEHIND bb = { 0 };
+            bb.dwFlags = DWM_BB_ENABLE | DWM_BB_BLURREGION;
+            bb.hRgnBlur = CreateRectRgn(0, 0, -1, -1);  // makes the window transparent
+            bb.fEnable = TRUE;
+            hr = _glfw_DwmEnableBlurBehindWindow(window->win32.handle, &bb);
+
+            if (!SUCCEEDED(hr)) {
+                window->transparent = GLFW_FALSE;
+                _glfwInputError(GLFW_PLATFORM_ERROR,
+                    "WGL: Failed to enable blur behind window required for transparency");
+            }
+        }
+    }
+
     return GLFW_TRUE;
 }
 

--- a/src/wgl_context.c
+++ b/src/wgl_context.c
@@ -366,12 +366,14 @@ isWindowsVersionOrGreater(WORD wMajorVersion, WORD wMinorVersion, WORD wServiceP
     return VerifyVersionInfoW(&osvi, VER_MAJORVERSION | VER_MINORVERSION | VER_SERVICEPACKMAJOR, dwlConditionMask) != FALSE;
 }
 
-static GLFWbool isWindows8OrGreater() {
+static GLFWbool isWindows8OrGreater()
+{
     GLFWbool isWin8OrGreater = isWindowsVersionOrGreater(HIBYTE(_WIN32_WINNT_WIN8), LOBYTE(_WIN32_WINNT_WIN8), 0) ? GLFW_TRUE: GLFW_FALSE;
     return isWin8OrGreater;
 }
 
-static GLFWbool setupTransparentWindow(HWND handle, GLFWbool isDecorated) {
+static GLFWbool setupTransparentWindow(_GLFWwindow* window)
+{
     if (!isCompositionEnabled) {
         _glfwInputError(GLFW_PLATFORM_ERROR,
             "WGL: Composition needed for transparent window is disabled");
@@ -383,6 +385,7 @@ static GLFWbool setupTransparentWindow(HWND handle, GLFWbool isDecorated) {
     }
 
     HRESULT hr = S_OK;
+    HWND handle = window->win32.handle;
 
     DWM_BLURBEHIND bb = { 0 };
     bb.dwFlags = DWM_BB_ENABLE | DWM_BB_BLURREGION;
@@ -403,7 +406,8 @@ static GLFWbool setupTransparentWindow(HWND handle, GLFWbool isDecorated) {
     // the layered window, all pixels painted by the window in this color will be transparent.
     // That doesn't seem to be the case anymore on Windows 8+, at least when used with
     // DwmEnableBlurBehindWindow + negative region.
-    if (isDecorated && isWindows8OrGreater()) {
+    if (window->decorated && isWindows8OrGreater())
+    {
         long style = GetWindowLong(handle, GWL_EXSTYLE);
         if (!style) {
             _glfwInputError(GLFW_PLATFORM_ERROR,
@@ -433,6 +437,7 @@ static GLFWbool setupTransparentWindow(HWND handle, GLFWbool isDecorated) {
             return GLFW_FALSE;
         }
     }
+
     return GLFW_TRUE;
 }
 
@@ -585,10 +590,10 @@ GLFWbool _glfwCreateContextWGL(_GLFWwindow* window,
         }
     }
 
-    if (window->transparent) {
-        if (!setupTransparentWindow(window->win32.handle, window->decorated)) {
+    if (window->transparent)
+    {
+        if (!setupTransparentWindow(window))
             window->transparent = GLFW_FALSE;
-        }
     }
 
     return GLFW_TRUE;

--- a/src/win32_init.c
+++ b/src/win32_init.c
@@ -97,6 +97,8 @@ static GLFWbool loadLibraries(void)
             GetProcAddress(_glfw.win32.dwmapi.instance, "DwmIsCompositionEnabled");
         _glfw.win32.dwmapi.DwmFlush = (DWMFLUSH_T)
             GetProcAddress(_glfw.win32.dwmapi.instance, "DwmFlush");
+        _glfw.win32.dwmapi.DwmEnableBlurBehindWindow = (DWMENABLEBLURBEHINDWINDOW_T)
+            GetProcAddress(_glfw.win32.dwmapi.instance, "DwmEnableBlurBehindWindow");
     }
 
     _glfw.win32.shcore.instance = LoadLibraryA("shcore.dll");

--- a/src/win32_platform.h
+++ b/src/win32_platform.h
@@ -120,6 +120,12 @@ typedef enum PROCESS_DPI_AWARENESS
 } PROCESS_DPI_AWARENESS;
 #endif /*DPI_ENUMS_DECLARED*/
 
+#if !defined(_DWMAPI_H_)
+// Blur behind data structures
+#define DWM_BB_ENABLE                 0x00000001  // fEnable has been specified
+#define DWM_BB_BLURREGION             0x00000002  // hRgnBlur has been specified
+#define DWM_BB_TRANSITIONONMAXIMIZED  0x00000004  // fTransitionOnMaximized has been specified
+
 typedef struct _DWM_BLURBEHIND
 {
     DWORD dwFlags;
@@ -127,31 +133,31 @@ typedef struct _DWM_BLURBEHIND
     HRGN hRgnBlur;
     BOOL fTransitionOnMaximized;
 } DWM_BLURBEHIND, *PDWM_BLURBEHIND;
+#endif
 
 // winmm.dll function pointer typedefs
 typedef MMRESULT (WINAPI * JOYGETDEVCAPS_T)(UINT,LPJOYCAPS,UINT);
 typedef MMRESULT (WINAPI * JOYGETPOS_T)(UINT,LPJOYINFO);
 typedef MMRESULT (WINAPI * JOYGETPOSEX_T)(UINT,LPJOYINFOEX);
 typedef DWORD (WINAPI * TIMEGETTIME_T)(void);
-typedef HRESULT(WINAPI * DWMENABLEBLURBEHINDWINDOW_T)(HWND, const DWM_BLURBEHIND*);
 #define _glfw_joyGetDevCaps _glfw.win32.winmm.joyGetDevCaps
 #define _glfw_joyGetPos _glfw.win32.winmm.joyGetPos
 #define _glfw_joyGetPosEx _glfw.win32.winmm.joyGetPosEx
 #define _glfw_timeGetTime _glfw.win32.winmm.timeGetTime
-#define _glfw_DwmEnableBlurBehindWindow _glfw.win32.dwmapi.DwmEnableBlurBehindWindow
 
 // user32.dll function pointer typedefs
 typedef BOOL (WINAPI * SETPROCESSDPIAWARE_T)(void);
 typedef BOOL (WINAPI * CHANGEWINDOWMESSAGEFILTEREX_T)(HWND,UINT,DWORD,PCHANGEFILTERSTRUCT);
 #define _glfw_SetProcessDPIAware _glfw.win32.user32.SetProcessDPIAware
 #define _glfw_ChangeWindowMessageFilterEx _glfw.win32.user32.ChangeWindowMessageFilterEx
-#define _glfw_DwmEnableBlurBehindWindow _glfw.win32.dwmapi.DwmEnableBlurBehindWindow
 
 // dwmapi.dll function pointer typedefs
 typedef HRESULT (WINAPI * DWMISCOMPOSITIONENABLED_T)(BOOL*);
 typedef HRESULT (WINAPI * DWMFLUSH_T)(VOID);
+typedef HRESULT (WINAPI * DWMENABLEBLURBEHINDWINDOW_T)(HWND, const DWM_BLURBEHIND*);
 #define _glfw_DwmIsCompositionEnabled _glfw.win32.dwmapi.DwmIsCompositionEnabled
 #define _glfw_DwmFlush _glfw.win32.dwmapi.DwmFlush
+#define _glfw_DwmEnableBlurBehindWindow _glfw.win32.dwmapi.DwmEnableBlurBehindWindow
 
 // shcore.dll function pointer typedefs
 typedef HRESULT (WINAPI * SETPROCESSDPIAWARENESS_T)(PROCESS_DPI_AWARENESS);

--- a/src/win32_platform.h
+++ b/src/win32_platform.h
@@ -120,21 +120,32 @@ typedef enum PROCESS_DPI_AWARENESS
 } PROCESS_DPI_AWARENESS;
 #endif /*DPI_ENUMS_DECLARED*/
 
+typedef struct _DWM_BLURBEHIND
+{
+    DWORD dwFlags;
+    BOOL fEnable;
+    HRGN hRgnBlur;
+    BOOL fTransitionOnMaximized;
+} DWM_BLURBEHIND, *PDWM_BLURBEHIND;
+
 // winmm.dll function pointer typedefs
 typedef MMRESULT (WINAPI * JOYGETDEVCAPS_T)(UINT,LPJOYCAPS,UINT);
 typedef MMRESULT (WINAPI * JOYGETPOS_T)(UINT,LPJOYINFO);
 typedef MMRESULT (WINAPI * JOYGETPOSEX_T)(UINT,LPJOYINFOEX);
 typedef DWORD (WINAPI * TIMEGETTIME_T)(void);
+typedef HRESULT(WINAPI * DWMENABLEBLURBEHINDWINDOW_T)(HWND, const DWM_BLURBEHIND*);
 #define _glfw_joyGetDevCaps _glfw.win32.winmm.joyGetDevCaps
 #define _glfw_joyGetPos _glfw.win32.winmm.joyGetPos
 #define _glfw_joyGetPosEx _glfw.win32.winmm.joyGetPosEx
 #define _glfw_timeGetTime _glfw.win32.winmm.timeGetTime
+#define _glfw_DwmEnableBlurBehindWindow _glfw.win32.dwmapi.DwmEnableBlurBehindWindow
 
 // user32.dll function pointer typedefs
 typedef BOOL (WINAPI * SETPROCESSDPIAWARE_T)(void);
 typedef BOOL (WINAPI * CHANGEWINDOWMESSAGEFILTEREX_T)(HWND,UINT,DWORD,PCHANGEFILTERSTRUCT);
 #define _glfw_SetProcessDPIAware _glfw.win32.user32.SetProcessDPIAware
 #define _glfw_ChangeWindowMessageFilterEx _glfw.win32.user32.ChangeWindowMessageFilterEx
+#define _glfw_DwmEnableBlurBehindWindow _glfw.win32.dwmapi.DwmEnableBlurBehindWindow
 
 // dwmapi.dll function pointer typedefs
 typedef HRESULT (WINAPI * DWMISCOMPOSITIONENABLED_T)(BOOL*);
@@ -237,6 +248,7 @@ typedef struct _GLFWlibraryWin32
         HINSTANCE       instance;
         DWMISCOMPOSITIONENABLED_T DwmIsCompositionEnabled;
         DWMFLUSH_T      DwmFlush;
+        DWMENABLEBLURBEHINDWINDOW_T DwmEnableBlurBehindWindow;
     } dwmapi;
 
     // shcore.dll

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -732,6 +732,19 @@ static int createWindow(_GLFWwindow* window, const _GLFWwndconfig* wndconfig)
     window->win32.numer     = GLFW_DONT_CARE;
     window->win32.denom     = GLFW_DONT_CARE;
 
+    // Accelerated transparent windows
+    // It currently doesn't support decorated windows.
+    // If decorated is required we just return an opaque window.
+    // Since DwmEnableBlurBehindWindow is supported since Vista,
+    // previous versions will simply get an opaque window.
+    if (!window->decorated && _glfw_DwmEnableBlurBehindWindow && window->transparent) {
+        DWM_BLURBEHIND bb = { 0 };
+        bb.dwFlags = 3; // DWM_BB_ENABLE | DWM_BB_BLURREGION
+        bb.hRgnBlur = CreateRectRgn(0, 0, -1, -1); // an invalid hRgnBlur makes the the window transparent
+        bb.fEnable = TRUE;
+        _glfw_DwmEnableBlurBehindWindow(window->win32.handle, &bb);
+    }
+
     return GLFW_TRUE;
 }
 

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -732,19 +732,6 @@ static int createWindow(_GLFWwindow* window, const _GLFWwndconfig* wndconfig)
     window->win32.numer     = GLFW_DONT_CARE;
     window->win32.denom     = GLFW_DONT_CARE;
 
-    // Accelerated transparent windows
-    // It currently doesn't support decorated windows.
-    // If decorated is required we just return an opaque window.
-    // Since DwmEnableBlurBehindWindow is supported since Vista,
-    // previous versions will simply get an opaque window.
-    if (!window->decorated && _glfw_DwmEnableBlurBehindWindow && window->transparent) {
-        DWM_BLURBEHIND bb = { 0 };
-        bb.dwFlags = 3; // DWM_BB_ENABLE | DWM_BB_BLURREGION
-        bb.hRgnBlur = CreateRectRgn(0, 0, -1, -1); // an invalid hRgnBlur makes the the window transparent
-        bb.fEnable = TRUE;
-        _glfw_DwmEnableBlurBehindWindow(window->win32.handle, &bb);
-    }
-
     return GLFW_TRUE;
 }
 


### PR DESCRIPTION
This method uses desktop composition for efficient window transparency.

Since windows 8, composition is always on. If composition is disabled on vista or 7, transparency is simply ignored. Also, since it requires a pixel format supporting compositing, if we can't find it (e.g. windows xp) we ignore transparency similarly to how @datenwolf is doing it for glx's frame buffer configs.

This shouldn't be tested in a virtual machine.
On a side note, desktop composition can be enabled in the "Performance Options" dialog (win+r systempropertiesperformance). It is on by default but won't work unless the Aero score index has been refreshed after installing gpu drivers (Control Panel\All Control Panel Items\Performance Information and Tools).