### PR TITLE
Fixed crash during maximize/restore

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -1155,7 +1155,7 @@ void _glfwPlatformSetWindowSizeLimits(_GLFWwindow* window,
 void _glfwPlatformSetWindowAspectRatio(_GLFWwindow* window, int numer, int denom)
 {
     if (numer == GLFW_DONT_CARE || denom == GLFW_DONT_CARE)
-        [window->ns.object setContentAspectRatio:NSMakeSize(0, 0)];
+        [window->ns.object setResizeIncrements:NSMakeSize(1.0, 1.0)];
     else
         [window->ns.object setContentAspectRatio:NSMakeSize(numer, denom)];
 }


### PR DESCRIPTION
OS and version: MacOS X El Capitan (10.11.5)
Release or commit: 2e6a110181b1aa08e0a8a43cdb6c88c4a642ab3a
Error messages: 
Call stack:

```
2016-09-01 00:30:48.873 main[80456:9371783] *** Assertion failure in -[_NSCGSWindow setFrame:], /Library/Caches/com.apple.xbs/Sources/AppKit/AppKit-1404.47/CGS.subproj/NSCGSWindow.m:621
2016-09-01 00:30:48.876 main[80456:9371783] An uncaught exception was raised
2016-09-01 00:30:48.876 main[80456:9371783] Invalid parameter not satisfying: CGRectContainsRect(CGRectMake((CGFloat)INT_MIN, (CGFloat)INT_MIN, (CGFloat)INT_MAX - (CGFloat)INT_MIN, (CGFloat)INT_MAX - (CGFloat)INT_MIN), frame)
2016-09-01 00:30:48.876 main[80456:9371783] (
	0   CoreFoundation                      0x00007fff9ea314f2 __exceptionPreprocess + 178
	1   libobjc.A.dylib                     0x00007fff9ae37f7e objc_exception_throw + 48
	2   CoreFoundation                      0x00007fff9ea361ca +[NSException raise:format:arguments:] + 106
	3   Foundation                          0x00007fff9267d856 -[NSAssertionHandler handleFailureInMethod:object:file:lineNumber:description:] + 198
	4   AppKit                              0x00007fff89674204 -[_NSCGSWindow setFrame:] + 250
	5   AppKit                              0x00007fff89767a23 _NSShapeRoundedWindowWithWeighting + 216
	6   AppKit                              0x00007fff8961b371 -[NSThemeFrame shapeWindow] + 265
	7   AppKit                              0x00007fff8961a291 -[NSThemeFrame setFrameSize:] + 440
	8   AppKit                              0x00007fff89600906 -[NSWindow _setFrame:updateBorderViewSize:] + 1088
	9   AppKit                              0x00007fff89619379 -[NSWindow _oldPlaceWindow:] + 1075
	10  AppKit                              0x00007fff8961874e -[NSWindow _setFrameCommon:display:stashSize:] + 2743
	11  AppKit                              0x00007fff89617c88 -[NSWindow _setFrame:display:allowImplicitAnimation:stashSize:] + 222
	12  AppKit                              0x00007fff89617ba3 -[NSWindow setFrame:display:] + 67
	13  AppKit                              0x00007fff897be43f __28-[NSMoveHelper _doAnimation]_block_invoke + 1084
	14  AppKit                              0x00007fff8972d2ea -[NSScreenDisplayLink _fire] + 439
	15  CoreFoundation                      0x00007fff9e9aeb94 __CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK_FUNCTION__ + 20
	16  CoreFoundation                      0x00007fff9e9ae823 __CFRunLoopDoTimer + 1075
	17  CoreFoundation                      0x00007fff9e9ae37a __CFRunLoopDoTimers + 298
	18  CoreFoundation                      0x00007fff9e9a5871 __CFRunLoopRun + 1841
	19  CoreFoundation                      0x00007fff9e9a4ed8 CFRunLoopRunSpecific + 296
	20  AppKit                              0x00007fff897bd6bc -[NSMoveHelper _doAnimation] + 1630
	21  AppKit                              0x00007fff897d6af9 -[NSMoveHelper _resizeWindow:toFrame:display:] + 419
	22  AppKit                              0x00007fff89738035 -[NSWindow setFrame:display:animate:] + 1472
	23  AppKit                              0x00007fff897d5bfc -[NSWindow zoom:] + 843
	24  main                                0x0000000004054170 runtime.asmcgocall + 112
)
2016-09-01 00:30:48.876 main[80456:9371783] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Invalid parameter not satisfying: CGRectContainsRect(CGRectMake((CGFloat)INT_MIN, (CGFloat)INT_MIN, (CGFloat)INT_MAX - (CGFloat)INT_MIN, (CGFloat)INT_MAX - (CGFloat)INT_MIN), frame)'
*** First throw call stack:
(
	0   CoreFoundation                      0x00007fff9ea314f2 __exceptionPreprocess + 178
	1   libobjc.A.dylib                     0x00007fff9ae37f7e objc_exception_throw + 48
	2   CoreFoundation                      0x00007fff9ea361ca +[NSException raise:format:arguments:] + 106
	3   Foundation                          0x00007fff9267d856 -[NSAssertionHandler handleFailureInMethod:object:file:lineNumber:description:] + 198
	4   AppKit                              0x00007fff89674204 -[_NSCGSWindow setFrame:] + 250
	5   AppKit                              0x00007fff89767a23 _NSShapeRoundedWindowWithWeighting + 216
	6   AppKit                              0x00007fff8961b371 -[NSThemeFrame shapeWindow] + 265
	7   AppKit                              0x00007fff8961a291 -[NSThemeFrame setFrameSize:] + 440
	8   AppKit                              0x00007fff89600906 -[NSWindow _setFrame:updateBorderViewSize:] + 1088
	9   AppKit                              0x00007fff89619379 -[NSWindow _oldPlaceWindow:] + 1075
	10  AppKit                              0x00007fff8961874e -[NSWindow _setFrameCommon:display:stashSize:] + 2743
	11  AppKit                              0x00007fff89617c88 -[NSWindow _setFrame:display:allowImplicitAnimation:stashSize:] + 222
	12  AppKit                              0x00007fff89617ba3 -[NSWindow setFrame:display:] + 67
	13  AppKit                              0x00007fff897be43f __28-[NSMoveHelper _doAnimation]_block_invoke + 1084
	14  AppKit                              0x00007fff8972d2ea -[NSScreenDisplayLink _fire] + 439
	15  CoreFoundation                      0x00007fff9e9aeb94 __CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK_FUNCTION__ + 20
	16  CoreFoundation                      0x00007fff9e9ae823 __CFRunLoopDoTimer + 1075
	17  CoreFoundation                      0x00007fff9e9ae37a __CFRunLoopDoTimers + 298
	18  CoreFoundation                      0x00007fff9e9a5871 __CFRunLoopRun + 1841
	19  CoreFoundation                      0x00007fff9e9a4ed8 CFRunLoopRunSpecific + 296
	20  AppKit                              0x00007fff897bd6bc -[NSMoveHelper _doAnimation] + 1630
	21  AppKit                              0x00007fff897d6af9 -[NSMoveHelper _resizeWindow:toFrame:display:] + 419
	22  AppKit                              0x00007fff89738035 -[NSWindow setFrame:display:animate:] + 1472
	23  AppKit                              0x00007fff897d5bfc -[NSWindow zoom:] + 843
	24  main                                0x0000000004054170 runtime.asmcgocall + 112
)
libc++abi.dylib: terminating with uncaught exception of type NSException
SIGABRT: abort
PC=0x7fff96595f06 m=0
```

A crash will happen on cocoa systems if you do the following code:

```c
glfwSetWindowAspectRatio(w, GLFW_DONT_CARE, GLFW_DONT_CARE);
glfwMaximizeWindow(w);
```

The same is true for `glfwRestoreWindow`.