### PR TITLE
Joystick Hat Support

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -286,6 +286,23 @@ extern "C" {
 #define GLFW_REPEAT                 2
 /*! @} */
 
+/*! @defgroup hat_directions Joystick hat directions
+ *
+ *  See [joystick hat input](@ref joystick_hat) for how these are used.
+ *
+ *  @ingroup input
+ *  @{ */
+#define GLFW_HAT_CENTERED           0
+#define GLFW_HAT_UP                 1
+#define GLFW_HAT_RIGHT              2
+#define GLFW_HAT_DOWN               4
+#define GLFW_HAT_LEFT               8
+#define GLFW_HAT_RIGHT_UP           (GLFW_HAT_RIGHT | GLFW_HAT_UP)
+#define GLFW_HAT_RIGHT_DOWN         (GLFW_HAT_RIGHT | GLFW_HAT_DOWN)
+#define GLFW_HAT_LEFT_UP            (GLFW_HAT_LEFT  | GLFW_HAT_UP)
+#define GLFW_HAT_LEFT_DOWN          (GLFW_HAT_LEFT  | GLFW_HAT_DOWN)
+/*! @} */
+
 /*! @defgroup keys Keyboard keys
  *
  *  See [key input](@ref input_key) for how these are used.
@@ -3753,6 +3770,60 @@ GLFWAPI const float* glfwGetJoystickAxes(int jid, int* count);
  *  @ingroup input
  */
 GLFWAPI const unsigned char* glfwGetJoystickButtons(int jid, int* count);
+
+/*! @brief Returns the state of all hats of the specified joystick.
+ *
+ *  This function returns the state of all hats of the specified joystick.
+ *  Each element in the array is one of the following:
+ *
+ *      GLFW_HAT_CENTERED
+ *      GLFW_HAT_UP
+ *      GLFW_HAT_RIGHT
+ *      GLFW_HAT_DOWN
+ *      GLFW_HAT_LEFT
+ *      GLFW_HAT_RIGHT_UP
+ *      GLFW_HAT_RIGHT_DOWN
+ *      GLFW_HAT_LEFT_UP
+ *      GLFW_HAT_LEFT_DOWN
+ *
+ *  For masking purposes, the hat state may be ANDed with the following primary
+ *  directions:
+ *
+ *      GLFW_HAT_UP
+ *      GLFW_HAT_RIGHT
+ *      GLFW_HAT_DOWN
+ *      GLFW_HAT_LEFT
+ *
+ *  Querying a joystick slot with no device present is not an error, but will
+ *  cause this function to return `NULL`.  Call @ref glfwJoystickPresent to
+ *  check device presence.
+ *
+ *  @param[in] jid The [joystick](@ref joysticks) to query.
+ *  @param[out] count Where to store the number of hat states in the returned
+ *  array.  This is set to zero if the joystick is not present or an error
+ *  occurred.
+ *  @return An array of hat states, or `NULL` if the joystick is not present
+ *  or an [error](@ref error_handling) occurred.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+ *  GLFW_INVALID_ENUM and @ref GLFW_PLATFORM_ERROR.
+ *
+ *  @remark @linux Linux does not currently support hats.
+ *
+ *  @pointer_lifetime The returned array is allocated and freed by GLFW.  You
+ *  should not free it yourself.  It is valid until the specified joystick is
+ *  disconnected, this function is called again for that joystick or the library
+ *  is terminated.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref joystick_hat
+ *
+ *  @since Added in version 3.3.
+ *
+ *  @ingroup input
+ */
+GLFWAPI const unsigned char* glfwGetJoystickHats(int jid, int* count);
 
 /*! @brief Returns the name of the specified joystick.
  *

--- a/src/cocoa_joystick.h
+++ b/src/cocoa_joystick.h
@@ -51,6 +51,7 @@ typedef struct _GLFWjoystickNS
 
     float*          axes;
     unsigned char*  buttons;
+    unsigned char*  hats;
 } _GLFWjoystickNS;
 
 

--- a/src/input.c
+++ b/src/input.c
@@ -598,6 +598,22 @@ GLFWAPI const unsigned char* glfwGetJoystickButtons(int jid, int* count)
     return _glfwPlatformGetJoystickButtons(jid, count);
 }
 
+GLFWAPI const unsigned char* glfwGetJoystickHats(int jid, int* count)
+{
+    assert(count != NULL);
+    *count = 0;
+
+    _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
+
+    if (jid < 0 || jid > GLFW_JOYSTICK_LAST)
+    {
+        _glfwInputError(GLFW_INVALID_ENUM, "Invalid joystick %i", jid);
+        return NULL;
+    }
+
+    return _glfwPlatformGetJoystickHats(jid, count);
+}
+
 GLFWAPI const char* glfwGetJoystickName(int jid)
 {
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);

--- a/src/internal.h
+++ b/src/internal.h
@@ -626,6 +626,11 @@ const float* _glfwPlatformGetJoystickAxes(int jid, int* count);
  */
 const unsigned char* _glfwPlatformGetJoystickButtons(int jid, int* count);
 
+/*! @copydoc glfwGetJoystickHats
+ *  @ingroup platform
+ */
+const unsigned char* _glfwPlatformGetJoystickHats(int jid, int* count);
+
 /*! @copydoc glfwGetJoystickName
  *  @ingroup platform
  */

--- a/src/linux_joystick.h
+++ b/src/linux_joystick.h
@@ -42,6 +42,8 @@ typedef struct _GLFWjoystickLinux
     int             axisCount;
     unsigned char*  buttons;
     int             buttonCount;
+    unsigned char*  hats;
+    int             hatCount;
     char*           name;
     char*           path;
 } _GLFWjoystickLinux;

