### PR TITLE
X11: send timestamp of last key press to NET_ACTIVE_WINDOW

### DIFF
--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -1945,7 +1945,8 @@ void _glfwPlatformHideWindow(_GLFWwindow* window)
 void _glfwPlatformFocusWindow(_GLFWwindow* window)
 {
     if (_glfw.x11.NET_ACTIVE_WINDOW)
-        sendEventToWM(window, _glfw.x11.NET_ACTIVE_WINDOW, 1, 0, 0, 0, 0);
+        sendEventToWM(window, _glfw.x11.NET_ACTIVE_WINDOW,
+                      1, window->x11.lastKeyTime, 0, 0, 0);
     else
     {
         XRaiseWindow(_glfw.x11.display, window->x11.handle);


### PR DESCRIPTION
The EWMH specifications require that the timestamp of the last
user interaction should be sent to `NET_ACTIVE_WINDOW`.
Since GLFW send just 0 currently, the GNOME Shell would issue a warning
upon receiving a `NET_ACTIVE_WINDOW` message:

> Window manager warning: Buggy client sent a _NET_ACTIVE_WINDOW message
> with a timestamp of 0

This commit fixes this by sending `lastKeyTime` as the timestamp
which should be a reasonable approximation to the last user interaction.

I have not tested this patch extensively, but it silences the warning and it should not alter existent behaviour.