### PR TITLE
Stop github thinking this is Mathematica

### DIFF
--- a/src/cocoa_monitor.m
+++ b/src/cocoa_monitor.m
@@ -331,7 +331,7 @@ GLFWvidmode* _glfwPlatformGetVideoModes(_GLFWmonitor* monitor, int* count)
         if (i < *count)
             continue;
 
-        (*count)++;
+        *count++;
         result[*count - 1] = mode;
     }
 


### PR DESCRIPTION
`*` has a higher precedence than `++`, so this doesn't change the functionality. It does remove any occurrences of `(*`, which starts a Mathematica comment.