### PR TITLE
Add occlusion callback and window attribute

### DIFF
--- a/docs/window.dox
+++ b/docs/window.dox
@@ -1150,6 +1150,12 @@ void window_occlusion_callback(GLFWwindow* window, int occluded)
 }
 @endcode
 
+You can also get the current occlusion state with @ref glfwGetWindowAttrib.
+
+@code
+int occluded = glfwGetWindowAttrib(window, GLFW_OCCLUDED);
+@endcode
+
 @note This is currently implemented on macOS only.
 
 
@@ -1288,6 +1294,10 @@ for details.
 @anchor GLFW_VISIBLE_attrib
 __GLFW_VISIBLE__ indicates whether the specified window is visible.  See @ref
 window_hide for details.
+
+@anchor GLFW_OCCLUDED_attrib
+__GLFW_OCCLUDED__ indicates whether the specified window is occluded.
+See @ref window_occlusion for details.
 
 @anchor GLFW_RESIZABLE_attrib
 __GLFW_RESIZABLE__ indicates whether the specified window is resizable _by the

--- a/docs/window.dox
+++ b/docs/window.dox
@@ -1120,6 +1120,39 @@ not supported, the application as a whole.  Once the user has given it
 attention, the system will automatically end the request.
 
 
+@subsection window_occlusion Window occlusion state
+
+A window may not be visible to the user because it is occluded by other windows.
+In contrast to a hidden window it will still be shown in the task bar, dock or
+window list. The occluded state can change without any direct interaction with
+the window, e.g. if the user moves an overlapping window out of the way.
+
+If you wish to be notified when a window becomes occluded or when a part of it
+becomes visible again, set an occlusion callback.
+
+@code
+glfwSetWindowOcclusionCallback(window, window_occlusion_callback);
+@endcode
+
+The callback function receives changes in the occlusion state of the window.
+
+@code
+void window_occlusion_callback(GLFWwindow* window, int occluded)
+{
+    if (occluded)
+    {
+        // The window became fully occluded by other windows
+    }
+    else
+    {
+        // The window is no longer fully occluded
+    }
+}
+@endcode
+
+@note This is currently implemented on macOS only.
+
+
 @subsection window_refresh Window damage and refresh
 
 If you wish to be notified when the contents of a window is damaged and needs

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -1239,6 +1239,23 @@ typedef void (* GLFWwindowrefreshfun)(GLFWwindow*);
  */
 typedef void (* GLFWwindowfocusfun)(GLFWwindow*,int);
 
+/*! @brief The function signature for window occlusion callbacks.
+ *
+ *  This is the function signature for window occlusion callback functions.
+ *
+ *  @param[in] window The window whose occlusion state changed.
+ *  @param[in] occluded `GLFW_TRUE` if the window was occluded, or `GLFW_FALSE`
+ *  if the window is no longer occluded.
+ *
+ *  @sa @ref window_occlusion
+ *  @sa @ref glfwSetWindowOcclusionCallback
+ *
+ *  @since Added in version 3.3.
+ *
+ *  @ingroup window
+ */
+typedef void (* GLFWwindowocclusionfun)(GLFWwindow*,int);
+
 /*! @brief The function signature for window iconify/restore callbacks.
  *
  *  This is the function signature for window iconify/restore callback
@@ -3542,6 +3559,31 @@ GLFWAPI GLFWwindowrefreshfun glfwSetWindowRefreshCallback(GLFWwindow* window, GL
  *  @ingroup window
  */
 GLFWAPI GLFWwindowfocusfun glfwSetWindowFocusCallback(GLFWwindow* window, GLFWwindowfocusfun cbfun);
+
+/*! @brief Sets the occlusion callback for the specified window.
+ *
+ *  This function sets the occlusion callback of the specified window, which is
+ *  called when the window becomes (fully) occluded by other windows or when (a
+ *  part of) the window becomes visible again because an overlapping window is
+ *  moved away.
+ *
+ *  @param[in] window The window whose callback to set.
+ *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
+ *  callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or the
+ *  library had not been [initialized](@ref intro_init).
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_occlusion
+ *
+ *  @since Added in version 3.3.
+ *
+ *  @ingroup window
+ */
+GLFWAPI GLFWwindowocclusionfun glfwSetWindowOcclusionCallback(GLFWwindow* window, GLFWwindowocclusionfun cbfun);
 
 /*! @brief Sets the iconify callback for the specified window.
  *

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -825,6 +825,11 @@ extern "C" {
  *  [window attribute](@ref GLFW_FOCUS_ON_SHOW_attrib).
  */
 #define GLFW_FOCUS_ON_SHOW          0x0002000C
