### PR TITLE
Fix use of internal joystick API in null and Win32 drivers.

### DIFF
--- a/src/null_joystick.c
+++ b/src/null_joystick.c
@@ -31,7 +31,7 @@
 //////                       GLFW platform API                      //////
 //////////////////////////////////////////////////////////////////////////
 
-int _glfwPlatformPollJoystick(int jid, int mode)
+int _glfwPlatformPollJoystick(_GLFWjoystick* js, int mode)
 {
     return GLFW_FALSE;
 }

--- a/src/win32_joystick.c
+++ b/src/win32_joystick.c
@@ -576,11 +576,14 @@ void _glfwDetectJoystickConnectionWin32(void)
 void _glfwDetectJoystickDisconnectionWin32(void)
 {
     int jid;
+    _GLFWjoystick* js;
 
 	for (jid = 0;  jid <= GLFW_JOYSTICK_LAST;  jid++)
 	{
-        if (_glfw.joysticks[jid].present)
-		    _glfwPlatformPollJoystick(jid, _GLFW_POLL_PRESENCE);
+        js = &_glfw.joysticks[jid];
+
+        if (js->present)
+		    _glfwPlatformPollJoystick(js, _GLFW_POLL_PRESENCE);
 	}
 }
 


### PR DESCRIPTION
I found two inconsistencies in joysticks API.
In null driver it is a matter of using different function signature than in declaration.
In win32 driver joystick disconnection code iterated over id's instead of _GLFWjoystick*, this can lead to crash.