### PR TITLE
Use EGL_KHR_get_all_proc_addresses if possible.

### DIFF
--- a/src/egl_context.c
+++ b/src/egl_context.c
@@ -399,6 +399,8 @@ GLFWbool _glfwInitEGL(void)
         extensionSupportedEGL("EGL_KHR_create_context_no_error");
     _glfw.egl.KHR_gl_colorspace =
         extensionSupportedEGL("EGL_KHR_gl_colorspace");
+    _glfw.egl.KHR_get_all_proc_addresses =
+        extensionSupportedEGL("EGL_KHR_get_all_proc_addresses");
 
     return GLFW_TRUE;
 }
@@ -583,6 +585,7 @@ GLFWbool _glfwCreateContextEGL(_GLFWwindow* window,
     window->context.egl.config = config;
 
     // Load the appropriate client library
+    if (!_glfw.egl.KHR_get_all_proc_addresses)
     {
         int i;
         const char** sonames;

--- a/src/egl_context.h
+++ b/src/egl_context.h
@@ -176,6 +176,7 @@ typedef struct _GLFWlibraryEGL
     GLFWbool        KHR_create_context;
     GLFWbool        KHR_create_context_no_error;
     GLFWbool        KHR_gl_colorspace;
+    GLFWbool        KHR_get_all_proc_addresses;
 
     void*           handle;
 


### PR DESCRIPTION
On systems that support the EGL_KHR_get_all_proc_addresses extension, there's no need to load a client API library, since you can just load any OpenGL function through eglGetProcAddress.

This is especially useful for full OpenGL contexts (rather than GLES), because there isn't a client library to use with EGL. The libGLES\*.so libraries are supposed to be for GLES, and libGL.so.1 is only for GLX.

The change itself is pretty simple. It just checks for whether EGL_KHR_get_all_proc_addresses is supported in `_glfwInitEGL`, and then in `_glfwCreateContextEGL`, it'll skip trying to load the client library.