### PR TITLE
Fix EGL support

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -139,7 +139,32 @@ extern "C" {
 
 /* Include the chosen client API headers.
  */
-#if defined(__APPLE__)
+#if defined(GLFW_INCLUDE_ES1)
+ #include <GLES/gl.h>
+ #if defined(GLFW_INCLUDE_GLEXT)
+  #include <GLES/glext.h>
+ #endif
+#elif defined(GLFW_INCLUDE_ES2)
+ #include <GLES2/gl2.h>
+ #if defined(GLFW_INCLUDE_GLEXT)
+  #include <GLES2/gl2ext.h>
+ #endif
+#elif defined(GLFW_INCLUDE_ES3)
+ #include <GLES3/gl3.h>
+ #if defined(GLFW_INCLUDE_GLEXT)
+  #include <GLES2/gl2ext.h>
+ #endif
+#elif defined(GLFW_INCLUDE_ES31)
+ #include <GLES3/gl31.h>
+ #if defined(GLFW_INCLUDE_GLEXT)
+  #include <GLES2/gl2ext.h>
+ #endif
+#elif defined(GLFW_INCLUDE_ES32)
+ #include <GLES3/gl32.h>
+ #if defined(GLFW_INCLUDE_GLEXT)
+  #include <GLES2/gl2ext.h>
+ #endif
+#elif defined(__APPLE__)
  #if defined(GLFW_INCLUDE_GLCOREARB)
   #include <OpenGL/gl3.h>
   #if defined(GLFW_INCLUDE_GLEXT)
@@ -157,31 +182,6 @@ extern "C" {
 #else
  #if defined(GLFW_INCLUDE_GLCOREARB)
   #include <GL/glcorearb.h>
- #elif defined(GLFW_INCLUDE_ES1)
-  #include <GLES/gl.h>
-  #if defined(GLFW_INCLUDE_GLEXT)
-   #include <GLES/glext.h>
-  #endif
- #elif defined(GLFW_INCLUDE_ES2)
-  #include <GLES2/gl2.h>
-  #if defined(GLFW_INCLUDE_GLEXT)
-   #include <GLES2/gl2ext.h>
-  #endif
- #elif defined(GLFW_INCLUDE_ES3)
-  #include <GLES3/gl3.h>
-  #if defined(GLFW_INCLUDE_GLEXT)
-   #include <GLES2/gl2ext.h>
-  #endif
- #elif defined(GLFW_INCLUDE_ES31)
-  #include <GLES3/gl31.h>
-  #if defined(GLFW_INCLUDE_GLEXT)
-   #include <GLES2/gl2ext.h>
-  #endif
- #elif defined(GLFW_INCLUDE_ES32)
-  #include <GLES3/gl32.h>
-  #if defined(GLFW_INCLUDE_GLEXT)
-   #include <GLES2/gl2ext.h>
-  #endif
  #elif !defined(GLFW_INCLUDE_NONE)
   #include <GL/gl.h>
   #if defined(GLFW_INCLUDE_GLEXT)

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -423,6 +423,8 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
 
 - (id)makeBackingLayer
 {
+    if (!window->ns.layer)
+        window->ns.layer = [super makeBackingLayer];
     return window->ns.layer;
 }
 


### PR DESCRIPTION
This adds support for using GLFW with EGL backends on macOS. While EGL isn't available by default on macOS, there are third-party implementations like [SwiftShader](https://github.com/google/swiftshader).

EGL is typically used in conjunction with OpenGL ES, so we're now preferring inclusion of these headers when `GLFW_INCLUDE_ES*` is defined by moving them before the `#if __APPLE__` check.

Additionally, the addition of [MoltenVK support](https://github.com/glfw/glfw/commit/e94d16667b1696e90da6c1b5c551815b0f873534) added an override to `makeBackingLayer`. In non-Vulkan mode, this means that we are returning `nil` from that function. The NSGL implementation apparently creates this layer manually later on, but other OpenGL backends don't necessarily do that.