### PR TITLE
Handle X11 Selection* events despite NULL window

### DIFF
--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -957,6 +957,17 @@ static void processEvent(XEvent *event)
         return;
     }
 
+    if (event->type == SelectionClear)
+    {
+        handleSelectionClear(event);
+        return;
+    }
+    else if (event->type == SelectionRequest)
+    {
+        handleSelectionRequest(event);
+        return;
+    }
+
     window = findWindowByHandle(event->xany.window);
     if (window == NULL)
     {
@@ -1473,18 +1484,6 @@ static void processEvent(XEvent *event)
                 }
             }
 
-            return;
-        }
-
-        case SelectionClear:
-        {
-            handleSelectionClear(event);
-            return;
-        }
-
-        case SelectionRequest:
-        {
-            handleSelectionRequest(event);
             return;
         }
 


### PR DESCRIPTION
`processEvent` in `x11_window.c` currently discards events that can not be mapped to a current GLFW window. However, this breaks clipboard functionality by failing to respond to SelectionRequest and SelectionClear events.

This commit moves processing of these important clipboard events to before the NULL window test so that they are always considered.

Fixes #961 (tentatively; there is probably an underlying structural change to be made that fixes this properly).