### PR TITLE
Improve DPI change behavior on Windows

### DIFF
--- a/src/win32_init.c
+++ b/src/win32_init.c
@@ -98,6 +98,8 @@ static GLFWbool loadLibraries(void)
 
     _glfw.win32.user32.SetProcessDPIAware_ = (PFN_SetProcessDPIAware)
         GetProcAddress(_glfw.win32.user32.instance, "SetProcessDPIAware");
+    _glfw.win32.user32.EnableNonClientDpiScaling_ = (PFN_EnableNonClientDpiScaling)
+        GetProcAddress(_glfw.win32.user32.instance, "EnableNonClientDpiScaling");
     _glfw.win32.user32.ChangeWindowMessageFilterEx_ = (PFN_ChangeWindowMessageFilterEx)
         GetProcAddress(_glfw.win32.user32.instance, "ChangeWindowMessageFilterEx");
 

--- a/src/win32_platform.h
+++ b/src/win32_platform.h
@@ -209,8 +209,10 @@ typedef HRESULT (WINAPI * PFN_DirectInput8Create)(HINSTANCE,DWORD,REFIID,LPVOID*
 
 // user32.dll function pointer typedefs
 typedef BOOL (WINAPI * PFN_SetProcessDPIAware)(void);
+typedef BOOL (WINAPI * PFN_EnableNonClientDpiScaling)(HWND);
 typedef BOOL (WINAPI * PFN_ChangeWindowMessageFilterEx)(HWND,UINT,DWORD,PCHANGEFILTERSTRUCT);
 #define SetProcessDPIAware _glfw.win32.user32.SetProcessDPIAware_
+#define EnableNonClientDpiScaling _glfw.win32.user32.EnableNonClientDpiScaling_
 #define ChangeWindowMessageFilterEx _glfw.win32.user32.ChangeWindowMessageFilterEx_
 
 // dwmapi.dll function pointer typedefs
@@ -322,6 +324,7 @@ typedef struct _GLFWlibraryWin32
     struct {
         HINSTANCE                       instance;
         PFN_SetProcessDPIAware          SetProcessDPIAware_;
+        PFN_EnableNonClientDpiScaling   EnableNonClientDpiScaling_;
         PFN_ChangeWindowMessageFilterEx ChangeWindowMessageFilterEx_;
     } user32;
 

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -537,6 +537,16 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
 
                 break;
             }
+
+            case WM_NCCREATE:
+            {
+                // Windows 10: enable automatic non-client area scaling
+                if (EnableNonClientDpiScaling)
+                {
+                    EnableNonClientDpiScaling(hWnd);
+                }
+                break;
+            }
         }
 
         return DefWindowProcW(hWnd, uMsg, wParam, lParam);
@@ -985,6 +995,19 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
         {
             if (window->win32.transparent)
                 updateFramebufferTransparency(window);
+            return 0;
+        }
+
+        case WM_DPICHANGED:
+        {
+            // Resize and reposition the window to match the new DPI
+            RECT* const suggestedRect = (RECT*)lParam;
+            SetWindowPos(hWnd, NULL,
+                         suggestedRect->left,
+                         suggestedRect->top,
+                         suggestedRect->right - suggestedRect->left,
+                         suggestedRect->bottom - suggestedRect->top,
+                         SWP_NOZORDER | SWP_NOACTIVATE);
             return 0;
         }
 


### PR DESCRIPTION
When a window transitions between monitors with different scale/dpi settings:

1. It's automatically resized and repositioned by handling the `WM_DPICHANGED` event (Windows 8.1 or newer)
2. Its non-client area is automatically updated to match the new DPI (Windows 10 Anniversary Update or newer)

In Windows 10 Creators Update the [DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2](https://msdn.microsoft.com/library/windows/desktop/mt791579(v=vs.85).aspx) mode was introduced which includes the `EnableNonClientDpiScaling` behavior. However, I don't think we need all its features and supporting it in GLFW would be more complicated (required calls: `SetProcess/ThreadDpiAwarenessContext` and `IsValidDpiAwarenessContext`), so I left it out for now. Calling `EnableNonClientDpiScaling` is harmless, if an application sets the `_V2` context manually.

I recorded a video of the improved behavior, [here](https://www.youtube.com/watch?v=ZkHp1I06YTk).