### PR TITLE
Add version directives to GLSL shaders

### DIFF
--- a/tests/cursor.c
+++ b/tests/cursor.c
@@ -47,6 +47,7 @@
 #define CURSOR_FRAME_COUNT 60
 
 static const char* vertex_shader_text =
+"#version 110\n"
 "uniform mat4 MVP;\n"
 "attribute vec2 vPos;\n"
 "void main()\n"
@@ -55,6 +56,7 @@ static const char* vertex_shader_text =
 "}\n";
 
 static const char* fragment_shader_text =
+"#version 110\n"
 "void main()\n"
 "{\n"
 "    gl_FragColor = vec4(1.0);\n"

--- a/tests/sharing.c
+++ b/tests/sharing.c
@@ -36,6 +36,7 @@
 #include "linmath.h"
 
 static const char* vertex_shader_text =
+"#version 110\n"
 "uniform mat4 MVP;\n"
 "attribute vec2 vPos;\n"
 "varying vec2 texcoord;\n"
@@ -46,6 +47,7 @@ static const char* vertex_shader_text =
 "}\n";
 
 static const char* fragment_shader_text =
+"#version 110\n"
 "uniform sampler2D texture;\n"
 "uniform vec3 color;\n"
 "varying vec2 texcoord;\n"


### PR DESCRIPTION
Although not technically required, I believe it is best practice for shaders to specify which version of the GLSL spec they conform to. To quote the spec:

> Shaders should declare the version of the language they are written to.

NB: I have presumed the version is 1.10, but it should be corrected if a later version was intended.
