### PR TITLE
Fix a bunch of memleaks

### DIFF
--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -643,6 +643,10 @@ void _glfwPlatformTerminate(void)
     _glfwTerminateJoysticksLinux();
     _glfwTerminateThreadLocalStoragePOSIX();
 
+    xkb_keymap_unref(_glfw.wl.xkb.keymap);
+    xkb_state_unref(_glfw.wl.xkb.state);
+    xkb_context_unref(_glfw.wl.xkb.context);
+
     if (_glfw.wl.cursorTheme)
         wl_cursor_theme_destroy(_glfw.wl.cursorTheme);
     if (_glfw.wl.cursorSurface)

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -186,10 +186,10 @@ static void keyboardHandleKeymap(void* data,
         return;
     }
 
-    keymap = xkb_map_new_from_string(_glfw.wl.xkb.context,
-                                     mapStr,
-                                     XKB_KEYMAP_FORMAT_TEXT_V1,
-                                     0);
+    keymap = xkb_keymap_new_from_string(_glfw.wl.xkb.context,
+                                        mapStr,
+                                        XKB_KEYMAP_FORMAT_TEXT_V1,
+                                        0);
     munmap(mapStr, size);
     close(fd);
 
@@ -205,7 +205,7 @@ static void keyboardHandleKeymap(void* data,
     {
         _glfwInputError(GLFW_PLATFORM_ERROR,
                         "Wayland: Failed to create XKB state");
-        xkb_map_unref(keymap);
+        xkb_keymap_unref(keymap);
         return;
     }
 
@@ -215,13 +215,13 @@ static void keyboardHandleKeymap(void* data,
     _glfw.wl.xkb.state = state;
 
     _glfw.wl.xkb.control_mask =
-        1 << xkb_map_mod_get_index(_glfw.wl.xkb.keymap, "Control");
+        1 << xkb_keymap_mod_get_index(_glfw.wl.xkb.keymap, "Control");
     _glfw.wl.xkb.alt_mask =
-        1 << xkb_map_mod_get_index(_glfw.wl.xkb.keymap, "Mod1");
+        1 << xkb_keymap_mod_get_index(_glfw.wl.xkb.keymap, "Mod1");
     _glfw.wl.xkb.shift_mask =
-        1 << xkb_map_mod_get_index(_glfw.wl.xkb.keymap, "Shift");
+        1 << xkb_keymap_mod_get_index(_glfw.wl.xkb.keymap, "Shift");
     _glfw.wl.xkb.super_mask =
-        1 << xkb_map_mod_get_index(_glfw.wl.xkb.keymap, "Mod4");
+        1 << xkb_keymap_mod_get_index(_glfw.wl.xkb.keymap, "Mod4");
 }
 
 static void keyboardHandleEnter(void* data,
@@ -265,7 +265,7 @@ static void inputChar(_GLFWwindow* window, uint32_t key)
     const xkb_keysym_t *syms;
 
     code = key + 8;
-    num_syms = xkb_key_get_syms(_glfw.wl.xkb.state, code, &syms);
+    num_syms = xkb_state_key_get_syms(_glfw.wl.xkb.state, code, &syms);
 
     if (num_syms == 1)
     {
@@ -327,8 +327,10 @@ static void keyboardHandleModifiers(void* data,
                           group);
 
     mask = xkb_state_serialize_mods(_glfw.wl.xkb.state,
-                                    XKB_STATE_DEPRESSED |
-                                    XKB_STATE_LATCHED);
+                                    XKB_STATE_MODS_DEPRESSED |
+                                    XKB_STATE_LAYOUT_DEPRESSED |
+                                    XKB_STATE_MODS_LATCHED |
+                                    XKB_STATE_LAYOUT_LATCHED);
     if (mask & _glfw.wl.xkb.control_mask)
         modifiers |= GLFW_MOD_CONTROL;
     if (mask & _glfw.wl.xkb.alt_mask)

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -647,12 +647,29 @@ void _glfwPlatformTerminate(void)
         wl_cursor_theme_destroy(_glfw.wl.cursorTheme);
     if (_glfw.wl.cursorSurface)
         wl_surface_destroy(_glfw.wl.cursorSurface);
+    if (_glfw.wl.compositor)
+        wl_compositor_destroy(_glfw.wl.compositor);
+    if (_glfw.wl.shm)
+        wl_shm_destroy(_glfw.wl.shm);
+    if (_glfw.wl.shell)
+        wl_shell_destroy(_glfw.wl.shell);
+    if (_glfw.wl.pointer)
+        wl_pointer_destroy(_glfw.wl.pointer);
+    if (_glfw.wl.keyboard)
+        wl_keyboard_destroy(_glfw.wl.keyboard);
+    if (_glfw.wl.seat)
+        wl_seat_destroy(_glfw.wl.seat);
+    if (_glfw.wl.relativePointerManager)
+        zwp_relative_pointer_manager_v1_destroy(_glfw.wl.relativePointerManager);
+    if (_glfw.wl.pointerConstraints)
+        zwp_pointer_constraints_v1_destroy(_glfw.wl.pointerConstraints);
     if (_glfw.wl.registry)
         wl_registry_destroy(_glfw.wl.registry);
     if (_glfw.wl.display)
+    {
         wl_display_flush(_glfw.wl.display);
-    if (_glfw.wl.display)
         wl_display_disconnect(_glfw.wl.display);
+    }
 }
 
 const char* _glfwPlatformGetVersionString(void)


### PR DESCRIPTION
This was partially inspired from #475, but some of the fixes were bogus (`free()`ing already-freed memory) and it was generally incomplete, so I preferred to restart from scratch using valgrind.

There is one remaining leak, due to the `_GLFWmonitor`s being freed before `_glfwPlatformTerminate()` is executed, making everything allocated in `_GLFWmonitorWayland` impossible to free.