--- a/src/win32_joystick.c
+++ b/src/win32_joystick.c
@@ -249,6 +249,7 @@ static void closeJoystick(_GLFWjoystickWin32* js)
     free(js->name);
     free(js->axes);
     free(js->buttons);
+    free(js->hats);
     free(js->objects);
     memset(js, 0, sizeof(_GLFWjoystickWin32));
 
@@ -431,8 +432,10 @@ static BOOL CALLBACK deviceCallback(const DIDEVICEINSTANCE* di, void* user)
     js->guid = di->guidInstance;
     js->axisCount = data.axisCount + data.sliderCount;
     js->axes = calloc(js->axisCount, sizeof(float));
-    js->buttonCount += data.buttonCount + data.povCount * 4;
+    js->buttonCount = data.buttonCount;
     js->buttons = calloc(js->buttonCount, 1);
+    js->hatCount = data.povCount;
+    js->hats = calloc(js->hatCount, 1);
     js->objects = data.objects;
     js->objectCount = data.objectCount;
     js->name = _glfwCreateUTF8FromWideStringWin32(di->tszInstanceName);
@@ -476,8 +479,10 @@ static GLFWbool openXinputDevice(DWORD index)
     js = _glfw.win32_js + jid;
     js->axisCount = 6;
     js->axes = calloc(js->axisCount, sizeof(float));
-    js->buttonCount = 14;
+    js->buttonCount = 10;
     js->buttons = calloc(js->buttonCount, 1);
+    js->hatCount = 1;
+    js->hats = calloc(js->hatCount, 1);
     js->present = GLFW_TRUE;
     js->name = strdup(getDeviceDescription(&xic));
     js->index = index;
