### PR TITLE
Implement access to primary selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ information on what to include when reporting a bug.
 
 ## Changelog
 
+- Added `glfwSetX11SelectionString` and `glfwGetX11SelectionString`
+  native functions for accessing X11 primary selection as a supplement to
+  the clipboard on the X11 platform (#894)
 - Added `glfwGetError` function for querying the last error code and its
   description (#970)
 - Added `glfwUpdateGamepadMappings` function for importing gamepad mappings in

--- a/docs/input.dox
+++ b/docs/input.dox
@@ -868,6 +868,12 @@ The clipboard functions take a window handle argument because some window
 systems require a window to communicate with the system clipboard.  Any valid
 window may be used.
 
+X11 also has the concept of primary selection, which is similar to,
+but distinct from, the clipboard. If this is needed on X11, it can be
+accessed from the X11 native interface with the functions @ref
+glfwGetX11SelectionString and @ref glfwSetX11SelectionString. See
+@ref native.
+
 
 @section path_drop Path drop input
 

--- a/docs/news.dox
+++ b/docs/news.dox
@@ -5,6 +5,15 @@
 @section news_33 Release notes for 3.3
 
 
+@subsection news_33_native_x11_selection X11 native Primary Selection access
+
+GLFW now supports X11 platform specific native functions for accessing
+the X11 primary selection, as a supplement to the clipboard on this
+platform. See @ref clipboard.
+
+@see @ref error_handling
+
+
 @subsection news_33_geterror Error query
 
 GLFW now supports querying the last error code for the calling thread and its

--- a/include/GLFW/glfw3native.h
+++ b/include/GLFW/glfw3native.h
@@ -289,6 +289,56 @@ GLFWAPI RROutput glfwGetX11Monitor(GLFWmonitor* monitor);
  *  @ingroup native
  */
 GLFWAPI Window glfwGetX11Window(GLFWwindow* window);
+
+/*! @brief Sets the current primary selection to the specified string.
+ *
+ *  @param[in] string A UTF-8 encoded string.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @pointer_lifetime The specified string is copied before this function
+ *  returns.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref clipboard
+ *  @sa glfwGetX11SelectionString
+ *  @sa glfwSetClipboardString
+ *
+ *  @since Added in version 3.3.
+ *
+ *  @ingroup native
+ */
+GLFWAPI void glfwSetX11SelectionString(const char* string);
+
+/*! @brief Returns the contents of the current primary selection as a string.
+ *
+ *  If the selection is empty or if its contents cannot be converted, `NULL`
+ *  is returned and a @ref GLFW_FORMAT_UNAVAILABLE error is generated.
+ *
+ *  @return The contents of the selection as a UTF-8 encoded string, or `NULL`
+ *  if an [error](@ref error_handling) occurred.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @pointer_lifetime The returned string is allocated and freed by GLFW. You
+ *  should not free it yourself. It is valid until the next call to @ref
+ *  glfwGetX11SelectionString or @ref glfwSetX11SelectionString, or until the
+ *  library is terminated.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref clipboard
+ *  @sa glfwSetX11SelectionString
+ *  @sa glfwGetClipboardString
+ *
+ *  @since Added in version 3.3.
+ *
+ *  @ingroup native
+ */
+GLFWAPI const char* glfwGetX11SelectionString(void);
 #endif
 
 #if defined(GLFW_EXPOSE_NATIVE_GLX)

--- a/src/x11_init.c
+++ b/src/x11_init.c
@@ -611,6 +611,7 @@ static GLFWbool initExtensions(void)
     // ICCCM standard clipboard atoms
     _glfw.x11.TARGETS = XInternAtom(_glfw.x11.display, "TARGETS", False);
     _glfw.x11.MULTIPLE = XInternAtom(_glfw.x11.display, "MULTIPLE", False);
+    _glfw.x11.PRIMARY = XInternAtom(_glfw.x11.display, "PRIMARY", False);
     _glfw.x11.CLIPBOARD = XInternAtom(_glfw.x11.display, "CLIPBOARD", False);
 
     // Clipboard manager atoms
@@ -853,6 +854,7 @@ void _glfwPlatformTerminate(void)
         _glfw.x11.hiddenCursorHandle = (Cursor) 0;
     }
 
+    free(_glfw.x11.primarySelectionString);
     free(_glfw.x11.clipboardString);
 
     if (_glfw.x11.im)

--- a/src/x11_platform.h
+++ b/src/x11_platform.h
@@ -161,6 +161,8 @@ typedef struct _GLFWlibraryX11
     XIM             im;
     // Most recent error code received by X error handler
     int             errorCode;
+    // Primary selection string (while the primary selection is owned)
+    char*           primarySelectionString;
     // Clipboard string (while the selection is owned)
     char*           clipboardString;
     // Key name string
@@ -214,6 +216,7 @@ typedef struct _GLFWlibraryX11
     Atom            TARGETS;
     Atom            MULTIPLE;
     Atom            CLIPBOARD;
+    Atom            PRIMARY;
     Atom            CLIPBOARD_MANAGER;
     Atom            SAVE_TARGETS;
     Atom            NULL_;

--- a/tests/clipboard.c
+++ b/tests/clipboard.c
@@ -30,6 +30,12 @@
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
 
+// Can use cmake -DCMAKE_C_FLAGS=-DGLFW_EXPOSE_NATIVE_X11 to test X11 native
+// interface for primary selection.
+#ifdef GLFW_EXPOSE_NATIVE_X11
+ #include <GLFW/glfw3native.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -86,6 +92,30 @@ static void key_callback(GLFWwindow* window, int key, int scancode, int action, 
     }
 }
 
