### PR TITLE
MinGW builds will always use 32bit vulkan

### DIFF
--- a/CMake/modules/FindVulkan.cmake
+++ b/CMake/modules/FindVulkan.cmake
@@ -8,7 +8,7 @@ if (WIN32)
     find_path(VULKAN_INCLUDE_DIR NAMES vulkan/vulkan.h HINTS
         "$ENV{VULKAN_SDK}/Include"
         "$ENV{VK_SDK_PATH}/Include")
-    if (CMAKE_CL_64)
+    if (CMAKE_SIZEOF_VOID_P EQUAL 8)
         find_library(VULKAN_LIBRARY NAMES vulkan-1 HINTS
             "$ENV{VULKAN_SDK}/Bin"
             "$ENV{VK_SDK_PATH}/Bin")

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ information on what to include when reporting a bug.
           `vkGetInstanceProcAddr` when `_GLFW_VULKAN_STATIC` was enabled
 - [Win32] Bugfix: Undecorated windows could not be iconified by the user (#861)
 - [Win32] Bugfix: Deadzone logic could underflow with some controllers (#910)
+- [Win32] Bugfix: Using CMake with compilers besides Visual Studio would
+                  always link 32bit vulkan, even for 64bit builds
 - [X11] Replaced `_GLFW_HAS_XF86VM` compile-time option with dynamic loading
 - [Cocoa] Added support for Vulkan window surface creation via
           [MoltenVK](https://moltengl.com/moltenvk/) (#870)


### PR DESCRIPTION
`CMAKE_CL_64` is a Visual Studio only define, `CMAKE_SIZEOF_VOID_P EQUAL 8` should work for all compilers.