### PR TITLE
Hide cursor instead of using blank image

### DIFF
--- a/src/cocoa_init.m
+++ b/src/cocoa_init.m
@@ -352,9 +352,6 @@ void _glfwPlatformTerminate(void)
         _glfw.ns.listener = nil;
     }
 
-    [_glfw.ns.cursor release];
-    _glfw.ns.cursor = nil;
-
     free(_glfw.ns.clipboardString);
 
     _glfwTerminateNSGL();

--- a/src/cocoa_platform.h
+++ b/src/cocoa_platform.h
@@ -102,7 +102,6 @@ typedef struct _GLFWlibraryNS
     CGEventSourceRef    eventSource;
     id                  delegate;
     id                  autoreleasePool;
-    id                  cursor;
     TISInputSourceRef   inputSource;
     IOHIDManagerRef     hidManager;
     id                  unicodeData;


### PR DESCRIPTION
When cursor isn't in normal mode and should be hidden, use `[NSCursor hide]`
method instead of setting it to blank image. This should prevent
situations when hidden cursor becomes visible after system notification
was shown.

Fixes #971