### PR TITLE
Treat occluded windows as hidden

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -1339,7 +1339,8 @@ int _glfwPlatformWindowIconified(_GLFWwindow* window)
 
 int _glfwPlatformWindowVisible(_GLFWwindow* window)
 {
-    return [window->ns.object isVisible];
+  return [window->ns.object isVisible] &&
+         ([window->ns.object occlusionState] & NSWindowOcclusionStateVisible);
 }
 
 int _glfwPlatformWindowMaximized(_GLFWwindow* window)


### PR DESCRIPTION
If a window is not hidden but occluded, e.g. by another window or the
window is on another screen/desktop that is currently not shown,
_glfwPlatformWindowVisible() returns 1 although the window is physically
not visible. This commit fixes this issue by treating occluded windows
as hidden, i.e. non visible.
Usage example:
When the render loop is limited by v-sync, glfwSwapBuffers() does not
block on OS X when AppNap is enabled and the window is occluded.
Therefore the application starts to burn CPU cycles althoug nothing is
displayed. With the fix in this commit the application could check if
the window is visible using glfwGetWindowAttrib(window, GLFW_VISIBLE)
and if the window is hidden (or occluded) it could pause the render
loop.
This is a workaround for issue #680
