### PR TITLE
added `glfwGetKeyScancode` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ information on what to include when reporting a bug.
  - Added on-demand loading of Vulkan and context creation API libraries
  - Added `_GLFW_VULKAN_STATIC` build macro to make the library use the Vulkan
    loader linked statically into the application (#820)
+ - Added `glfwGetKeyScancode` function that allows retrieving platform depen-
+   dent scancodes for keys
  - Bugfix: Single compilation unit builds failed due to naming conflicts (#783)
  - Bugfix: The range checks for `glfwSetCursorPos` used the wrong minimum (#773)
  - Bugfix: Defining `GLFW_INCLUDE_VULKAN` when compiling the library did not
@@ -256,6 +258,7 @@ skills.
  - Santi Zupancic
  - Jonas Ådahl
  - Lasse Öörni
+ - Michael Stocker
  - All the unmentioned and anonymous contributors in the GLFW community, for bug
    reports, patches, feedback, testing and encouragement
 

--- a/docs/input.dox
+++ b/docs/input.dox
@@ -222,6 +222,20 @@ ignored.  This matches the behavior of the key callback, meaning the callback
 arguments can always be passed unmodified to this function.
 
 
+@subsection input_key_scancode Key scancodes
+
+If you need the platform dependent scancode for any given key, you can query
+it with @ref glfwGetKeyScancode.
+
+@code
+const short int scancode = glfwGetKeyScancode(GLFW_KEY_X);
+set_key_mapping(scancode, swap_weapons);
+@encode
+
+If the key is `GLFW_KEY_UNKNOWN` or does not exist on the keyboard this
+method will return `-1`.
+
+
 @section input_mouse Mouse input
 
 Mouse input comes in many forms, including cursor motion, button presses and

--- a/docs/news.dox
+++ b/docs/news.dox
@@ -2,6 +2,15 @@
 
 @page news New features
 
+@section new_33 New features in 3.3
+
+
+@subsection new_33_keyscancode Platform dependent scancodes
+
+GLFW now supports querying the platform dependent scancode of any key with
+@ref glfwGetKeyScancode.
+
+
 @section news_32 New features in 3.2
 
 

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -2999,6 +2999,30 @@ GLFWAPI void glfwSetInputMode(GLFWwindow* window, int mode, int value);
  */
 GLFWAPI const char* glfwGetKeyName(int key, int scancode);
 
+/*! @brief Returns the platform dependent scancode of the specified key.
+ *
+ *  This function returns the platform dependent scancode of the specified key.
+ *  This is intended for platform specific default keybindings.
+ *
+ *  If the key is `GLFW_KEY_UNKNOWN` or does not exist on the keyboard this
+ *  method will return `-1`.
+ *
+ *  @param[in] key The key to query.
+ *  @return The platform dependent scancode for the key, or `-1`.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @thread_safety This function may be called from any thread.
+ *
+ *  @sa @ref input_key_scancode
+ *
+ *  @since Added in version 3.3.
+ *
+ *  @ingroup input
+ */
+GLFWAPI const short int glfwGetKeyScancode(int key);
+
 /*! @brief Returns the last reported state of a keyboard key for the specified
  *  window.
  *

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -1511,6 +1511,16 @@ const char* _glfwPlatformGetKeyName(int key, int scancode)
     return _glfw.ns.keyName;
 }
 
+const short int _glfwPlatformGetKeyScancode(int key)
+{
+    if(key <= -1 || key >= (sizeof(_glfw.ns.nativeKeys) / sizeof(_glfw.ns.nativeKeys[0])))
+    {
+        return -1;
+    }
+
+    return _glfw.ns.nativeKeys[key];
+}
+
 int _glfwPlatformCreateCursor(_GLFWcursor* cursor,
                               const GLFWimage* image,
                               int xhot, int yhot)

--- a/src/input.c
+++ b/src/input.c
@@ -256,6 +256,12 @@ GLFWAPI const char* glfwGetKeyName(int key, int scancode)
     return _glfwPlatformGetKeyName(key, scancode);
 }
 
+GLFWAPI const short int glfwGetKeyScancode(int key)
+{
+    _GLFW_REQUIRE_INIT_OR_RETURN(-1);
+    return _glfwPlatformGetKeyScancode(key);
+}
+
 GLFWAPI int glfwGetKey(GLFWwindow* handle, int key)
 {
     _GLFWwindow* window = (_GLFWwindow*) handle;

--- a/src/internal.h
+++ b/src/internal.h
@@ -543,6 +543,11 @@ void _glfwPlatformSetCursorMode(_GLFWwindow* window, int mode);
  */
 const char* _glfwPlatformGetKeyName(int key, int scancode);
 
+/*! @copydoc glfwGetKeyScancode
+ *  @ingroup platform
+ */
+const int _glfwPlatformGetKeyScancode(int key);
+
 /*! @copydoc glfwGetMonitors
  *  @ingroup platform
  */

--- a/src/internal.h
+++ b/src/internal.h
@@ -546,7 +546,7 @@ const char* _glfwPlatformGetKeyName(int key, int scancode);
 /*! @copydoc glfwGetKeyScancode
  *  @ingroup platform
  */
-const int _glfwPlatformGetKeyScancode(int key);
+const short int _glfwPlatformGetKeyScancode(int key);
 
 /*! @copydoc glfwGetMonitors
  *  @ingroup platform

--- a/src/mir_window.c
+++ b/src/mir_window.c
@@ -744,6 +744,13 @@ const char* _glfwPlatformGetKeyName(int key, int scancode)
     return NULL;
 }
 
+const int _glfwPlatformGetKeyScancode(int key)
+{
+    _glfwInputError(GLFW_PLATFORM_ERROR,
+                    "Mir: Unsupported function %s", __PRETTY_FUNCTION__);
+    return NULL;
+}
+
 void _glfwPlatformSetClipboardString(_GLFWwindow* window, const char* string)
 {
     _glfwInputError(GLFW_PLATFORM_ERROR,

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -1511,6 +1511,16 @@ const char* _glfwPlatformGetKeyName(int key, int scancode)
     return _glfw.win32.keyName;
 }
 
+const short int _glfwPlatformGetKeyScancode(int key)
+{
+    if(key <= -1 || key >= (sizeof(_glfw.win32.nativeKeys) / sizeof(_glfw.win32.nativeKeys[0])))
+    {
+        return -1;
+    }
+
+    return _glfw.win32.nativeKeys[key];
+}
+
 int _glfwPlatformCreateCursor(_GLFWcursor* cursor,
                               const GLFWimage* image,
                               int xhot, int yhot)

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -686,6 +686,12 @@ const char* _glfwPlatformGetKeyName(int key, int scancode)
     return NULL;
 }
 
+const int _glfwPlatformGetKeyScancode(int key)
+{
+    // TODO
+	return -1;
+}
+
 int _glfwPlatformCreateCursor(_GLFWcursor* cursor,
                               const GLFWimage* image,
                               int xhot, int yhot)

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -2173,6 +2173,16 @@ const char* _glfwPlatformGetKeyName(int key, int scancode)
     return _glfw.x11.keyName;
 }
 
+const short int _glfwPlatformGetKeyScancode(int key)
+{
+    if(key <= -1 || key >= (sizeof(_glfw.x11.nativeKeys) / sizeof(_glfw.x11.nativeKeys[0])))
+    {
+        return -1;
+    }
+
+    return _glfw.x11.nativeKeys[key];
+}
+
 int _glfwPlatformCreateCursor(_GLFWcursor* cursor,
                               const GLFWimage* image,
                               int xhot, int yhot)


### PR DESCRIPTION
- allows retrieval of platform scancode from GLFW_KEY
- impls for: win32, cocoa, x11
- stubs for: mir, wayland

----
I followed the contribution guide to my understanding.

I have no experience with doxygen and have not before contributed to a big project, thus would be happy for review and pointing out of mistakes.

I did and do not have the means to compile the GLFW code locally at this time thus would be glad for someone else to help me out, IF the CI builds are not enough.