### PR TITLE
Update serial on Wayland button callback

### DIFF
--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -109,6 +109,8 @@ static void pointerHandleButton(void* data,
     if (!window)
         return;
 
+    _glfw.wl.pointerSerial = serial;
+
     /* Makes left, right and middle 0, 1 and 2. Overall order follows evdev
      * codes. */
     glfwButton = button - BTN_LEFT;


### PR DESCRIPTION
This is very important, because the serial used in the Wayland button callback wasn't being updated, making functions like ```wl_shell_surface_*``` useless inside the GLFW callbacks started by the Wayland backend.

The operations for moving and resizing a window using ```wl_shell_surface_move``` and ```wl_shell_surface_resize``` expect an update serial, which is fixed by this patch.

This is related to the issues https://github.com/glfw/glfw/issues/923 and https://github.com/glfw/glfw/issues/990.