@@ -496,7 +501,7 @@ static GLFWbool pollJoystickState(_GLFWjoystickWin32* js, int mode)
 
     if (js->device)
     {
-        int i, j, ai = 0, bi = 0;
+        int i, j, ai = 0, bi = 0, hi = 0;
         HRESULT result;
         DIJOYSTATE state;
 
@@ -547,19 +552,20 @@ static GLFWbool pollJoystickState(_GLFWjoystickWin32* js, int mode)
 
                 case _GLFW_TYPE_POV:
                 {
-                    const int directions[9] = { 1, 3, 2, 6, 4, 12, 8, 9, 0 };
+                    const unsigned char directions[9] = { 1, 3, 2, 6, 4, 12, 8, 9, 0 };
                     // Screams of horror are appropriate at this point
                     int value = LOWORD(*(DWORD*) data) / (45 * DI_DEGREES);
                     if (value < 0 || value > 8)
                         value = 8;
 
+                    js->hats[hi] = 0;
                     for (j = 0;  j < 4;  j++)
                     {
-                        if (directions[value] & (1 << j))
-                            js->buttons[bi++] = GLFW_PRESS;
-                        else
-                            js->buttons[bi++] = GLFW_RELEASE;
+                        unsigned char bit_value = 1 << j;
+                        if (directions[value] & bit_value)
+                            js->hats[hi] |= bit_value;
                     }
+                    hi++;
 
                     break;
                 }
@@ -573,7 +579,7 @@ static GLFWbool pollJoystickState(_GLFWjoystickWin32* js, int mode)
         int i;
         DWORD result;
         XINPUT_STATE xis;
-        const WORD buttons[14] =
+        const WORD buttons[10] =
         {
             XINPUT_GAMEPAD_A,
             XINPUT_GAMEPAD_B,
@@ -584,7 +590,10 @@ static GLFWbool pollJoystickState(_GLFWjoystickWin32* js, int mode)
             XINPUT_GAMEPAD_BACK,
             XINPUT_GAMEPAD_START,
             XINPUT_GAMEPAD_LEFT_THUMB,
-            XINPUT_GAMEPAD_RIGHT_THUMB,
+            XINPUT_GAMEPAD_RIGHT_THUMB
+        };
+        const WORD hat_buttons[4] =
+        {
             XINPUT_GAMEPAD_DPAD_UP,
             XINPUT_GAMEPAD_DPAD_RIGHT,
             XINPUT_GAMEPAD_DPAD_DOWN,
@@ -639,8 +648,13 @@ static GLFWbool pollJoystickState(_GLFWjoystickWin32* js, int mode)
         else
             js->axes[5] = -1.f;
 
-        for (i = 0;  i < 14;  i++)
+        for (i = 0;  i < 10;  i++)
             js->buttons[i] = (xis.Gamepad.wButtons & buttons[i]) ? 1 : 0;
+
+        js->hats[0] = 0;
+        for (i = 0;  i < 4;  i++)
+            if (xis.Gamepad.wButtons & hat_buttons[i])
+                js->hats[0] |= 1 << i;
 
         return GLFW_TRUE;
     }
@@ -750,6 +764,16 @@ const unsigned char* _glfwPlatformGetJoystickButtons(int jid, int* count)
 
     *count = js->buttonCount;
     return js->buttons;
+}
+
+const unsigned char* _glfwPlatformGetJoystickHats(int jid, int* count)
+{
+    _GLFWjoystickWin32* js = _glfw.win32_js + jid;
+    if (!pollJoystickState(js, _GLFW_UPDATE_STATE))
+        return NULL;
+
+    *count = js->hatCount;
+    return js->hats;
 }
 
 const char* _glfwPlatformGetJoystickName(int jid)

--- a/src/win32_joystick.h
+++ b/src/win32_joystick.h
@@ -47,6 +47,8 @@ typedef struct _GLFWjoystickWin32
     int                     axisCount;
     unsigned char*          buttons;
     int                     buttonCount;
+    unsigned char*          hats;
+    int                     hatCount;
     _GLFWjoyobjectWin32*    objects;
     int                     objectCount;
     char*                   name;

