### PR TITLE
Add support for querying work area

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ information on what to include when reporting a bug.
 
 ## Changelog
 
+- Added `glfwGetMonitorWorkarea` function for querying the monitor work area
 - Added `glfwGetKeyScancode` function that allows retrieving platform dependent
   scancodes for keys (#830)
 - Added `glfwSetWindowMaximizeCallback` and `GLFWwindowmaximizefun` for

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -79,6 +79,7 @@ int main(void)
     GLFWwindow* window;
     GLuint vertex_buffer, vertex_shader, fragment_shader, program;
     GLint mvp_location, vpos_location, vcol_location;
+    int workarea_x, workarea_y, workarea_width, workarea_height;
 
     glfwSetErrorCallback(error_callback);
 
@@ -131,6 +132,8 @@ int main(void)
     glVertexAttribPointer(vcol_location, 3, GL_FLOAT, GL_FALSE,
                           sizeof(vertices[0]), (void*) (sizeof(float) * 2));
 
+    glfwGetMonitorWorkarea(glfwGetPrimaryMonitor(), &workarea_x, &workarea_y, &workarea_width, &workarea_height);
+    printf("Monitor work area: %d, %d, %d, %d\n", workarea_x, workarea_y, workarea_width, workarea_height);
     while (!glfwWindowShouldClose(window))
     {
         float ratio;

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -1719,6 +1719,31 @@ GLFWAPI GLFWmonitor* glfwGetPrimaryMonitor(void);
  */
 GLFWAPI void glfwGetMonitorPos(GLFWmonitor* monitor, int* xpos, int* ypos);
 
+/*! @brief Returns the work area of the monitor.
+ *
+ *  This function returns the position, in screen coordinates, of the upper-left
+ *  corner of the specified monitor.
+ *
+ *  Any or all of the position arguments may be `NULL`.  If an error occurs, all
+ *  non-`NULL` position arguments will be set to zero.
+ *
+ *  @param[in] monitor The monitor to query.
+ *  @param[out] xpos Where to store the monitor x-coordinate, or `NULL`.
+ *  @param[out] ypos Where to store the monitor y-coordinate, or `NULL`.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref monitor_properties
+ *
+ *  @since Added in version 3.0.
+ *
+ *  @ingroup monitor
+ */
+GLFWAPI void glfwGetMonitorWorkarea(GLFWmonitor* monitor, int* xpos, int* ypos, int *width, int *height);
+
 /*! @brief Returns the physical size of the monitor.
  *
  *  This function returns the size, in millimetres, of the display area of the

--- a/src/cocoa_monitor.m
+++ b/src/cocoa_monitor.m
@@ -372,10 +372,10 @@ void _glfwPlatformGetMonitorWorkarea(_GLFWmonitor* monitor, int* xpos, int* ypos
 
     NSRect frameRect = [[NSScreen resultScreen] visibleFrame];
 
-    *xpos = NSMinX(frameRect)
-    *ypos = NSMinY(frameRect)
-    *width = NSMaxX(frameRect)
-    *height = NSMaxY(frameRect)
+    *xpos = NSMinX(frameRect);
+    *ypos = NSMinY(frameRect);
+    *width = NSMaxX(frameRect);
+    *height = NSMaxY(frameRect);
 }
 
 GLFWvidmode* _glfwPlatformGetVideoModes(_GLFWmonitor* monitor, int* count)

--- a/src/cocoa_monitor.m
+++ b/src/cocoa_monitor.m
@@ -360,6 +360,10 @@ void _glfwPlatformGetMonitorPos(_GLFWmonitor* monitor, int* xpos, int* ypos)
         *ypos = (int) bounds.origin.y;
 }
 
+void _glfwPlatformGetMonitorWorkarea(_GLFWmonitor* monitor, int* xpos, int* ypos, int *width, int *height)
+{
+}
+
 GLFWvidmode* _glfwPlatformGetVideoModes(_GLFWmonitor* monitor, int* count)
 {
     CFArrayRef modes;

--- a/src/cocoa_monitor.m
+++ b/src/cocoa_monitor.m
@@ -362,6 +362,20 @@ void _glfwPlatformGetMonitorPos(_GLFWmonitor* monitor, int* xpos, int* ypos)
 
 void _glfwPlatformGetMonitorWorkarea(_GLFWmonitor* monitor, int* xpos, int* ypos, int *width, int *height)
 {
+    NSScreen *resultScreen;
+    for (NSScreen *screen in [NSScreen screens]) {
+        if ([[[screen deviceDescription] valueForKey:@"NSScreenNumber"] intValue] == monitor->ns.displayID) {
+            resultScreen = screen;
+            break;
+        }
+    }
+
+    NSRect frameRect = [[NSScreen resultScreen] visibleFrame];
+
+    *xpos = NSMinX(frameRect)
+    *ypos = NSMinY(frameRect)
+    *width = NSMaxX(frameRect)
+    *height = NSMaxY(frameRect)
 }
 
 GLFWvidmode* _glfwPlatformGetVideoModes(_GLFWmonitor* monitor, int* count)

--- a/src/internal.h
+++ b/src/internal.h
@@ -597,6 +597,7 @@ const char* _glfwPlatformGetKeyName(int key, int scancode);
 int _glfwPlatformGetKeyScancode(int key);
 
 void _glfwPlatformGetMonitorPos(_GLFWmonitor* monitor, int* xpos, int* ypos);
+void _glfwPlatformGetMonitorWorkarea(_GLFWmonitor* monitor, int* xpos, int* ypos, int *width, int *height);
 GLFWvidmode* _glfwPlatformGetVideoModes(_GLFWmonitor* monitor, int* count);
 void _glfwPlatformGetVideoMode(_GLFWmonitor* monitor, GLFWvidmode* mode);
 void _glfwPlatformGetGammaRamp(_GLFWmonitor* monitor, GLFWgammaramp* ramp);

--- a/src/mir_monitor.c
+++ b/src/mir_monitor.c
@@ -121,6 +121,10 @@ static void FillInRGBBitsFromPixelFormat(GLFWvidmode* mode, const MirPixelFormat
     }
 }
 
+void _glfwPlatformGetMonitorWorkarea(_GLFWmonitor* monitor, int* xpos, int* ypos, int *width, int *height)
+{
+}
+
 GLFWvidmode* _glfwPlatformGetVideoModes(_GLFWmonitor* monitor, int* found)
 {
     int i;

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -296,6 +296,25 @@ GLFWAPI void glfwGetMonitorPos(GLFWmonitor* handle, int* xpos, int* ypos)
     _glfwPlatformGetMonitorPos(monitor, xpos, ypos);
 }
 
+GLFWAPI void glfwGetMonitorWorkarea(GLFWmonitor* handle, int* xpos, int* ypos, int* width, int* height)
+{
+    _GLFWmonitor* monitor = (_GLFWmonitor*) handle;
+    assert(monitor != NULL);
+
+    if (xpos)
+        *xpos = 0;
+    if (ypos)
+        *ypos = 0;
+    if (width)
+        *width = 0;
+    if (width)
+        *width = 0;
+
+    _GLFW_REQUIRE_INIT();
+
+    _glfwPlatformGetMonitorWorkarea(monitor, xpos, ypos, width, height);
+}
+
 GLFWAPI void glfwGetMonitorPhysicalSize(GLFWmonitor* handle, int* widthMM, int* heightMM)
 {
     _GLFWmonitor* monitor = (_GLFWmonitor*) handle;

--- a/src/null_monitor.c
+++ b/src/null_monitor.c
@@ -36,6 +36,10 @@ void _glfwPlatformGetMonitorPos(_GLFWmonitor* monitor, int* xpos, int* ypos)
 {
 }
 
+void _glfwPlatformGetMonitorWorkarea(_GLFWmonitor* monitor, int* xpos, int* ypos, int *width, int *height)
+{
+}
+
 GLFWvidmode* _glfwPlatformGetVideoModes(_GLFWmonitor* monitor, int* found)
 {
     return NULL;

--- a/src/win32_monitor.c
+++ b/src/win32_monitor.c
@@ -291,6 +291,36 @@ void _glfwPlatformGetMonitorPos(_GLFWmonitor* monitor, int* xpos, int* ypos)
         *ypos = settings.dmPosition.y;
 }
 
+static BOOL CALLBACK MonitorEnumProc(HMONITOR hMonitor, HDC hdcMonitor, LPRECT lprcMonitor, LPARAM dwData)
+{
+    RECT *workarea = (RECT *)dwData;
+    MONITORINFO monitorInfo;
+    GetMonitorInfo(hMonitor, &monitorInfo);
+    workarea->left = monitorInfo.rcWork.left;
+    workarea->top = monitorInfo.rcWork.top;
+    workarea->right = monitorInfo.rcWork.right;
+    workarea->bottom = monitorInfo.rcWork.bottom;
+    return TRUE;
+}
+
+void _glfwPlatformGetMonitorWorkarea(_GLFWmonitor* monitor, int* xpos, int* ypos, int *width, int *height)
+{
+    HDC dc;
+    RECT workarea;
+
+    dc = CreateDCW(L"DISPLAY", monitor->win32.adapterName, NULL, NULL);
+
+    if (!EnumDisplayMonitors(dc, NULL, MonitorEnumProc, (LPARAM)&workarea))
+        return;
+
+    DeleteDC(dc);
+
+    *xpos = workarea.left;
+    *ypos = workarea.top;
+    *width = workarea.right;
+    *height = workarea.bottom;
+}
+
 GLFWvidmode* _glfwPlatformGetVideoModes(_GLFWmonitor* monitor, int* count)
 {
     int modeIndex = 0, size = 0;

--- a/src/win32_monitor.c
+++ b/src/win32_monitor.c
@@ -295,6 +295,7 @@ static BOOL CALLBACK MonitorEnumProc(HMONITOR hMonitor, HDC hdcMonitor, LPRECT l
 {
     RECT *workarea = (RECT *)dwData;
     MONITORINFO monitorInfo;
+    monitorInfo.cbSize = sizeof(MONITORINFO);
     GetMonitorInfo(hMonitor, &monitorInfo);
     workarea->left = monitorInfo.rcWork.left;
     workarea->top = monitorInfo.rcWork.top;

--- a/src/x11_init.c
+++ b/src/x11_init.c
@@ -444,6 +444,8 @@ static void detectEWMH(void)
         getSupportedAtom(supportedAtoms, atomCount, "_NET_WM_WINDOW_TYPE");
     _glfw.x11.NET_WM_WINDOW_TYPE_NORMAL =
         getSupportedAtom(supportedAtoms, atomCount, "_NET_WM_WINDOW_TYPE_NORMAL");
+    _glfw.x11.NET_WORKAREA =
+        getSupportedAtom(supportedAtoms, atomCount, "_NET_WORKAREA");
     _glfw.x11.NET_ACTIVE_WINDOW =
         getSupportedAtom(supportedAtoms, atomCount, "_NET_ACTIVE_WINDOW");
     _glfw.x11.NET_FRAME_EXTENTS =

--- a/src/x11_monitor.c
+++ b/src/x11_monitor.c
@@ -338,6 +338,38 @@ void _glfwPlatformGetMonitorPos(_GLFWmonitor* monitor, int* xpos, int* ypos)
     }
 }
 
+void _glfwPlatformGetMonitorWorkarea(_GLFWmonitor* monitor, int* xpos, int* ypos, int *width, int *height)
+{
+    if (_glfw.x11.randr.available && !_glfw.x11.randr.monitorBroken)
+    {
+        Atom workarea = XInternAtom(_glfw.x11.display, "_NET_WORKAREA", True);
+        Atom type;
+        int format;
+        unsigned long num;
+        unsigned long bytesLeft;
+        unsigned long *workareaValues;
+        unsigned char *data = NULL;
+
+        if(workarea == None)
+            return;
+
+        if (XGetWindowProperty(_glfw.x11.display, _glfw.x11.root, workarea, 0,
+                               4 * 32, False, AnyPropertyType, &type, &format,
+                               &num, &bytesLeft, &data) != Success) {
+            return;
+        }
+
+        if(type == None || format == 0 || bytesLeft || num % 4)
+            return;
+
+        workareaValues = (unsigned long*)data;
+        *xpos = workareaValues[0];
+        *ypos = workareaValues[1];
+        *width = workareaValues[2];
+        *height = workareaValues[3];
+    }
+}
+
 GLFWvidmode* _glfwPlatformGetVideoModes(_GLFWmonitor* monitor, int* count)
 {
     GLFWvidmode* result;

--- a/src/x11_monitor.c
+++ b/src/x11_monitor.c
@@ -342,31 +342,15 @@ void _glfwPlatformGetMonitorWorkarea(_GLFWmonitor* monitor, int* xpos, int* ypos
 {
     if (_glfw.x11.randr.available && !_glfw.x11.randr.monitorBroken)
     {
-        Atom workarea = XInternAtom(_glfw.x11.display, "_NET_WORKAREA", True);
-        Atom type;
-        int format;
-        unsigned long num;
-        unsigned long bytesLeft;
-        unsigned long *workareaValues;
-        unsigned char *data = NULL;
+        Atom* extents = NULL;
 
-        if(workarea == None)
-            return;
+        _glfwGetWindowPropertyX11(_glfw.x11.root, _glfw.x11.NET_WORKAREA, XA_CARDINAL, (unsigned char**) &extents);
 
-        if (XGetWindowProperty(_glfw.x11.display, _glfw.x11.root, workarea, 0,
-                               4 * 32, False, AnyPropertyType, &type, &format,
-                               &num, &bytesLeft, &data) != Success) {
-            return;
-        }
-
-        if(type == None || format == 0 || bytesLeft || num % 4)
-            return;
-
-        workareaValues = (unsigned long*)data;
-        *xpos = workareaValues[0];
-        *ypos = workareaValues[1];
-        *width = workareaValues[2];
-        *height = workareaValues[3];
+        *xpos = extents[0];
+        *ypos = extents[1];
+        *width = extents[2];
+        *height = extents[3];
+        XFree(extents);
     }
 }
 

--- a/src/x11_platform.h
+++ b/src/x11_platform.h
@@ -195,6 +195,7 @@ typedef struct _GLFWlibraryX11
     Atom            NET_WM_STATE_MAXIMIZED_HORZ;
     Atom            NET_WM_BYPASS_COMPOSITOR;
     Atom            NET_WM_FULLSCREEN_MONITORS;
+    Atom            NET_WORKAREA;
     Atom            NET_ACTIVE_WINDOW;
     Atom            NET_FRAME_EXTENTS;
     Atom            NET_REQUEST_FRAME_EXTENTS;


### PR DESCRIPTION
This patch has the implementation for querying the work area on X11 and Windows.

- **The X11 implementation**. I believe everything is done with this implementation. I tested with single monitor, but since the monitor is passed directly to the function, I don't think there will be any problem with it.

- **The Windows implementation**. This implementation surely needs test on multiple monitors. I tested with a single monitor, and the work area retrieved was correct. However, we need to make sure that the ```HMONITOR``` that we grab the information from matches the ```_GLFWmonitor``` passed to the function.

- **The Cocoa implementation**. The implementation for Cocoa is a draft and needs to be test and reviewed.

This patch is related to the issue https://github.com/glfw/glfw/issues/920.