### PR TITLE
Joystick event callbacks

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -1121,6 +1121,42 @@ typedef void (* GLFWmonitorfun)(GLFWmonitor*,int);
  */
 typedef void (* GLFWjoystickfun)(int,int);
 
+/*! @brief The function signature for joystick button callbacks.
+ *
+ *  This is the function signature for joystick button callback
+ *  functions.
+ *
+ *  @param[in] joy The joystick that had a button pressed or released.
+ *  @param[in] button The button that was pressed or released.
+ *  @param[in] action One of `GLFW_PRESS` or `GLFW_RELEASE`.
+ *
+ *  @sa @ref joystick_event
+ *  @sa glfwSetJoystickButtonCallback
+ *
+ *  @since Added in version 3.2.
+ *
+ *  @ingroup input
+ */
+typedef void (* GLFWjoystickbuttonfun)(int,int,int);
+
+/*! @brief The function signature for joystick axis callbacks.
+ *
+ *  This is the function signature for joystick axis callback
+ *  functions.
+ *
+ *  @param[in] joy The joystick that had an axis moved.
+ *  @param[in] axis The axis that was moved.
+ *  @param[in] value The axis value.
+ *
+ *  @sa @ref joystick_event
+ *  @sa glfwSetJoystickAxisCallback
+ *
+ *  @since Added in version 3.2.
+ *
+ *  @ingroup input
+ */
+typedef void (* GLFWjoystickaxisfun)(int,int,float);
+
 /*! @brief Video mode type.
  *
  *  This describes a single video mode.
@@ -3679,6 +3715,50 @@ GLFWAPI const char* glfwGetJoystickName(int joy);
  *  @ingroup input
  */
 GLFWAPI GLFWjoystickfun glfwSetJoystickCallback(GLFWjoystickfun cbfun);
+
+/*! @brief Sets the joystick button callback.
+ *
+ *  This function sets the joystick button callback, or removes the currently
+ *  set callback.  This is called when a joystick button is pressed or released.
+ *
+ *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
+ *  callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or the
+ *  library had not been [initialized](@ref intro_init).
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref joystick_event
+ *
+ *  @since Added in version 3.2.
+ *
+ *  @ingroup input
+ */
+GLFWAPI GLFWjoystickbuttonfun glfwSetJoystickButtonCallback(GLFWjoystickbuttonfun cbfun);
+
+/*! @brief Sets the joystick axis callback.
+ *
+ *  This function sets the joystick axis callback, or removes the currently
+ *  set callback.  This is called when a joystick axis is moved.
+ *
+ *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
+ *  callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or the
+ *  library had not been [initialized](@ref intro_init).
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref joystick_event
+ *
+ *  @since Added in version 3.2.
+ *
+ *  @ingroup input
+ */
+GLFWAPI GLFWjoystickaxisfun glfwSetJoystickAxisCallback(GLFWjoystickaxisfun cbfun);
 
 /*! @brief Sets the clipboard to the specified string.
  *

--- a/src/input.c
+++ b/src/input.c
@@ -130,6 +130,18 @@ void _glfwInputJoystickChange(int joy, int event)
         _glfw.callbacks.joystick(joy, event);
 }
 
+void _glfwInputJoystickButtonState(int joy, int button, int action)
+{
+    if (_glfw.callbacks.joystick_button)
+        _glfw.callbacks.joystick_button(joy, button, action);
+}
+
+void _glfwInputJoystickAxisMoved(int joy, int axis, float value)
+{
+    if (_glfw.callbacks.joystick_axis)
+        _glfw.callbacks.joystick_axis(joy, axis, value);
+}
+
 
 //////////////////////////////////////////////////////////////////////////
 //////                       GLFW internal API                      //////
@@ -615,6 +627,20 @@ GLFWAPI GLFWjoystickfun glfwSetJoystickCallback(GLFWjoystickfun cbfun)
 {
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
     _GLFW_SWAP_POINTERS(_glfw.callbacks.joystick, cbfun);
+    return cbfun;
+}
+
+GLFWAPI GLFWjoystickbuttonfun glfwSetJoystickButtonCallback(GLFWjoystickbuttonfun cbfun)
+{
+    _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
+    _GLFW_SWAP_POINTERS(_glfw.callbacks.joystick_button, cbfun);
+    return cbfun;
+}
+
+GLFWAPI GLFWjoystickaxisfun glfwSetJoystickAxisCallback(GLFWjoystickaxisfun cbfun)
+{
+    _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
+    _GLFW_SWAP_POINTERS(_glfw.callbacks.joystick_axis, cbfun);
     return cbfun;
 }
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -463,8 +463,10 @@ struct _GLFWlibrary
     } vk;
 
     struct {
-        GLFWmonitorfun  monitor;
-        GLFWjoystickfun joystick;
+        GLFWmonitorfun          monitor;
+        GLFWjoystickfun         joystick;
+        GLFWjoystickbuttonfun   joystick_button;
+        GLFWjoystickaxisfun     joystick_axis;
     } callbacks;
 
     // This is defined in the window API's platform.h
@@ -952,6 +954,22 @@ void _glfwInputDrop(_GLFWwindow* window, int count, const char** names);
  *  @ingroup event
  */
 void _glfwInputJoystickChange(int joy, int event);
