### PR TITLE
calloc error in cocoa_joystick.m

### DIFF
--- a/src/cocoa_joystick.m
+++ b/src/cocoa_joystick.m
@@ -322,7 +322,7 @@ static void matchCallback(void* context,
 
     js->axes = calloc(CFArrayGetCount(js->axisElements), sizeof(float));
     js->buttons = calloc(CFArrayGetCount(js->buttonElements) +
-                         CFArrayGetCount(js->hatElements) * 4, 1);
+                         CFArrayGetCount(js->hatElements) * 4, sizeof(unsigned char));
 
     _glfwInputJoystickChange(joy, GLFW_CONNECTED);
 }


### PR DESCRIPTION
The calloc call for js->buttons uses 1 instead of sizeof(unsigned char) for the element size.