### PR TITLE
Transparent hint check

### DIFF
--- a/docs/window.dox
+++ b/docs/window.dox
@@ -289,7 +289,9 @@ constraint.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.
 
 @anchor GLFW_TRANSPARENT
 __GLFW_TRANSPARENT__ specifies whether the framebuffer will support transparency
-in the background. Possible values are `GLFW_TRUE` and `GLFW_FALSE`.
+in the background. If transparency is not provided by your driver, GLFW will
+gracefully fallback to opaque. It is possible to check for this outcome
+with `glfwGetWindowAttrib()`. Possible values are `GLFW_TRUE` and `GLFW_FALSE`.
 
 
 @subsubsection window_hints_mtr Monitor related hints

--- a/examples/gears.c
+++ b/examples/gears.c
@@ -322,6 +322,11 @@ int main(int argc, char *argv[])
         exit( EXIT_FAILURE );
     }
 
+    if (!glfwGetWindowAttrib(window, GLFW_TRANSPARENT))
+    {
+        fprintf( stderr, "Failed to set GLFW_TRANSPARENT flag\n" );
+    }
+
     // Set callback functions
     glfwSetFramebufferSizeCallback(window, reshape);
     glfwSetKeyCallback(window, key);

--- a/src/context.c
+++ b/src/context.c
@@ -318,6 +318,12 @@ const _GLFWfbconfig* _glfwChooseFBConfig(const _GLFWfbconfig* desired,
         }
     }
 
+    if (desired->transparent && closest->transparent != GLFW_TRUE)
+    {
+        // If we couldn't find a transparency match,
+        // update the fb hint for client checking.
+        _glfw.hints.framebuffer.transparent = GLFW_FALSE;
+    }
     return closest;
 }
 

--- a/src/context.c
+++ b/src/context.c
@@ -318,12 +318,6 @@ const _GLFWfbconfig* _glfwChooseFBConfig(const _GLFWfbconfig* desired,
         }
     }
 
-    if (desired->transparent && closest->transparent != GLFW_TRUE)
-    {
-        // If we couldn't find a transparency match,
-        // update the fb hint for client checking.
-        _glfw.hints.framebuffer.transparent = GLFW_FALSE;
-    }
     return closest;
 }
 

--- a/src/egl_context.c
+++ b/src/egl_context.c
@@ -188,6 +188,9 @@ static GLFWbool chooseEGLConfig(const _GLFWctxconfig* ctxconfig,
     if (closest)
         *result = (EGLConfig) closest->handle;
 
+    if (desired->transparent && closest->transparent != GLFW_TRUE)
+        _glfw.hints.framebuffer.transparent = GLFW_FALSE;
+
     free(nativeConfigs);
     free(usableConfigs);
 

--- a/src/glx_context.c
+++ b/src/glx_context.c
@@ -141,6 +141,9 @@ static GLFWbool chooseGLXFBConfig(const _GLFWfbconfig* desired,
     if (closest)
         *result = (GLXFBConfig) closest->handle;
 
+    if (desired->transparent && closest->transparent != GLFW_TRUE)
+        _glfw.hints.framebuffer.transparent = GLFW_FALSE;
+
     XFree(nativeConfigs);
     free(usableConfigs);
 

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -988,6 +988,7 @@ static int createNativeWindow(_GLFWwindow* window,
     WCHAR* wideTitle;
     DWORD style = getWindowStyle(window);
     DWORD exStyle = getWindowExStyle(window);
+    GLFWbool transparent = GLFW_FALSE;
 
     if (window->monitor)
     {
@@ -1061,6 +1062,7 @@ static int createNativeWindow(_GLFWwindow* window,
         bb.dwFlags = DWM_BB_ENABLE | DWM_BB_BLURREGION;
         bb.hRgnBlur = region;
         bb.fEnable = TRUE;
+        transparent = GLFW_TRUE;
 
         if (SUCCEEDED(DwmEnableBlurBehindWindow(window->win32.handle, &bb)))
         {
@@ -1089,6 +1091,9 @@ static int createNativeWindow(_GLFWwindow* window,
 
         DeleteObject(region);
     }
+
+    // Need to let the framebuffer hint aware of the composition results.
+    _glfw.hints.framebuffer.transparent = transparent;
 
     return GLFW_TRUE;
 }

--- a/src/window.c
+++ b/src/window.c
@@ -732,6 +732,8 @@ GLFWAPI int glfwGetWindowAttrib(GLFWwindow* handle, int attrib)
             return window->resizable;
         case GLFW_DECORATED:
             return window->decorated;
+        case GLFW_TRANSPARENT:
+            return _glfw.hints.framebuffer.transparent;
         case GLFW_FLOATING:
             return window->floating;
         case GLFW_AUTO_ICONIFY:


### PR DESCRIPTION
Currently the outcome of setting window transparency is unknown.

This pull request adds the ability to get the result of the GLFW_TRANSPARENT hint window outcome by using `glfwGetWindowAttrib()`.

I have also updated the docs detailing this graceful fallback and how to check it's outcome.
Along with adding it to the gears example, as to show how to catch it.