### PR TITLE
Fixed X11 behavior when disconnecting / connecting the last display

### DIFF
--- a/src/x11_init.c
+++ b/src/x11_init.c
@@ -499,31 +499,6 @@ static GLFWbool initExtensions(void)
 
     if (_glfw.x11.randr.available)
     {
-        XRRScreenResources* sr = XRRGetScreenResourcesCurrent(_glfw.x11.display,
-                                                              _glfw.x11.root);
-
-        if (!sr->ncrtc || !XRRGetCrtcGammaSize(_glfw.x11.display, sr->crtcs[0]))
-        {
-            // This is either a headless system or an older Nvidia binary driver
-            // with broken gamma support
-            // Flag it as useless and fall back to Xf86VidMode gamma, if
-            // available
-            _glfwInputError(GLFW_PLATFORM_ERROR,
-                            "X11: Detected broken RandR gamma ramp support");
-            _glfw.x11.randr.gammaBroken = GLFW_TRUE;
-        }
-
-        if (!sr->ncrtc || !sr->noutput || !sr->nmode)
-        {
-            // This is either a headless system or broken Cygwin/X RandR
-            // Flag it as useless and fall back to Xlib display functions
-            _glfwInputError(GLFW_PLATFORM_ERROR,
-                            "X11: Detected broken RandR monitor support");
-            _glfw.x11.randr.monitorBroken = GLFW_TRUE;
-        }
-
-        XRRFreeScreenResources(sr);
-
         XRRSelectInput(_glfw.x11.display, _glfw.x11.root,
                        RROutputChangeNotifyMask);
     }

--- a/src/x11_platform.h
+++ b/src/x11_platform.h
@@ -221,8 +221,6 @@ typedef struct _GLFWlibraryX11
         int         errorBase;
         int         major;
         int         minor;
-        GLFWbool    gammaBroken;
-        GLFWbool    monitorBroken;
     } randr;
 
     struct {


### PR DESCRIPTION
- Removed the one-time detection of headless display
- Removed virtual "Display" display created when no monitor is plugged
- Hardened monitor functions