### PR TITLE
Add GLFW_CENTER_CURSOR window hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ information on what to include when reporting a bug.
                   function on macOS 10.12+
 - [Cocoa] Bugfix: Running in AppSandbox would emit warnings (#816,#882)
 - [EGL] Added support for `EGL_KHR_get_all_proc_addresses` (#871)
+- Added 'GLFW_CENTER_CURSOR' window hint for controlling cursor centering
 
 
 ## Contact
@@ -272,6 +273,7 @@ skills.
  - Santi Zupancic
  - Jonas Ådahl
  - Lasse Öörni
+ - Liam Middlebrook
  - All the unmentioned and anonymous contributors in the GLFW community, for bug
    reports, patches, feedback, testing and encouragement
 

--- a/docs/window.dox
+++ b/docs/window.dox
@@ -411,6 +411,7 @@ GLFW_FOCUSED                  | `GLFW_TRUE`                 | `GLFW_TRUE` or `GL
 GLFW_AUTO_ICONIFY             | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`
 GLFW_FLOATING                 | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
 GLFW_MAXIMIZED                | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
+GLFW_CENTER_CURSOR            | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`
 GLFW_RED_BITS                 | 8                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`
 GLFW_GREEN_BITS               | 8                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`
 GLFW_BLUE_BITS                | 8                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`
@@ -1021,6 +1022,10 @@ __GLFW_MAXIMIZED__ indicates whether the specified window is maximized.  See
 @anchor GLFW_VISIBLE_attrib
 __GLFW_VISIBLE__ indicates whether the specified window is visible.  See @ref
 window_hide for details.
+
+`GLFW_CENTER_CURSOR` indicates whether the cursor should be moved to the center
+of the full screen window during creation. This is ignored for windowed mode
+windows.
 
 @anchor GLFW_RESIZABLE_attrib
 __GLFW_RESIZABLE__ indicates whether the specified window is resizable _by the

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -681,6 +681,7 @@ extern "C" {
  *  [window attribute](@ref GLFW_MAXIMIZED_attrib).
  */
 #define GLFW_MAXIMIZED              0x00020008
+#define GLFW_CENTER_CURSOR          0x00020009
 
 /*! @brief Framebuffer bit depth hint.
  *

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -1091,7 +1091,8 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
         if (!acquireMonitor(window))
             return GLFW_FALSE;
 
-        centerCursor(window);
+    if (wndconfig->centerCursor)
+            centerCursor(window);
     }
 
     return GLFW_TRUE;

--- a/src/internal.h
+++ b/src/internal.h
@@ -264,6 +264,7 @@ struct _GLFWwndconfig
     GLFWbool      autoIconify;
     GLFWbool      floating;
     GLFWbool      maximized;
+    GLFWbool      centerCursor;
 };
 
 /*! @brief Context configuration.

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -1034,7 +1034,10 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
         if (!acquireMonitor(window))
             return GLFW_FALSE;
 
-        centerCursor(window);
+        if (wndconfig->centerCursor)
+        {
+            centerCursor(window);
+        }
     }
 
     return GLFW_TRUE;
@@ -1506,7 +1509,6 @@ void _glfwPlatformSetCursorMode(_GLFWwindow* window, int mode)
         _glfwPlatformGetCursorPos(window,
                                   &_glfw.win32.restoreCursorPosX,
                                   &_glfw.win32.restoreCursorPosY);
-        centerCursor(window);
         updateClipRect(window);
     }
     else if (_glfw.win32.disabledCursorWindow == window)

--- a/src/window.c
+++ b/src/window.c
@@ -340,6 +340,9 @@ GLFWAPI void glfwWindowHint(int hint, int value)
         case GLFW_VISIBLE:
             _glfw.hints.window.visible = value ? GLFW_TRUE : GLFW_FALSE;
             break;
+	case GLFW_CENTER_CURSOR:
+	    _glfw.hints.window.centerCursor = value ? GLFW_TRUE : GLFW_FALSE;
+	    break;
         case GLFW_CLIENT_API:
             _glfw.hints.context.client = value;
             break;

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -1594,7 +1594,10 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
         if (!acquireMonitor(window))
             return GLFW_FALSE;
 
-        centerCursor(window);
+        if(wndconfig->centerCursor)
+        {
+            centerCursor(window);
+        }
     }
 
     XFlush(_glfw.x11.display);
@@ -2234,7 +2237,6 @@ void _glfwPlatformSetCursorMode(_GLFWwindow* window, int mode)
         _glfwPlatformGetCursorPos(window,
                                   &_glfw.x11.restoreCursorPosX,
                                   &_glfw.x11.restoreCursorPosY);
-        centerCursor(window);
         XGrabPointer(_glfw.x11.display, window->x11.handle, True,
                      ButtonPressMask | ButtonReleaseMask | PointerMotionMask,
                      GrabModeAsync, GrabModeAsync,


### PR DESCRIPTION
Implement a hint for positioning the cursor in the center of the window.

Fixes #749 
