### PR TITLE
Fix 'first responder' error on 10.12

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -1032,11 +1032,11 @@ static GLFWbool createNativeWindow(_GLFWwindow* window,
     [window->ns.view setWantsBestResolutionOpenGLSurface:YES];
 #endif /*_GLFW_USE_RETINA*/
 
+    [window->ns.object setContentView:window->ns.view];
     [window->ns.object makeFirstResponder:window->ns.view];
     [window->ns.object setTitle:[NSString stringWithUTF8String:wndconfig->title]];
     [window->ns.object setDelegate:window->ns.delegate];
     [window->ns.object setAcceptsMouseMovedEvents:YES];
-    [window->ns.object setContentView:window->ns.view];
     [window->ns.object setRestorable:NO];
 
     return GLFW_TRUE;


### PR DESCRIPTION
Error message is displayed during the startup because Cocoa view is set as the first responder for window but this view isn't in this window (actually it is not in any window at all).

Fixes the issue described in #876. **Tested only on macOS 10.12.**
