### PR TITLE
Corrected glfwSetWindowSizeLimits to correctly limit size

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ skills.
  - Santi Zupancic
  - Jonas Ådahl
  - Lasse Öörni
+ - Warren Hu
  - All the unmentioned and anonymous contributors in the GLFW community, for bug
    reports, patches, feedback, testing and encouragement
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ does not find Doxygen, the documentation will not be generated.
                    when the process was provided a `STARTUPINFO` (#780)
  - [GLX] Bugfix: Dynamically loaded entry points were not verified
  - [EGL] Bugfix: Dynamically loaded entry points were not verified
+ - [X11] Bugfix: Fixed window size limits being ignored if window minimums or
+                 maximums were set to GLFW_DONT_CARE
 
 
 ## Contact

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -229,6 +229,22 @@ static void updateNormalHints(_GLFWwindow* window, int width, int height)
                 hints->max_height = window->maxheight;
             }
 
+            if (window->minwidth != GLFW_DONT_CARE &&
+                window->minheight != GLFW_DONT_CARE)
+            {
+                hints->flags |= (PMinSize);
+                hints->min_width = window->minwidth;
+                hints->min_height = window->minheight;
+            }
+
+            if (window->maxwidth != GLFW_DONT_CARE &&
+                window->maxheight != GLFW_DONT_CARE)
+            {
+                hints->flags |= (PMaxSize);
+                hints->max_width = window->maxwidth;
+                hints->max_height = window->maxheight;
+            }
+
             if (window->numer != GLFW_DONT_CARE &&
                 window->denom != GLFW_DONT_CARE)
             {


### PR DESCRIPTION
Minimal example showing issue on Ubuntu 16.04 running X11:
```c++
#include <GLFW/glfw3.h>

int main() {
    glfwInit();

    GLFWwindow* window = glfwCreateWindow(800, 600, "Resize me", nullptr, nullptr);

    glfwSetWindowSizeLimits(window, 800, 600, GLFW_DONT_CARE, GLFW_DONT_CARE);

    while(!glfwWindowShouldClose(window)){
        glfwPollEvents();
    }

    glfwTerminate();
    return 0;
}
```

You can resize the window below 800 by 600 even though the limit was set. Also didn't work if the order was reversed i.e. `glfwSetWindowSize(window, GLFW_DONT_CARE, GLFW_DONT_CARE, 800, 600)`