### PR TITLE
Fix type conversion between NSPoint and CGPoint

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -1030,7 +1030,9 @@ static GLFWbool createNativeWindow(_GLFWwindow* window,
     else
     {
         [window->ns.object center];
-        _glfw.ns.cascadePoint = [window->ns.object cascadeTopLeftFromPoint:_glfw.ns.cascadePoint];
+        _glfw.ns.cascadePoint =
+            NSPointToCGPoint([window->ns.object cascadeTopLeftFromPoint:
+                              NSPointFromCGPoint(_glfw.ns.cascadePoint)]);
 
         if (wndconfig->resizable)
         {


### PR DESCRIPTION
An error occured at cocoa_window.m:
glfw/src/cocoa_window.m:1033:76: error: sending 'CGPoint'
      (aka 'struct CGPoint') to parameter of incompatible type 'NSPoint'
      (aka 'struct _NSPoint')
  ...= [window->ns.object cascadeTopLeftFromPoint:_glfw.ns.cascadePoint];

So I fixed type conversion between NSPoint and CGPoint.

My compiler is below:
gcc --version
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 6.0 (clang-600.0.57) (based on LLVM 3.5svn)
Target: x86_64-apple-darwin13.4.0
Thread model: posix

Changing declaration of cascadePoint at cocoa_platform.h might be better,
but I choose less header file changing.