### PR TITLE
Use VK_API_VERSION_1_0 to make the Vulkan example build again

### DIFF
--- a/tests/vulkan.c
+++ b/tests/vulkan.c
@@ -1778,7 +1778,7 @@ static void demo_init_vk(struct demo *demo) {
         .applicationVersion = 0,
         .pEngineName = APP_SHORT_NAME,
         .engineVersion = 0,
-        .apiVersion = VK_API_VERSION,
+        .apiVersion = VK_API_VERSION_1_0,
     };
     VkInstanceCreateInfo inst_info = {
         .sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,


### PR DESCRIPTION
The previous VK_API_VERSION define has been removed from recent headers.