### PR TITLE
examples/particles: Fix periodic stutter: ensure that tv_nsec<1e9

### DIFF
--- a/examples/particles.c
+++ b/examples/particles.c
@@ -457,7 +457,12 @@ static void draw_particles(GLFWwindow* window, double t, float dt)
     {
         struct timespec ts;
         clock_gettime(CLOCK_REALTIME, &ts);
-        ts.tv_nsec += 100000000;
+        ts.tv_nsec += 100 * 1000 * 1000;
+        if (ts.tv_nsec >= 1000 * 1000 * 1000)
+        {
+            ts.tv_sec++;
+            ts.tv_nsec -= 1000 * 1000 * 1000;
+        }
         cnd_timedwait(&thread_sync.p_done, &thread_sync.particles_lock, &ts);
     }
 
@@ -908,7 +913,12 @@ static int physics_thread_main(void* arg)
         {
             struct timespec ts;
             clock_gettime(CLOCK_REALTIME, &ts);
-            ts.tv_nsec += 100000000;
+            ts.tv_nsec += 100 * 1000 * 1000;
+            if (ts.tv_nsec >= 1000 * 1000 * 1000)
+            {
+                ts.tv_sec++;
+                ts.tv_nsec -= 1000 * 1000 * 1000;
+            }
             cnd_timedwait(&thread_sync.d_done, &thread_sync.particles_lock, &ts);
         }
 


### PR DESCRIPTION
Each time when "ts.tv_nsec" became greater or equal than 1e9, the cnd_timedwait() function returned immediately, causing the thread to become a busy waiting loop (slowing the other thread, on which the current was waiting, down), until "ts.tv_nsec" became smaller than 1e9.
This caused noticeable stutter one 10th of a second, since the timeout was 100ms.