### PR TITLE
Stop crashing when Compose is unavailable

### DIFF
--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -294,7 +294,7 @@ static int toGLFWKeyCode(uint32_t key)
 
 static xkb_keysym_t composeSymbol(xkb_keysym_t sym)
 {
-    if (sym == XKB_KEY_NoSymbol)
+    if (sym == XKB_KEY_NoSymbol || !_glfw.wl.xkb.composeState)
         return sym;
     if (xkb_compose_state_feed(_glfw.wl.xkb.composeState, sym)
             != XKB_COMPOSE_FEED_ACCEPTED)


### PR DESCRIPTION
There was a missing check for when no Compose key was configured in the
xkb file, making _glfw.wl.xkb.composeState NULL and crashing on key
press.