### PR TITLE
Disable default Alt key processing

### DIFF
--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -566,10 +566,10 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
             else
                 _glfwInputKey(window, key, scancode, action, mods);
 
-            if(wParam == VK_MENU) {
+            if(wParam == VK_MENU || wParam == VK_F10) {
                 return 0;
             }
-            break; // #fix: disable system default ALT process, solve dead block problem when glfw-window is a cross-thread child window.
+            break; // #fix: disable system default ALT/F10 process, solve dead block problem when glfw-window is a cross-thread child window.
         }
 
         case WM_LBUTTONDOWN:

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -566,7 +566,10 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
             else
                 _glfwInputKey(window, key, scancode, action, mods);
 
-            break;
+            if(wParam == VK_MENU) {
+                return 0;
+            }
+            break; // #fix: disable system default ALT process, solve dead block problem when glfw-window is a cross-thread child window.
         }
 
         case WM_LBUTTONDOWN:


### PR DESCRIPTION
solve dead block problem when glfw-window is a cross-thread child window.