+
+/*! @brief Notifies shared code of a joystick button pressed/release action.
+ *  @param[in] joy The joystick that had a button pressed or released.
+ *  @param[in] button The button that was pressed or released.
+ *  @param[in] action One of `GLFW_PRESS` or `GLFW_RELEASE`.
+ *  @ingroup event
+ */
+void _glfwInputJoystickButtonState(int joy, int button, int action);
+
+/*! @brief Notifies shared code of joystick axis motion.
+ *  @param[in] joy The joystick that had an axis moved.
+ *  @param[in] axis The axis that was moved.
+ *  @param[in] value The current position of the axis.
+ *  @ingroup event
+ */
+void _glfwInputJoystickAxisMoved(int joy, int axis, float value);
 
 
 //========================================================================

--- a/tests/events.c
+++ b/tests/events.c
@@ -474,6 +474,18 @@ static void joystick_callback(int joy, int event)
     }
 }
 
+static void joystick_button_callback(int joy, int button, int action)
+{
+    printf("%08x at %0.3f: Joystick %i button %i was %s\n",
+           counter++, glfwGetTime(), joy, button, get_action_name(action));
+}
+
+static void joystick_axis_callback(int joy, int axis, float value)
+{
+    printf("%08x at %0.3f: Joystick %i axis %i was moved to %f\n",
+           counter++, glfwGetTime(), joy, axis, value);
+}
+
 int main(int argc, char** argv)
 {
     Slot* slots;
@@ -491,6 +503,8 @@ int main(int argc, char** argv)
 
     glfwSetMonitorCallback(monitor_callback);
     glfwSetJoystickCallback(joystick_callback);
+    glfwSetJoystickButtonCallback(joystick_button_callback);
+    glfwSetJoystickAxisCallback(joystick_axis_callback);
 
     while ((ch = getopt(argc, argv, "hfn:")) != -1)
     {


### PR DESCRIPTION
A complete structure for joystick axis and button event callbacks has been provided in glfw3.h, internal.h, and input.h.  Also, testing has been included in events.c.

Implementation has been provided only for OS X, in cocoa_joystick.m (see the notes with that file for more details).

I am not particularly familiar with Windows or Linux programming, nor do I have the setup to compile and test code on those platforms.  However, if it would be helpful in the meantime, I think it would be relatively easy to simulate joystick events on those platforms by performing polling in the _glfwPlatformPollEvents() functions and calling the joystick button and axis callback functions when the polled values have changed.  Doing the same thing for _glfwPlatformWaitEvents() and _glfwPlatformWaitEventsTimeout() should also be relatively straightforward by repeatedly waiting for regular events, perhaps with a 0.1 second wait time, and then polling for joystick events, until an event occurs (or the timeout elapses).
