### PR TITLE
Added preproccessor directive to build Vulkan DLL

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -94,6 +94,7 @@ typedef const GLubyte* (APIENTRY * PFNGLGETSTRINGPROC)(GLenum);
 typedef void (APIENTRY * PFNGLGETINTEGERVPROC)(GLenum,GLint*);
 typedef const GLubyte* (APIENTRY * PFNGLGETSTRINGIPROC)(GLenum,GLuint);
 
+#if !defined(VULKAN_H_)
 #define VK_NULL_HANDLE 0
 
 typedef void* VkInstance;
@@ -154,6 +155,8 @@ typedef VkResult (APIENTRY * PFN_vkEnumerateInstanceExtensionProperties)(const c
 
 #define vkEnumerateInstanceExtensionProperties _glfw.vk.EnumerateInstanceExtensionProperties
 #define vkGetInstanceProcAddr _glfw.vk.GetInstanceProcAddr
+
+#endif //VULKAN_H_
 
 #if defined(_GLFW_COCOA)
  #include "cocoa_platform.h"


### PR DESCRIPTION
If `vulkan.h` was included or if `GLFW_INCLUDE_VULKAN` was defined in `glfw_config.h`, then attempting to build GLFW as a DLL would cause compilation errors, since `internal.h` redefines a few vulkan types.