### PR TITLE
Problem checking for pre-existing joystick in matchCallback in cocoa_jo…

### DIFF
--- a/src/cocoa_joystick.m
+++ b/src/cocoa_joystick.m
@@ -276,7 +276,7 @@ static void matchCallback(void* context,
 
     for (joy = GLFW_JOYSTICK_1;  joy <= GLFW_JOYSTICK_LAST;  joy++)
     {
-        if (!_glfw.ns_js.js[joy].present && _glfw.ns_js.js[joy].deviceRef == deviceRef)
+        if (_glfw.ns_js.js[joy].present && _glfw.ns_js.js[joy].deviceRef == deviceRef)
             return;
     }
 


### PR DESCRIPTION
…ystick.m

The matchCallback function has an initial loop to filter out redundant joystick additions based on matching deviceRef values.  However, the if statement incorrectly combines this test with the condition that the joystick is not present, which is obviously incorrect.