### PR TITLE
Fixed XSetInputFocus before VisibilityNotify

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ does not find Doxygen, the documentation will not be generated.
 
 ## Changelog
 
+ - [X11] Bugfix: Didn't wait until window was visible before setting focus (#789)
  - Bugfix: Single compilation unit builds failed due to naming conflicts (#783)
  - Bugfix: The range checks for `glfwSetCursorPos` used the wrong minimum (#773)
  - [Win32] Bugfix: `glfwSetClipboardString` created an unneccessary intermediate

--- a/src/x11_platform.h
+++ b/src/x11_platform.h
@@ -112,6 +112,7 @@ typedef struct _GLFWwindowX11
     XIC             ic;
 
     GLFWbool        overrideRedirect;
+    GLFWbool        visuallyMapped;
 
     // Cached position and size used to filter out duplicate events
     int             width, height;


### PR DESCRIPTION
Should resolve glfw/glfw#789. Calling glfwCreateWindow might fail on non-reparenting window managers (like dwm or xmonad), since they don't set their visibility flag right after being mapped with XMapWindow. Attempting to print map_state (retrieved with XGetWindowAttributes) results in either IsUnmapped or IsUnviewable on the tested window manager (which is dwm 6.1-3) right before calling XSetInputFocus. Doing this gives BadMatch errors when actually calling XSetInputFocus, which should be expected given that the documentation in XLib says that this happens if a window isn't viewable when called. References to these follow below to make it easier to double check and test the changes I have made for this.

XMapWindow: https://tronche.com/gui/x/xlib/window/XMapWindow.html
XSetInputFocus: https://tronche.com/gui/x/xlib/input/XSetInputFocus.html
VisibilityNotify: https://tronche.com/gui/x/xlib/events/window-state-change/visibility.html
XGetWindowAttributes: https://tronche.com/gui/x/xlib/window-information/XGetWindowAttributes.html

I haven't programmed with Xlib before, so take everything I have said with a huge grain of salt. It does seem to fix the problem for me, with my window manager. However, I don't know if this patch works or breaks for everyone else involved. If you have any spare time, could anyone check if this patch seems somewhat reasonable (doesn't break anything and conforms with the planned glfw architecture, also not messing up too much of the code)? If it  doesn't indeed seem to break for anyone else, and fixes these issues for other similar WMs, could you consider merging these changes into mainline glfw for others?

Any feedback/improvements are welcome.
Thanks for your help and time!