### PR TITLE
Fix example build errors on VS 2010

### DIFF
--- a/deps/linmath.h
+++ b/deps/linmath.h
@@ -192,19 +192,21 @@ static inline void mat4x4_rotate(mat4x4 R, mat4x4 M, float x, float y, float z, 
 	vec3 u = {x, y, z};
 
 	if(vec3_len(u) > 1e-4) {
-		vec3_norm(u, u);
 		mat4x4 T;
-		mat4x4_from_vec3_mul_outer(T, u, u);
-
+		mat4x4 C;
 		mat4x4 S = {
 			{    0,  u[2], -u[1], 0},
 			{-u[2],     0,  u[0], 0},
 			{ u[1], -u[0],     0, 0},
 			{    0,     0,     0, 0}
 		};
+
+		vec3_norm(u, u);
+		mat4x4_from_vec3_mul_outer(T, u, u);
+
+
 		mat4x4_scale(S, S, s);
 
-		mat4x4 C;
 		mat4x4_identity(C);
 		mat4x4_sub(C, C, T);
 
@@ -259,6 +261,9 @@ static inline void mat4x4_invert(mat4x4 T, mat4x4 M)
 {
 	float s[6];
 	float c[6];
+	/* Assumes it is invertible */
+	float idet = 1.0f/( s[0]*c[5]-s[1]*c[4]+s[2]*c[3]+s[3]*c[2]-s[4]*c[1]+s[5]*c[0] );
+
 	s[0] = M[0][0]*M[1][1] - M[1][0]*M[0][1];
 	s[1] = M[0][0]*M[1][2] - M[1][0]*M[0][2];
 	s[2] = M[0][0]*M[1][3] - M[1][0]*M[0][3];
@@ -272,10 +277,7 @@ static inline void mat4x4_invert(mat4x4 T, mat4x4 M)
 	c[3] = M[2][1]*M[3][2] - M[3][1]*M[2][2];
 	c[4] = M[2][1]*M[3][3] - M[3][1]*M[2][3];
 	c[5] = M[2][2]*M[3][3] - M[3][2]*M[2][3];
-	
-	/* Assumes it is invertible */
-	float idet = 1.0f/( s[0]*c[5]-s[1]*c[4]+s[2]*c[3]+s[3]*c[2]-s[4]*c[1]+s[5]*c[0] );
-	
+		
 	T[0][0] = ( M[1][1] * c[5] - M[1][2] * c[4] + M[1][3] * c[3]) * idet;
 	T[0][1] = (-M[0][1] * c[5] + M[0][2] * c[4] - M[0][3] * c[3]) * idet;
 	T[0][2] = ( M[3][1] * s[5] - M[3][2] * s[4] + M[3][3] * s[3]) * idet;
@@ -298,9 +300,9 @@ static inline void mat4x4_invert(mat4x4 T, mat4x4 M)
 }
 static inline void mat4x4_orthonormalize(mat4x4 R, mat4x4 M)
 {
-	mat4x4_dup(R, M);
 	float s = 1.;
 	vec3 h;
+	mat4x4_dup(R, M);
 
 	vec3_norm(R[2], R[2]);
 	
@@ -387,14 +389,14 @@ static inline void mat4x4_look_at(mat4x4 m, vec3 eye, vec3 center, vec3 up)
 	/* TODO: The negation of of can be spared by swapping the order of
 	 *       operands in the following cross products in the right way. */
 	vec3 f;
+	vec3 s;
+	vec3 t;
 	vec3_sub(f, center, eye);	
 	vec3_norm(f, f);	
 	
-	vec3 s;
 	vec3_mul_cross(s, f, up);
 	vec3_norm(s, s);
 
-	vec3 t;
 	vec3_mul_cross(t, s, f);
 
 	m[0][0] =  s[0];
@@ -471,8 +473,8 @@ static inline void quat_conj(quat r, quat q)
 }
 static inline void quat_rotate(quat r, float angle, vec3 axis) {
 	vec3 v;
-	vec3_scale(v, axis, sinf(angle / 2));
 	int i;
+	vec3_scale(v, axis, sinf(angle / 2));
 	for(i=0; i<3; ++i)
 		r[i] = v[i];
 	r[3] = cosf(angle / 2);


### PR DESCRIPTION
According to C89, all block-local variables need to be declared at the beginning of the block. MSVC2013 relaxes this restriction.