--- a/tests/events.c
+++ b/tests/events.c
@@ -463,17 +463,19 @@ static void joystick_callback(int jid, int event)
 {
     if (event == GLFW_CONNECTED)
     {
-        int axisCount, buttonCount;
+        int axisCount, buttonCount, hatCount;
 
         glfwGetJoystickAxes(jid, &axisCount);
         glfwGetJoystickButtons(jid, &buttonCount);
+        glfwGetJoystickHats(jid, &hatCount);
 
-        printf("%08x at %0.3f: Joystick %i (%s) was connected with %i axes and %i buttons\n",
+        printf("%08x at %0.3f: Joystick %i (%s) was connected with %i axes, %i buttons, and %i hats\n",
                counter++, glfwGetTime(),
                jid,
                glfwGetJoystickName(jid),
                axisCount,
-               buttonCount);
+               buttonCount,
+               hatCount);
     }
     else
     {

--- a/tests/joysticks.c
+++ b/tests/joysticks.c
@@ -171,9 +171,10 @@ int main(void)
                          NK_WINDOW_MINIMIZABLE |
                          NK_WINDOW_TITLE))
             {
-                int j, axis_count, button_count;
+                int j, axis_count, button_count, hat_count;
                 const float* axes;
                 const unsigned char* buttons;
+                const unsigned char* hats;
 
                 nk_layout_row_dynamic(nk, 30, 1);
 
@@ -194,6 +195,46 @@ int main(void)
                         char name[16];
                         snprintf(name, sizeof(name), "%i", j + 1);
                         nk_select_label(nk, name, NK_TEXT_CENTERED, buttons[j]);
+                    }
+                }
+
+                nk_layout_row_dynamic(nk, 60, 4);
+
+                hats = glfwGetJoystickHats(joysticks[i], &hat_count);
+                if (hat_count)
+                {
+                    for (j = 0;  j < hat_count;  j++)
+                    {
+                        switch(hats[j])
+                        {
+                        case GLFW_HAT_CENTERED:
+                            nk_select_label(nk, "centered", NK_TEXT_CENTERED, 0);
+                            break;
+                        case GLFW_HAT_UP:
+                            nk_select_label(nk, "up", NK_TEXT_CENTERED, 1);
+                            break;
+                        case GLFW_HAT_RIGHT:
+                            nk_select_label(nk, "right", NK_TEXT_CENTERED, 1);
+                            break;
+                        case GLFW_HAT_DOWN:
+                            nk_select_label(nk, "down", NK_TEXT_CENTERED, 1);
+                            break;
+                        case GLFW_HAT_LEFT:
+                            nk_select_label(nk, "left", NK_TEXT_CENTERED, 1);
+                            break;
+                        case GLFW_HAT_RIGHT_UP:
+                            nk_select_label(nk, "right_up", NK_TEXT_CENTERED, 1);
+                            break;
+                        case GLFW_HAT_RIGHT_DOWN:
+                            nk_select_label(nk, "right_down", NK_TEXT_CENTERED, 1);
+                            break;
+                        case GLFW_HAT_LEFT_UP:
+                            nk_select_label(nk, "left_up", NK_TEXT_CENTERED, 1);
+                            break;
+                        case GLFW_HAT_LEFT_DOWN:
+                            nk_select_label(nk, "left_down", NK_TEXT_CENTERED, 1);
+                            break;
+                        }
                     }
                 }
 


### PR DESCRIPTION
This code implements joystick hat support per issue #889.

The API change is to add the following function (and #defines for each of the hat positions such as GLFW_HAT_RIGHT_UP):

    GLFWAPI const unsigned char* glfwGetJoystickHats(int jid, int* count);

The events test (events.c) has been updated to reflect the number of hat switches when a joystick is connected.

The joystick test (joystick.c) has been updated to add a new row for hat switches that displays the position in human-readable text (e.g., "right_up").

Code for macOS has been provided and tested.

Code for Windows has been provided, but has not been compiled or tested since I do not have access to a Windows system.

Code for Linux has also been provided, but relevant portions are compiled out with the #defines JSIOCGHATS and JS_EVENT_HAT -- following the JSIOCGAXES / JSIOCGBUTTONS and JS_EVENT_AXIS / JS_EVENT_BUTTON syntax, respectively -- since <linux/joystick.h> does not currently provide support for hat switches; if such support is added to <linux/joystick.h>, the code should work however.  This code also has not been compiled or tested since I do not have access to a Linux system.

A remark about the lack of support for hat switches on Linux appears in the documentation for glfwGetJoystickHats in glfw3.h.