### PR TITLE
Fix build on OpenBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,11 +199,13 @@ endif()
 # Find and add Unix math and time libraries
 #--------------------------------------------------------------------
 if (UNIX AND NOT APPLE)
-    find_library(RT_LIBRARY rt)
-    mark_as_advanced(RT_LIBRARY)
-    if (RT_LIBRARY)
-        list(APPEND glfw_LIBRARIES "${RT_LIBRARY}")
-        list(APPEND glfw_PKG_LIBS "-lrt")
+    if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD")
+	find_library(RT_LIBRARY rt)
+	mark_as_advanced(RT_LIBRARY)
+	if (RT_LIBRARY)
+            list(APPEND glfw_LIBRARIES "${RT_LIBRARY}")
+            list(APPEND glfw_PKG_LIBS "-lrt")
+	endif()
     endif()
 
     find_library(MATH_LIBRARY m)


### PR DESCRIPTION
OpenBSD [doesn't have librt](http://marc.info/?l=openbsd-tech&m=139559970907629), but provides all librt's functions in libc. Here's a shot for a fix.