### PR TITLE
Support for attention request

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ information on what to include when reporting a bug.
 
 ## Changelog
 
+- Added `glfwRequestWindowAttention` function that request attention to the
+  non-focused or minimized window
 - Added `glfwGetKeyScancode` function that allows retrieving platform dependent
   scancodes for keys (#830)
 - Added `glfwSetWindowMaximizeCallback` and `GLFWwindowmaximizefun` for

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -79,6 +79,7 @@ int main(void)
     GLFWwindow* window;
     GLuint vertex_buffer, vertex_shader, fragment_shader, program;
     GLint mvp_location, vpos_location, vcol_location;
+    double start;
 
     glfwSetErrorCallback(error_callback);
 
@@ -131,11 +132,17 @@ int main(void)
     glVertexAttribPointer(vcol_location, 3, GL_FLOAT, GL_FALSE,
                           sizeof(vertices[0]), (void*) (sizeof(float) * 2));
 
+    start = glfwGetTime();
     while (!glfwWindowShouldClose(window))
     {
         float ratio;
         int width, height;
         mat4x4 m, p, mvp;
+
+        if (glfwGetTime() - start > 10.0) {
+            glfwRequestWindowAttention(window);
+            start = glfwGetTime();
+        }
 
         glfwGetFramebufferSize(window, &width, &height);
         ratio = width / (float) height;

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -79,7 +79,6 @@ int main(void)
     GLFWwindow* window;
     GLuint vertex_buffer, vertex_shader, fragment_shader, program;
     GLint mvp_location, vpos_location, vcol_location;
-    double start;
 
     glfwSetErrorCallback(error_callback);
 
@@ -132,17 +131,11 @@ int main(void)
     glVertexAttribPointer(vcol_location, 3, GL_FLOAT, GL_FALSE,
                           sizeof(vertices[0]), (void*) (sizeof(float) * 2));
 
-    start = glfwGetTime();
     while (!glfwWindowShouldClose(window))
     {
         float ratio;
         int width, height;
         mat4x4 m, p, mvp;
-
-        if (glfwGetTime() - start > 10.0) {
-            glfwRequestWindowAttention(window);
-            start = glfwGetTime();
-        }
 
         glfwGetFramebufferSize(window, &width, &height);
         ratio = width / (float) height;

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -2698,23 +2698,6 @@ GLFWAPI void glfwMaximizeWindow(GLFWwindow* window);
  */
 GLFWAPI void glfwShowWindow(GLFWwindow* window);
 
-/*! @brief Request attention to the specified window.
- *
- *  This function makes the specified window to request attention.
- *
- *  @param[in] window The window to request attention.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwRequestWindowAttention(GLFWwindow* window);
-
 /*! @brief Hides the specified window.
  *
  *  This function hides the specified window if it was previously visible.  If
@@ -2767,6 +2750,26 @@ GLFWAPI void glfwHideWindow(GLFWwindow* window);
  *  @ingroup window
  */
 GLFWAPI void glfwFocusWindow(GLFWwindow* window);
+
+/*! @brief Request attention to the specified window.
+ *
+ *  This function makes the specified window to request attention.
+ *
+ *  @param[in] window The window to request attention.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @remark @macos The attention request will be made for the application and 
+ *  not the window passed in the argument.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @since Added in version 3.3.
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwRequestWindowAttention(GLFWwindow* window);
 
 /*! @brief Returns the monitor that the window uses for full screen mode.
  *

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -2698,6 +2698,8 @@ GLFWAPI void glfwMaximizeWindow(GLFWwindow* window);
  */
 GLFWAPI void glfwShowWindow(GLFWwindow* window);
 
+GLFWAPI void glfwRequestWindowAttention(GLFWwindow* window);
+
 /*! @brief Hides the specified window.
  *
  *  This function hides the specified window if it was previously visible.  If

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -2698,6 +2698,21 @@ GLFWAPI void glfwMaximizeWindow(GLFWwindow* window);
  */
 GLFWAPI void glfwShowWindow(GLFWwindow* window);
 
+/*! @brief Request attention to the specified window.
+ *
+ *  This function makes the specified window to request attention.
+ *
+ *  @param[in] window The window to request attention.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @since Added in version 3.3.
+ *
+ *  @ingroup window
+ */
 GLFWAPI void glfwRequestWindowAttention(GLFWwindow* window);
 
 /*! @brief Hides the specified window.

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -1272,6 +1272,10 @@ void _glfwPlatformShowWindow(_GLFWwindow* window)
     [window->ns.object orderFront:nil];
 }
 
+void _glfwPlatformRequestWindowAttention(_GLFWwindow* window)
+{
+}
+
 void _glfwPlatformHideWindow(_GLFWwindow* window)
 {
     [window->ns.object orderOut:nil];

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -1272,14 +1272,14 @@ void _glfwPlatformShowWindow(_GLFWwindow* window)
     [window->ns.object orderFront:nil];
 }
 
-void _glfwPlatformRequestWindowAttention(_GLFWwindow* window)
-{
-    [window->ns.object requestUserAttention:NSInformationalRequest];
-}
-
 void _glfwPlatformHideWindow(_GLFWwindow* window)
 {
     [window->ns.object orderOut:nil];
+}
+
+void _glfwPlatformRequestWindowAttention(_GLFWwindow* window)
+{
+    [NSApp requestUserAttention:NSInformationalRequest];
 }
 
 void _glfwPlatformFocusWindow(_GLFWwindow* window)

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -1274,6 +1274,7 @@ void _glfwPlatformShowWindow(_GLFWwindow* window)
 
 void _glfwPlatformRequestWindowAttention(_GLFWwindow* window)
 {
+    [window->ns.object requestUserAttention:NSInformationalRequest];
 }
 
 void _glfwPlatformHideWindow(_GLFWwindow* window)

--- a/src/internal.h
+++ b/src/internal.h
@@ -629,6 +629,7 @@ void _glfwPlatformIconifyWindow(_GLFWwindow* window);
 void _glfwPlatformRestoreWindow(_GLFWwindow* window);
 void _glfwPlatformMaximizeWindow(_GLFWwindow* window);
 void _glfwPlatformShowWindow(_GLFWwindow* window);
+void _glfwPlatformRequestWindowAttention(_GLFWwindow* window);
 void _glfwPlatformHideWindow(_GLFWwindow* window);
 void _glfwPlatformFocusWindow(_GLFWwindow* window);
 void _glfwPlatformSetWindowMonitor(_GLFWwindow* window, _GLFWmonitor* monitor, int xpos, int ypos, int width, int height, int refreshRate);

--- a/src/mir_window.c
+++ b/src/mir_window.c
@@ -567,6 +567,10 @@ void _glfwPlatformShowWindow(_GLFWwindow* window)
     mir_surface_spec_release(spec);
 }
 
+void _glfwPlatformRequestWindowAttention(_GLFWwindow* window)
+{
+}
+
 void _glfwPlatformFocusWindow(_GLFWwindow* window)
 {
     _glfwInputError(GLFW_PLATFORM_ERROR,

--- a/src/null_window.c
+++ b/src/null_window.c
@@ -172,6 +172,11 @@ void _glfwPlatformShowWindow(_GLFWwindow* window)
 {
 }
 
+
+void _glfwPlatformRequestWindowAttention(_GLFWwindow* window)
+{
+}
+
 void _glfwPlatformUnhideWindow(_GLFWwindow* window)
 {
 }

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -1311,6 +1311,11 @@ void _glfwPlatformShowWindow(_GLFWwindow* window)
     ShowWindow(window->win32.handle, SW_SHOW);
 }
 
+void _glfwPlatformRequestWindowAttention(_GLFWwindow* window)
+{
+    FlashWindow(window->win32.handle, TRUE);
+}
+
 void _glfwPlatformHideWindow(_GLFWwindow* window)
 {
     ShowWindow(window->win32.handle, SW_HIDE);

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -1311,14 +1311,14 @@ void _glfwPlatformShowWindow(_GLFWwindow* window)
     ShowWindow(window->win32.handle, SW_SHOW);
 }
 
-void _glfwPlatformRequestWindowAttention(_GLFWwindow* window)
-{
-    FlashWindow(window->win32.handle, TRUE);
-}
-
 void _glfwPlatformHideWindow(_GLFWwindow* window)
 {
     ShowWindow(window->win32.handle, SW_HIDE);
+}
+
+void _glfwPlatformRequestWindowAttention(_GLFWwindow* window)
+{
+    FlashWindow(window->win32.handle, TRUE);
 }
 
 void _glfwPlatformFocusWindow(_GLFWwindow* window)

--- a/src/window.c
+++ b/src/window.c
@@ -675,6 +675,16 @@ GLFWAPI void glfwShowWindow(GLFWwindow* handle)
     _glfwPlatformFocusWindow(window);
 }
 
+GLFWAPI void glfwRequestWindowAttention(GLFWwindow* handle)
+{
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    assert(window != NULL);
+
+    _GLFW_REQUIRE_INIT();
+
+    _glfwPlatformRequestWindowAttention(window);
+}
+
 GLFWAPI void glfwHideWindow(GLFWwindow* handle)
 {
     _GLFWwindow* window = (_GLFWwindow*) handle;

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -589,6 +589,10 @@ void _glfwPlatformShowWindow(_GLFWwindow* window)
     }
 }
 
+void _glfwPlatformRequestWindowAttention(_GLFWwindow* window)
+{
+}
+
 void _glfwPlatformHideWindow(_GLFWwindow* window)
 {
     if (!window->monitor)

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -589,10 +589,6 @@ void _glfwPlatformShowWindow(_GLFWwindow* window)
     }
 }
 
-void _glfwPlatformRequestWindowAttention(_GLFWwindow* window)
-{
-}
-
 void _glfwPlatformHideWindow(_GLFWwindow* window)
 {
     if (!window->monitor)
@@ -601,6 +597,10 @@ void _glfwPlatformHideWindow(_GLFWwindow* window)
             wl_shell_surface_destroy(window->wl.shellSurface);
         window->wl.visible = GLFW_FALSE;
     }
+}
+
+void _glfwPlatformRequestWindowAttention(_GLFWwindow* window)
+{
 }
 
 void _glfwPlatformFocusWindow(_GLFWwindow* window)

--- a/src/x11_init.c
+++ b/src/x11_init.c
@@ -438,6 +438,8 @@ static void detectEWMH(void)
         getSupportedAtom(supportedAtoms, atomCount, "_NET_WM_STATE_MAXIMIZED_VERT");
     _glfw.x11.NET_WM_STATE_MAXIMIZED_HORZ =
         getSupportedAtom(supportedAtoms, atomCount, "_NET_WM_STATE_MAXIMIZED_HORZ");
+    _glfw.x11.NET_WM_STATE_DEMANDS_ATTENTION =
+        getSupportedAtom(supportedAtoms, atomCount, "_NET_WM_STATE_DEMANDS_ATTENTION");
     _glfw.x11.NET_WM_FULLSCREEN_MONITORS =
         getSupportedAtom(supportedAtoms, atomCount, "_NET_WM_FULLSCREEN_MONITORS");
     _glfw.x11.NET_WM_WINDOW_TYPE =

--- a/src/x11_platform.h
+++ b/src/x11_platform.h
@@ -194,6 +194,7 @@ typedef struct _GLFWlibraryX11
     Atom            NET_WM_STATE_FULLSCREEN;
     Atom            NET_WM_STATE_MAXIMIZED_VERT;
     Atom            NET_WM_STATE_MAXIMIZED_HORZ;
+    Atom            NET_WM_STATE_DEMANDS_ATTENTION;
     Atom            NET_WM_BYPASS_COMPOSITOR;
     Atom            NET_WM_FULLSCREEN_MONITORS;
     Atom            NET_ACTIVE_WINDOW;

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -2072,6 +2072,24 @@ void _glfwPlatformShowWindow(_GLFWwindow* window)
     waitForVisibilityNotify(window);
 }
 
+void _glfwPlatformRequestWindowAttention(_GLFWwindow* window)
+{
+    XEvent xev;
+
+    Atom wm_state = XInternAtom(_glfw.x11.display, "_NET_WM_STATE", False);
+    Atom wm_attention = XInternAtom(_glfw.x11.display, "_NET_WM_STATE_DEMANDS_ATTENTION", False);
+
+    memset(&xev, 0, sizeof(xev));
+    xev.type = ClientMessage;
+    xev.xclient.window = window->x11.handle;
+    xev.xclient.message_type = wm_state;
+    xev.xclient.format = 32;
+    xev.xclient.data.l[0] = 1; /* _NET_WM_STATE_ADD */
+    xev.xclient.data.l[1] = wm_attention;
+
+    XSendEvent(_glfw.x11.display, DefaultRootWindow(_glfw.x11.display), False, SubstructureRedirectMask | SubstructureNotifyMask, &xev);
+}
+
 void _glfwPlatformHideWindow(_GLFWwindow* window)
 {
     XUnmapWindow(_glfw.x11.display, window->x11.handle);

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -2072,6 +2072,12 @@ void _glfwPlatformShowWindow(_GLFWwindow* window)
     waitForVisibilityNotify(window);
 }
 
+void _glfwPlatformHideWindow(_GLFWwindow* window)
+{
+    XUnmapWindow(_glfw.x11.display, window->x11.handle);
+    XFlush(_glfw.x11.display);
+}
+
 void _glfwPlatformRequestWindowAttention(_GLFWwindow* window)
 {
     XEvent xev;
@@ -2085,12 +2091,6 @@ void _glfwPlatformRequestWindowAttention(_GLFWwindow* window)
     xev.xclient.data.l[1] = _glfw.x11.NET_WM_STATE_DEMANDS_ATTENTION;
 
     XSendEvent(_glfw.x11.display, DefaultRootWindow(_glfw.x11.display), False, SubstructureRedirectMask | SubstructureNotifyMask, &xev);
-}
-
-void _glfwPlatformHideWindow(_GLFWwindow* window)
-{
-    XUnmapWindow(_glfw.x11.display, window->x11.handle);
-    XFlush(_glfw.x11.display);
 }
 
 void _glfwPlatformFocusWindow(_GLFWwindow* window)

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -2076,16 +2076,13 @@ void _glfwPlatformRequestWindowAttention(_GLFWwindow* window)
 {
     XEvent xev;
 
-    Atom wm_state = XInternAtom(_glfw.x11.display, "_NET_WM_STATE", False);
-    Atom wm_attention = XInternAtom(_glfw.x11.display, "_NET_WM_STATE_DEMANDS_ATTENTION", False);
-
     memset(&xev, 0, sizeof(xev));
     xev.type = ClientMessage;
     xev.xclient.window = window->x11.handle;
-    xev.xclient.message_type = wm_state;
+    xev.xclient.message_type = _glfw.x11.NET_WM_STATE;
     xev.xclient.format = 32;
     xev.xclient.data.l[0] = _NET_WM_STATE_ADD;
-    xev.xclient.data.l[1] = wm_attention;
+    xev.xclient.data.l[1] = _glfw.x11.NET_WM_STATE_DEMANDS_ATTENTION;
 
     XSendEvent(_glfw.x11.display, DefaultRootWindow(_glfw.x11.display), False, SubstructureRedirectMask | SubstructureNotifyMask, &xev);
 }

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -2084,7 +2084,7 @@ void _glfwPlatformRequestWindowAttention(_GLFWwindow* window)
     xev.xclient.window = window->x11.handle;
     xev.xclient.message_type = wm_state;
     xev.xclient.format = 32;
-    xev.xclient.data.l[0] = 1; /* _NET_WM_STATE_ADD */
+    xev.xclient.data.l[0] = _NET_WM_STATE_ADD;
     xev.xclient.data.l[1] = wm_attention;
 
     XSendEvent(_glfw.x11.display, DefaultRootWindow(_glfw.x11.display), False, SubstructureRedirectMask | SubstructureNotifyMask, &xev);


### PR DESCRIPTION
This pull contains the implementation of attention request for X11.

The added function was ```glfwRequestWindowAttention```.

The example ```simple.c``` was updated to demonstrate the functionality.

This patch is related with the issue https://github.com/glfw/glfw/issues/732.