### PR TITLE
Correct program name printed by tearing test

### DIFF
--- a/tests/tearing.c
+++ b/tests/tearing.c
@@ -43,7 +43,7 @@ static double frame_rate;
 
 static void usage(void)
 {
-    printf("Usage: iconify [-h] [-f]\n");
+    printf("Usage: tearing [-h] [-f]\n");
     printf("Options:\n");
     printf("  -f create full screen window\n");
     printf("  -h show this help\n");


### PR DESCRIPTION
The tearing test incorrectly calls itself "iconify" when printing usage information; probably just a copy-paste error.