### PR TITLE
Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,17 @@ os:
     - linux
     - osx
 sudo: false
+dist: trusty
 addons:
     apt:
         sources:
             - kubuntu-backports
         packages:
             - cmake
+            - libxrandr-dev
+            - libxinerama-dev
+            - libxcursor-dev
+            - libxi-dev
 env:
     - BUILD_SHARED_LIBS=ON
     - BUILD_SHARED_LIBS=OFF


### PR DESCRIPTION
Hi @elmindreda !

I have no idea how this happened, but travis changed something, which resulted in the cmake version of the default image being 2.8.7 rather than 2.8.12, which is insufficient for building glfw.
This affected us with magnum aswell (see https://github.com/mosra/magnum/pull/203), and since we build glfw as a dependency on travis aswell, I thought I'd contribute our fixes here, too.

Cheers, Jonathan.