### PR TITLE
Convert Linux joystick code to using the evdev API

### DIFF
--- a/src/linux_joystick.h
+++ b/src/linux_joystick.h
@@ -27,27 +27,34 @@
 #ifndef _glfw3_linux_joystick_h_
 #define _glfw3_linux_joystick_h_
 
+#include <linux/input.h>
+#include <linux/limits.h>
 #include <regex.h>
 
 #define _GLFW_PLATFORM_JOYSTICK_STATE         _GLFWjoystickLinux linjs
 #define _GLFW_PLATFORM_LIBRARY_JOYSTICK_STATE _GLFWlibraryLinux  linjs
 
+#define HATS_MAX ((ABS_HAT3Y - ABS_HAT0X) / 2)
 
 // Linux-specific joystick data
 //
 typedef struct _GLFWjoystickLinux
 {
-    int             fd;
-    char*           path;
+    int                  fd;
+    char                 path[PATH_MAX];
+    int                  keyMap[KEY_MAX];
+    int                  absMap[ABS_MAX];
+    struct input_absinfo absInfo[ABS_MAX];
+    int                  hats[HATS_MAX][2];
 } _GLFWjoystickLinux;
 
 // Linux-specific joystick API data
 //
 typedef struct _GLFWlibraryLinux
 {
-    int             inotify;
-    int             watch;
-    regex_t         regex;
+    int                  inotify;
+    int                  watch;
+    regex_t              regex;
 } _GLFWlibraryLinux;
 
 


### PR DESCRIPTION
* Convert Linux joystick code to using the evdev API
* Add support for hats on Linux

I'd recently experimented with swapping over from SDL2 to glfw and ran into the fact that hats are currently unsupported on Linux. I found a few issues on here which seem to have came to the same conclusion as myself; there is no good way to support them without converting over to the evdev API. I've done this conversion, and added support for hats.

As a disclaimer, I have no prior experience with evdev, so please triple check this change.

One concern of mine is that I'm not at all honoring the `flat` member from `struct input_absinfo`. It seems while the `fuzz` member is honored by the kernel, `flat` is expected to be handled by userspace code. However, I don't really know how exactly it should be used.