+#ifdef GLFW_EXPOSE_NATIVE_X11
+static void mouse_button_callback(GLFWwindow *window, int button, int action, int mods)
+{
+    if (action != GLFW_PRESS)
+        return;
+    if (button == GLFW_MOUSE_BUTTON_LEFT)
+    {
+        const char* string = "GLFW Selection";
+        glfwSetX11SelectionString(string);
+        printf("Setting selection to \"%s\"\n", string);
+    }
+    if (button == GLFW_MOUSE_BUTTON_MIDDLE)
+    {
+        const char* string;
+
+        string = glfwGetX11SelectionString();
+        if (string)
+            printf("Selection contains \"%s\"\n", string);
+        else
+            printf("Selection does not contain a string\n");
+    }
+}
+#endif
+
 static void framebuffer_size_callback(GLFWwindow* window, int width, int height)
 {
     glViewport(0, 0, width, height);
@@ -132,6 +162,9 @@ int main(int argc, char** argv)
     glfwSwapInterval(1);
 
     glfwSetKeyCallback(window, key_callback);
+#ifdef GLFW_EXPOSE_NATIVE_X11
+    glfwSetMouseButtonCallback(window, mouse_button_callback);
+#endif
     glfwSetFramebufferSizeCallback(window, framebuffer_size_callback);
 
     glClearColor(0.5f, 0.5f, 0.5f, 0);


### PR DESCRIPTION
This patch implements the access to X11 primary selection that was requested in issue #894.

New functions glfwSetSelectionString() and glfwGetSelectionString() are added similar to glfwSetClipboardString() and glfwGetClipboardString(). These functions do nothing on platforms with no X11-like primary selection.

There is some discussion in the issue 894 as to whether this is too X11 specific to be included in GLFW, or if it should perhaps be in the platform-specific api. Win32 does not have any similar concept to primary selection, to my knowledge. On the other hand, there are some references to primary selection in Wayland, eg. https://wiki.gnome.org/Initiatives/Wayland/PrimarySelection. So this might be non-X11 specific in the future.

In any case, I decided to create this pull request, which is rebased against latest GLFW master, in case it is useful.

I added stubs for other platforms; howver patch is currently only tested on Linux/X11 due to my lack of available other platforms.

Signed-off-by: Kristian Nielsen <knielsen@knielsen-hq.org>