### PR TITLE
Opaque vs transparent buffers

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -252,7 +252,7 @@ void glfwDefaultWindowHints(void)
     _glfw.hints.framebuffer.redBits      = 8;
     _glfw.hints.framebuffer.greenBits    = 8;
     _glfw.hints.framebuffer.blueBits     = 8;
-    _glfw.hints.framebuffer.alphaBits    = 8;
+    _glfw.hints.framebuffer.alphaBits    = 0;
     _glfw.hints.framebuffer.depthBits    = 24;
     _glfw.hints.framebuffer.stencilBits  = 8;
     _glfw.hints.framebuffer.doublebuffer = GLFW_TRUE;

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -178,6 +178,12 @@ static const struct wl_surface_listener surfaceListener = {
 static void setOpaqueRegion(_GLFWwindow* window)
 {
     struct wl_region* region;
+    int alphaBits;
+
+    eglGetConfigAttrib(_glfw.egl.display, window->context.egl.config,
+                       EGL_ALPHA_SIZE, &alphaBits);
+    if (alphaBits > 0)
+        return;
 
     region = wl_compositor_create_region(_glfw.wl.compositor);
     if (!region)


### PR DESCRIPTION
Hi,

I'm not sure this is the right approach, since it changes the default value for all platforms. Anyhow, if I'm not misunderstanding, GLFW at the current state (not counting the wip branch which adds support for it) doesn't support transparent windows, but still asks for transparent window framebuffers by default. The first commit changes the default behaviour to simply ask for a non-transparent buffer. The reason for doing this is that if we default to a transparent buffer configs, we'll get transparent buffers meaning.. well.. they'll be transparent, which seems to go against what is supported.

The other solution I had to this was simply to override the framebuffer configuration when creating the Wayland window EGL context by copying the fbconfig and overriding the alphaBits field, but it seemed off as well.

Both these solutions feels a bit awkward really, since we still have the GLFW_ALPHA_BITS hint. The patch in this PR allows the application to override it and get a transparent window, while the mentioned alternative approach would always override that hint. What is the point of that hint if not to cause the window to be transparent?

The second patch simply checks what type of framebuffer configuration we got, and does the right thing accordingly.
