### PR TITLE
Bad range handling of hat values

### DIFF
--- a/src/cocoa_joystick.m
+++ b/src/cocoa_joystick.m
@@ -246,7 +246,7 @@ static GLFWbool pollJoystickButtonEvents(_GLFWjoystickNS* js)
             CFArrayGetValueAtIndex(js->hatElements, i);
 
         // Bit fields of button presses for each direction, including nil
-        const int directions[9] = { 1, 3, 2, 6, 4, 12, 8, 9, 0 };
+        const int directions[9] = { 0, 1, 3, 2, 6, 4, 12, 8, 9 };
 
         long j, value = getElementValue(js, hat);
         if (value < 0 || value > 8)


### PR DESCRIPTION
Joystick hat switch button in the up-left direction is always pressed in neutral position (at least on 10.11). It looks like on macOS the directions array should start with the neutral bitfield first rather than last like on Windows. This was tested using tests/joysticks.app. However, it has not been tested on other versions of macOS.