+/*! @brief Occlusion window attribute
+ *
+ *  Occlusion [window attribute](@ref GLFW_OCCLUDED_attrib).
+ */
+#define GLFW_OCCLUDED               0x0002000D
 
 /*! @brief Framebuffer bit depth hint.
  *

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -329,6 +329,11 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
     _glfwInputWindowPos(window, x, y);
 }
 
+- (void)windowDidChangeOcclusionState:(NSNotification *)notification
+{
+    _glfwInputWindowOcclusion(window, !([window->ns.object occlusionState] & NSWindowOcclusionStateVisible));
+}
+
 - (void)windowDidMiniaturize:(NSNotification *)notification
 {
     if (window->monitor)

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -1515,6 +1515,11 @@ int _glfwPlatformWindowFocused(_GLFWwindow* window)
     return [window->ns.object isKeyWindow];
 }
 
+int _glfwPlatformWindowOccluded(_GLFWwindow* window)
+{
+    return !([window->ns.object occlusionState] & NSWindowOcclusionStateVisible);
+}
+
 int _glfwPlatformWindowIconified(_GLFWwindow* window)
 {
     return [window->ns.object isMiniaturized];

--- a/src/internal.h
+++ b/src/internal.h
@@ -657,6 +657,7 @@ void _glfwPlatformSetWindowMonitor(_GLFWwindow* window, _GLFWmonitor* monitor,
                                    int xpos, int ypos, int width, int height,
                                    int refreshRate);
 int _glfwPlatformWindowFocused(_GLFWwindow* window);
+int _glfwPlatformWindowOccluded(_GLFWwindow* window);
 int _glfwPlatformWindowIconified(_GLFWwindow* window);
 int _glfwPlatformWindowVisible(_GLFWwindow* window);
 int _glfwPlatformWindowMaximized(_GLFWwindow* window);

--- a/src/internal.h
+++ b/src/internal.h
@@ -399,6 +399,7 @@ struct _GLFWwindow
         GLFWwindowclosefun      close;
         GLFWwindowrefreshfun    refresh;
         GLFWwindowfocusfun      focus;
+        GLFWwindowocclusionfun  occlusion;
         GLFWwindowiconifyfun    iconify;
         GLFWwindowmaximizefun   maximize;
         GLFWframebuffersizefun  fbsize;
@@ -697,6 +698,7 @@ void _glfwPlatformUnlockMutex(_GLFWmutex* mutex);
 //////////////////////////////////////////////////////////////////////////
 
 void _glfwInputWindowFocus(_GLFWwindow* window, GLFWbool focused);
+void _glfwInputWindowOcclusion(_GLFWwindow* window, GLFWbool occluded);
 void _glfwInputWindowPos(_GLFWwindow* window, int xpos, int ypos);
 void _glfwInputWindowSize(_GLFWwindow* window, int width, int height);
 void _glfwInputFramebufferSize(_GLFWwindow* window, int width, int height);

--- a/src/null_window.c
+++ b/src/null_window.c
@@ -222,6 +222,11 @@ int _glfwPlatformWindowFocused(_GLFWwindow* window)
     return GLFW_FALSE;
 }
 
+int _glfwPlatformWindowOccluded(_GLFWwindow* window)
+{
+    return GLFW_FALSE;
+}
+
 int _glfwPlatformWindowIconified(_GLFWwindow* window)
 {
     return GLFW_FALSE;

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -1760,6 +1760,11 @@ int _glfwPlatformWindowFocused(_GLFWwindow* window)
     return window->win32.handle == GetActiveWindow();
 }
 
+int _glfwPlatformWindowOccluded(_GLFWwindow* window)
+{
+    return GLFW_FALSE;
+}
+
 int _glfwPlatformWindowIconified(_GLFWwindow* window)
 {
     return IsIconic(window->win32.handle);

--- a/src/window.c
+++ b/src/window.c
@@ -66,6 +66,14 @@ void _glfwInputWindowFocus(_GLFWwindow* window, GLFWbool focused)
     }
 }
 
+// Notifies shared code that a window's occlusion state has changed
+//
+void _glfwInputWindowOcclusion(_GLFWwindow* window, GLFWbool occluded)
+{
+    if (window->callbacks.occlusion)
+        window->callbacks.occlusion((GLFWwindow*) window, occluded);
+}
+
 // Notifies shared code that a window has moved
 // The position is specified in client-area relative screen coordinates
 //
@@ -1022,6 +1030,17 @@ GLFWAPI GLFWwindowfocusfun glfwSetWindowFocusCallback(GLFWwindow* handle,
 
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
     _GLFW_SWAP_POINTERS(window->callbacks.focus, cbfun);
+    return cbfun;
+}
+
+GLFWAPI GLFWwindowocclusionfun glfwSetWindowOcclusionCallback(GLFWwindow* handle,
+                                                              GLFWwindowocclusionfun cbfun)
+{
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    assert(window != NULL);
+
+    _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
+    _GLFW_SWAP_POINTERS(window->callbacks.occlusion, cbfun);
     return cbfun;
 }
 

--- a/src/window.c
+++ b/src/window.c
@@ -832,6 +832,8 @@ GLFWAPI int glfwGetWindowAttrib(GLFWwindow* handle, int attrib)
             return window->focusOnShow;
         case GLFW_TRANSPARENT_FRAMEBUFFER:
             return _glfwPlatformFramebufferTransparent(window);
+        case GLFW_OCCLUDED:
+            return _glfwPlatformWindowOccluded(window);
         case GLFW_RESIZABLE:
             return window->resizable;
         case GLFW_DECORATED:

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -1243,6 +1243,11 @@ int _glfwPlatformWindowFocused(_GLFWwindow* window)
     return _glfw.wl.keyboardFocus == window;
 }
 
+int _glfwPlatformWindowOccluded(_GLFWwindow* window)
+{
+    return GLFW_FALSE;
+}
+
 int _glfwPlatformWindowIconified(_GLFWwindow* window)
 {
     // wl_shell doesn't have any iconified concept, and xdg-shell doesn’t give

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -2433,6 +2433,11 @@ int _glfwPlatformWindowFocused(_GLFWwindow* window)
     return window->x11.handle == focused;
 }
 
+int _glfwPlatformWindowOccluded(_GLFWwindow* window)
+{
+    return GLFW_FALSE;
+}
+
 int _glfwPlatformWindowIconified(_GLFWwindow* window)
 {
     return getWindowState(window) == IconicState;

--- a/tests/events.c
+++ b/tests/events.c
@@ -326,6 +326,14 @@ static void window_focus_callback(GLFWwindow* window, int focused)
            focused ? "focused" : "defocused");
 }
 
+static void window_occlusion_callback(GLFWwindow* window, int occluded)
+{
+    Slot* slot = glfwGetWindowUserPointer(window);
+    printf("%08x to %i at %0.3f: Window %s\n",
+           counter++, slot->number, glfwGetTime(),
+           occluded ? "occluded" : "not occluded");
+}
+
 static void window_iconify_callback(GLFWwindow* window, int iconified)
 {
     Slot* slot = glfwGetWindowUserPointer(window);
@@ -608,6 +616,7 @@ int main(int argc, char** argv)
         glfwSetWindowCloseCallback(slots[i].window, window_close_callback);
         glfwSetWindowRefreshCallback(slots[i].window, window_refresh_callback);
         glfwSetWindowFocusCallback(slots[i].window, window_focus_callback);
+        glfwSetWindowOcclusionCallback(slots[i].window, window_occlusion_callback);
         glfwSetWindowIconifyCallback(slots[i].window, window_iconify_callback);
         glfwSetWindowMaximizeCallback(slots[i].window, window_maximize_callback);
         glfwSetMouseButtonCallback(slots[i].window, mouse_button_callback);


### PR DESCRIPTION
Adds `glfwSetWindowOcclusionCallback(GLFWwindow* window, GLFWwindowocclusionfun cbfun)` and `GLFW_OCCLUDED` window attribute as a first step towards #680.

Only implemented on macOS for now.