### PR TITLE
Updated touch structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ skills.
  - Christoph Kubisch
  - Konstantin Käfer
  - Eric Larson
+ - Quinten Lansu
  - Robin Leffmann
  - Glenn Lewis
  - Shane Liesegang

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -272,18 +272,18 @@ extern "C" {
 #define GLFW_FALSE                  0
 /*! @} */
 
-/*! @name Key and button actions
+/*! @name Key, button and touch actions
  *  @{ */
-/*! @brief The key or mouse button was released.
+/*! @brief The key or button was released or the touch ended.
  *
- *  The key or mouse button was released.
+ *  The key or button was released or the touch ended.
  *
  *  @ingroup input
  */
 #define GLFW_RELEASE                0
-/*! @brief The key or mouse button was pressed.
+/*! @brief The key or button was pressed or the touch started.
  *
- *  The key or mouse button was pressed.
+ *  The key or button was pressed or the touch started.
  *
  *  @ingroup input
  */
@@ -295,6 +295,10 @@ extern "C" {
  *  @ingroup input
  */
 #define GLFW_REPEAT                 2
+/*! @brief The touch was moved.
+ *  @ingroup input
+ */
+#define GLFW_MOVE                   3
 /*! @} */
 
 /*! @defgroup keys Keyboard keys
@@ -870,6 +874,7 @@ extern "C" {
 #define GLFW_CURSOR                 0x00033001
 #define GLFW_STICKY_KEYS            0x00033002
 #define GLFW_STICKY_MOUSE_BUTTONS   0x00033003
+#define GLFW_TOUCH                  0x00030004
 
 #define GLFW_CURSOR_NORMAL          0x00034001
 #define GLFW_CURSOR_HIDDEN          0x00034002
@@ -1301,6 +1306,42 @@ typedef void (* GLFWcharmodsfun)(GLFWwindow*,unsigned int,int);
  *  @ingroup input
  */
 typedef void (* GLFWdropfun)(GLFWwindow*,int,const char**);
+
+/*! @brief Touch point info.
+*
+*  This describes the touch point info.
+*
+*  @sa @ref touch
+*
+*  @since Added in version 3.2.1 (touch branch)
+*
+*  @ingroup touch
+*/
+typedef struct GLFWtouch
+{
+	/*! Touch id
+	*/
+	int id;
+	/*! Touch action
+	*/
+	int action;
+	/*! X position
+	*/
+	double x;
+	/*! Y position
+	*/
+	double y;
+} GLFWtouch;
+
+/*! @brief The function signature for touch callbacks.
+*  @param[in] window The window that received the event.
+*  @param[in] touchPoints All valid touch points
+*  @param[in] count The number of valid touch points
+*  @ingroup event
+*
+*  @sa glfwSetTouchCallback
+*/
+typedef void(*GLFWtouchfun)(GLFWwindow*, GLFWtouch*, int);
 
 /*! @brief The function signature for monitor configuration callbacks.
  *
@@ -3928,6 +3969,21 @@ GLFWAPI GLFWscrollfun glfwSetScrollCallback(GLFWwindow* window, GLFWscrollfun cb
  *  @ingroup input
  */
 GLFWAPI GLFWdropfun glfwSetDropCallback(GLFWwindow* window, GLFWdropfun cbfun);
+
+/*! @brief Sets the touch callback.
+ *
+ *  This function sets the touch callback, which is called when a touch is
+ *  started, ended or moved.
+ *
+ *  @param[in] window The window whose callback to set.
+ *  @param[in] cbfun The new scroll callback, or `NULL` to remove the currently
+ *  set callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or an
+ *  error occurred.
+ *
+ *  @ingroup input
+ */
+GLFWAPI GLFWtouchfun glfwSetTouchCallback(GLFWwindow* window, GLFWtouchfun cbfun);
 
 /*! @brief Returns whether the specified joystick is present.
  *

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -1490,6 +1490,10 @@ void _glfwPlatformGetCursorPos(_GLFWwindow* window, double* xpos, double* ypos)
         *ypos = contentRect.size.height - pos.y - 1;
 }
 
+void _glfwPlatformSetTouchInput(_GLFWwindow* window, int enabled)
+{
+}
+
 void _glfwPlatformSetCursorPos(_GLFWwindow* window, double x, double y)
 {
     updateCursorImage(window);

--- a/src/input.c
+++ b/src/input.c
@@ -35,6 +35,17 @@
 // Internal key state used for sticky keys
 #define _GLFW_STICK 3
 
+// Set touch input for the specified window
+//
+static void setTouchInput(_GLFWwindow* window, int enabled)
+{
+	if (window->touchInput == enabled)
+		return;
+
+	_glfwPlatformSetTouchInput(window, enabled);
+
+	window->touchInput = enabled;
+}
 
 //////////////////////////////////////////////////////////////////////////
 //////                         GLFW event API                       //////
@@ -124,6 +135,12 @@ void _glfwInputDrop(_GLFWwindow* window, int count, const char** paths)
         window->callbacks.drop((GLFWwindow*) window, count, paths);
 }
 
+void _glfwInputTouch(_GLFWwindow* window, GLFWtouch* touchPoints, int count)
+{
+	if (window->callbacks.touch)
+		window->callbacks.touch((GLFWwindow*)window, touchPoints, count);
+}
+
 void _glfwInputJoystick(int jid, int event)
 {
     if (_glfw.callbacks.joystick)
@@ -205,6 +222,8 @@ GLFWAPI int glfwGetInputMode(GLFWwindow* handle, int mode)
             return window->stickyKeys;
         case GLFW_STICKY_MOUSE_BUTTONS:
             return window->stickyMouseButtons;
+        case GLFW_TOUCH:
+            return window->touchInput;
         default:
             _glfwInputError(GLFW_INVALID_ENUM, "Invalid input mode %i", mode);
             return 0;
@@ -687,6 +706,15 @@ GLFWAPI const char* glfwGetJoystickName(int jid)
         return NULL;
 
     return _glfw.joysticks[jid].name;
+}
+
+GLFWAPI GLFWtouchfun glfwSetTouchCallback(GLFWwindow* handle, GLFWtouchfun cbfun)
+{
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
+    _GLFW_SWAP_POINTERS(window->callbacks.touch, cbfun);
+	setTouchInput(window, 1);
+    return cbfun;
 }
 
 GLFWAPI GLFWjoystickfun glfwSetJoystickCallback(GLFWjoystickfun cbfun)

--- a/src/internal.h
+++ b/src/internal.h
@@ -388,6 +388,8 @@ struct _GLFWwindow
 
     GLFWbool            stickyKeys;
     GLFWbool            stickyMouseButtons;
+    GLFWbool            touchInput;
+    double              cursorPosX, cursorPosY;
     int                 cursorMode;
     char                mouseButtons[GLFW_MOUSE_BUTTON_LAST + 1];
     char                keys[GLFW_KEY_LAST + 1];
@@ -413,6 +415,7 @@ struct _GLFWwindow
         GLFWcharfun             character;
         GLFWcharmodsfun         charmods;
         GLFWdropfun             drop;
+        GLFWtouchfun            touch;
     } callbacks;
 
     // This is defined in the window API's platform.h
@@ -566,6 +569,14 @@ void _glfwPlatformTerminate(void);
  *  @note The returned string must not change for the duration of the program.
  */
 const char* _glfwPlatformGetVersionString(void);
+
+/*! @brief Sets whether touch input is enabled for the specified window.
+ *  @param[in] window The window whose touch input status to change.
+ *  @param[in] enabled @c GL_TRUE to enable touch input, or @c GL_FALSE to
+ *  disable it.
+ *  @ingroup platform
+ */
+void _glfwPlatformSetTouchInput(_GLFWwindow* window, int enabled);
 
 /*! @copydoc glfwGetCursorPos
  *  @ingroup platform
@@ -961,6 +972,14 @@ void _glfwInputCursorPos(_GLFWwindow* window, double xpos, double ypos);
  *  @ingroup event
  */
 void _glfwInputCursorEnter(_GLFWwindow* window, GLFWbool entered);
+
+/*! @brief Notifies shared code of a touch start/end event.
+*  @param[in] window The window that received the event.
+*  @param[in] touchPoints All valid touch points
+*  @param[in] count The numer of valid touch points
+*  @ingroup event
+*/
+void _glfwInputTouch(_GLFWwindow* window, GLFWtouch* touchPoints, int count);
 
 /*! @brief Notifies shared code of a monitor connection or disconnection.
  *  @param[in] monitor The monitor that was connected or disconnected.

--- a/src/win32_init.c
+++ b/src/win32_init.c
@@ -85,6 +85,22 @@ static GLFWbool loadLibraries(void)
         GetProcAddress(_glfw.win32.user32.instance, "SetProcessDPIAware");
     _glfw.win32.user32.ChangeWindowMessageFilterEx = (PFN_ChangeWindowMessageFilterEx)
         GetProcAddress(_glfw.win32.user32.instance, "ChangeWindowMessageFilterEx");
+    _glfw.win32.user32.GetTouchInputInfo = (PFN_GetTouchInputInfo)
+        GetProcAddress(_glfw.win32.user32.instance, "GetTouchInputInfo");
+    _glfw.win32.user32.CloseTouchInputHandle = (PFN_CloseTouchInputHandle)
+        GetProcAddress(_glfw.win32.user32.instance, "CloseTouchInputHandle");
+    _glfw.win32.user32.RegisterTouchWindow = (PFN_RegisterTouchWindow)
+        GetProcAddress(_glfw.win32.user32.instance, "RegisterTouchWindow");
+    _glfw.win32.user32.UnregisterTouchWindow = (PFN_UnregisterTouchWindow)
+        GetProcAddress(_glfw.win32.user32.instance, "UnregisterTouchWindow");
+
+    if (_glfw.win32.user32.GetTouchInputInfo &&
+        _glfw.win32.user32.CloseTouchInputHandle &&
+        _glfw.win32.user32.RegisterTouchWindow &&
+        _glfw.win32.user32.UnregisterTouchWindow)
+    {
+        _glfw.win32.touch.available = GLFW_TRUE;
+    }
 
     _glfw.win32.dinput8.instance = LoadLibraryA("dinput8.dll");
     if (_glfw.win32.dinput8.instance)

--- a/src/win32_platform.h
+++ b/src/win32_platform.h
@@ -160,6 +160,34 @@ typedef enum PROCESS_DPI_AWARENESS
  #define DIDFT_OPTIONAL	0x80000000
 #endif
 
+#if WINVER < 0x0601
+
+#define WM_TOUCH 0x0240
+
+DECLARE_HANDLE(HTOUCHINPUT);
+
+typedef struct tagTOUCHINPUT
+{
+    LONG x;
+    LONG y;
+    HANDLE hSource;
+    DWORD dwID;
+    DWORD dwFlags;
+    DWORD dwMask;
+    DWORD dwTime;
+    ULONG_PTR dwExtraInfo;
+    DWORD cxContact;
+    DWORD cyContext;
+} TOUCHINPUT, *PTOUCHINPUT;
+
+#define TOUCH_COORD_TO_PIXEL(x) ((x) / 100)
+
+#define TOUCHEVENTF_MOVE    0x0001
+#define TOUCHEVENTF_DOWN    0x0002
+#define TOUCHEVENTF_UP      0x0004
+
+#endif /*WINVER < 0x0601*/
+
 // winmm.dll function pointer typedefs
 typedef DWORD (WINAPI * PFN_timeGetTime)(void);
 #define timeGetTime _glfw.win32.winmm.GetTime
@@ -177,8 +205,16 @@ typedef HRESULT (WINAPI * PFN_DirectInput8Create)(HINSTANCE,DWORD,REFIID,LPVOID*
 // user32.dll function pointer typedefs
 typedef BOOL (WINAPI * PFN_SetProcessDPIAware)(void);
 typedef BOOL (WINAPI * PFN_ChangeWindowMessageFilterEx)(HWND,UINT,DWORD,PCHANGEFILTERSTRUCT);
+typedef BOOL (WINAPI * PFN_GetTouchInputInfo)(HTOUCHINPUT,UINT,PTOUCHINPUT,int);
+typedef BOOL (WINAPI * PFN_CloseTouchInputHandle)(HTOUCHINPUT);
+typedef BOOL (WINAPI * PFN_RegisterTouchWindow)(HWND,LONG);
+typedef BOOL (WINAPI * PFN_UnregisterTouchWindow)(HWND);
 #define _glfw_SetProcessDPIAware _glfw.win32.user32.SetProcessDPIAware
 #define _glfw_ChangeWindowMessageFilterEx _glfw.win32.user32.ChangeWindowMessageFilterEx
+#define _glfw_GetTouchInputInfo     _glfw.win32.user32.GetTouchInputInfo
+#define _glfw_CloseTouchInputHandle _glfw.win32.user32.CloseTouchInputHandle
+#define _glfw_RegisterTouchWindow   _glfw.win32.user32.RegisterTouchWindow
+#define _glfw_UnregisterTouchWindow _glfw.win32.user32.UnregisterTouchWindow
 
 // dwmapi.dll function pointer typedefs
 typedef HRESULT (WINAPI * PFN_DwmIsCompositionEnabled)(BOOL*);
@@ -279,8 +315,17 @@ typedef struct _GLFWlibraryWin32
         HINSTANCE                       instance;
         PFN_SetProcessDPIAware          SetProcessDPIAware;
         PFN_ChangeWindowMessageFilterEx ChangeWindowMessageFilterEx;
+		PFN_GetTouchInputInfo     GetTouchInputInfo;
+        PFN_CloseTouchInputHandle CloseTouchInputHandle;
+        PFN_RegisterTouchWindow   RegisterTouchWindow;
+        PFN_UnregisterTouchWindow UnregisterTouchWindow;
     } user32;
 
+    struct {
+        GLFWbool        available;
+    } touch;
+
+    // dwmapi.dll
     struct {
         HINSTANCE                       instance;
         PFN_DwmIsCompositionEnabled     DwmIsCompositionEnabled;

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -2207,6 +2207,10 @@ void _glfwPlatformPostEmptyEvent(void)
     XFlush(_glfw.x11.display);
 }
 
+void _glfwPlatformSetTouchInput(_GLFWwindow* window, int enabled)
+{
+}
+
 void _glfwPlatformGetCursorPos(_GLFWwindow* window, double* xpos, double* ypos)
 {
     Window root, child;

--- a/tests/events.c
+++ b/tests/events.c
@@ -50,6 +50,7 @@ typedef struct
     GLFWwindow* window;
     int number;
     int closeable;
+    int touch;
 } Slot;
 
 static void usage(void)
@@ -203,6 +204,8 @@ static const char* get_action_name(int action)
             return "released";
         case GLFW_REPEAT:
             return "repeated";
+        case GLFW_MOVE:
+            return "moved";
     }
 
     return "caused unknown action";
@@ -393,6 +396,15 @@ static void key_callback(GLFWwindow* window, int key, int scancode, int action, 
 
     switch (key)
     {
+        case GLFW_KEY_T:
+        {
+            slot->touch = !slot->touch;
+            glfwSetInputMode(window, GLFW_TOUCH, slot->touch);
+
+            printf("(( touch %s ))\n", slot->touch ? "enabled" : "disabled");
+            break;
+        }
+
         case GLFW_KEY_C:
         {
             slot->closeable = !slot->closeable;
@@ -482,6 +494,20 @@ static void joystick_callback(int jid, int event)
     }
 }
 
+static void touch_callback(GLFWwindow* window, GLFWtouch* touchPoints, int count)
+{
+	printf("Priting info about all touch points");
+	int i;
+	for (i = 0; i < count; ++i) {
+		printf("%08x at %0.3f: Touch %i %s at position %0.3f %0.3f\n",
+			counter++,
+			glfwGetTime(),
+			touchPoints[i].id,
+			get_action_name(touchPoints[i].action),
+			touchPoints[i].x, touchPoints[i].y);
+	}
+}
+
 int main(int argc, char** argv)
 {
     Slot* slots;
@@ -553,6 +579,7 @@ int main(int argc, char** argv)
         char title[128];
 
         slots[i].closeable = GLFW_TRUE;
+        slots[i].touch = GLFW_FALSE;
         slots[i].number = i + 1;
 
         snprintf(title, sizeof(title), "Event Linter (Window %i)", slots[i].number);
@@ -597,6 +624,7 @@ int main(int argc, char** argv)
         glfwSetCharCallback(slots[i].window, char_callback);
         glfwSetCharModsCallback(slots[i].window, char_mods_callback);
         glfwSetDropCallback(slots[i].window, drop_callback);
+        glfwSetTouchCallback(slots[i].window, touch_callback);
 
         glfwMakeContextCurrent(slots[i].window);
         gladLoadGLLoader((GLADloadproc) glfwGetProcAddress);


### PR DESCRIPTION
I wanted touch support inside GLFW, for convenience over software setups like TUIO, so continued on your touch branch, and based on previous experiences with multi-touch applications, I have bundled all the touch points into one container before sending them out through the callbacks.

I have merged to "latest" and then later on to "master", so it's up-to-date for a convenient merge (or to new feature branch) and possibly then part of 3.3 (as I saw in an issue was the plan).
I have built this branch with Visual Studio 2015 x64, XCode 8.2.1, gcc-4.8(on two linux systems).

The actual touch support is, as with your previous commits, only supporting WM_TOUCH, i.e. Windows. If desired, I could gather effort on implementing support on x11 and cocoa side.