### PR TITLE
Crash in Debian 9 on glfwCreateWindow

### DIFF
--- a/src/glx_context.c
+++ b/src/glx_context.c
@@ -59,7 +59,7 @@ static GLFWbool chooseGLXFBConfig(const _GLFWfbconfig* desired, GLXFBConfig* res
     // HACK: This is a (hopefully temporary) workaround for Chromium
     //       (VirtualBox GL) not setting the window bit on any GLXFBConfigs
     vendor = glXGetClientString(_glfw.x11.display, GLX_VENDOR);
-    if (strcmp(vendor, "Chromium") == 0)
+    if (vendor && strcmp(vendor, "Chromium") == 0)
         trustWindowBit = GLFW_FALSE;
 
     nativeConfigs =


### PR DESCRIPTION
Fix crash when glXGetClientString returns a null string