### PR TITLE
Add explanation of parameters to gamma test

### DIFF
--- a/tests/gamma.c
+++ b/tests/gamma.c
@@ -43,6 +43,9 @@ static GLfloat gamma_value = 1.0f;
 static void usage(void)
 {
     printf("Usage: gamma [-h] [-f]\n");
+    printf("Options:\n");
+    printf("  -f create full screen window\n");
+    printf("  -h show this help\n");
 }
 
 static void set_gamma(GLFWwindow* window, float value)


### PR DESCRIPTION
Unlike similar test programs (e.g. tearing.c), the gamma test does not explain the meanings of the optional parameters `h` and `f`. This patch adds these explanations to the usage text.