### PR TITLE
Fixes  #740 - size callbacks incorrect on monitor orientation change

### DIFF
--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -637,8 +637,17 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
                 _glfwInputWindowIconify(window, GLFW_FALSE);
             }
 
-            _glfwInputFramebufferSize(window, LOWORD(lParam), HIWORD(lParam));
-            _glfwInputWindowSize(window, LOWORD(lParam), HIWORD(lParam));
+            // WM_SIZE params do not appear to catch display orientation
+            // changes correctly, so use Get functions to retreive.
+            // Both framebuffer and window sizes are the same, but get both
+            // here for potential future proofing.
+            int fbwidth, fbheight;
+            _glfwPlatformGetFramebufferSize(window, &fbwidth, &fbheight);
+            _glfwInputFramebufferSize(window, fbwidth, fbheight);
+
+            int wwidth, wheight;
+            _glfwPlatformGetWindowSize(window, &wwidth, &wheight);
+            _glfwInputWindowSize(window, wwidth, wheight);
             return 0;
         }
 


### PR DESCRIPTION
The WM_SIZE callback  of a fullscreen window appears incorrectly inverts the width & height when the monitor orientation is changed from landscape to portrait or visa versa.

This fix uses the glfwGet*Size functions to get the correct size via the client area. Although the functions for window and framebuffer size are currently the same on windows I've use both here in case future window scaling changes cause these to differ - but this may be over engineering things and a single get size call may be preferable.