### PR TITLE
Fixes Issue 817 on OSX: Missing call to removeObserver

### DIFF
--- a/src/cocoa_init.m
+++ b/src/cocoa_init.m
@@ -359,6 +359,8 @@ void _glfwPlatformTerminate(void)
             removeObserver:_glfw.ns.listener
                       name:(__bridge NSString*)kTISNotifySelectedKeyboardInputSourceChanged
                     object:nil];
+        [[NSDistributedNotificationCenter defaultCenter]
+            removeObserver:_glfw.ns.listener];
         [_glfw.ns.listener release];
         _glfw.ns.listener = nil;
     }


### PR DESCRIPTION
Fixes #817.

As noted in the documentation for [nsdistributednotificationcenter](https://developer.apple.com/reference/foundation/nsdistributednotificationcenter/1416236-removeobserver?language=objc),
(under the Discussion heading) before an observer is deallocated
a call should be made to `removeObserver:` in order to ensure
that the listener is unbound from all observation pools
correctly. I can confirm that this fixes #817 for me.