### PR TITLE
Add Wayland to the CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,10 @@ branches:
     only:
         - ci
         - master
-os:
-    - linux
-    - osx
 sudo: false
 dist: trusty
 addons:
     apt:
-        sources:
-            - kubuntu-backports
         packages:
             - cmake
             - libxrandr-dev
@@ -22,13 +17,46 @@ addons:
 env:
     global:
         - CFLAGS=-Werror
-    matrix:
-        - BUILD_SHARED_LIBS=ON
-        - BUILD_SHARED_LIBS=OFF
+matrix:
+    include:
+        - os: linux
+          env: BUILD_SHARED_LIBS=ON
+        - os: linux
+          env: BUILD_SHARED_LIBS=OFF
+        - os: linux
+          sudo: required
+          addons:
+              apt:
+                  packages:
+                      - libwayland-dev
+                      - libxkbcommon-dev
+                      - libegl1-mesa-dev
+          env:
+              - USE_WAYLAND=ON
+              - BUILD_SHARED_LIBS=ON
+        - os: linux
+          sudo: required
+          addons:
+              apt:
+                  packages:
+                      - libwayland-dev
+                      - libxkbcommon-dev
+                      - libegl1-mesa-dev
+          env:
+              - USE_WAYLAND=ON
+              - BUILD_SHARED_LIBS=OFF
+        - os: osx
+          env: BUILD_SHARED_LIBS=ON
+        - os: osx
+          env: BUILD_SHARED_LIBS=OFF
 script:
     - mkdir build
     - cd build
-    - cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} ..
+    - if test -n "${USE_WAYLAND}"; then wget https://mirrors.kernel.org/ubuntu/pool/universe/e/extra-cmake-modules/extra-cmake-modules_5.38.0a-0ubuntu1_amd64.deb; fi
+    - if test -n "${USE_WAYLAND}"; then sudo dpkg -i extra-cmake-modules_5.38.0a-0ubuntu1_amd64.deb; fi
+    - if test -n "${USE_WAYLAND}"; then git clone git://anongit.freedesktop.org/wayland/wayland-protocols; fi
+    - if test -n "${USE_WAYLAND}"; then pushd wayland-protocols; ./autogen.sh --prefix=/usr; make -j; sudo make install; popd; fi
+    - cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} -DGLFW_USE_WAYLAND=${USE_WAYLAND} ..
     - cmake --build .
 notifications:
     email:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,6 +287,9 @@ if (_GLFW_WAYLAND)
 
     find_package(XKBCommon REQUIRED)
     list(APPEND glfw_INCLUDE_DIRS "${XKBCOMMON_INCLUDE_DIRS}")
+
+    include(CheckIncludeFiles)
+    check_include_files(xkbcommon/xkbcommon-compose.h HAVE_XKBCOMMON_COMPOSE_H)
 endif()
 
 #--------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,13 +276,13 @@ if (_GLFW_WAYLAND)
     find_package(ECM REQUIRED NO_MODULE)
     list(APPEND CMAKE_MODULE_PATH "${ECM_MODULE_PATH}")
 
-    find_package(Wayland REQUIRED)
+    find_package(Wayland REQUIRED Client Cursor Egl)
     find_package(WaylandScanner REQUIRED)
     find_package(WaylandProtocols 1.1 REQUIRED)
 
     list(APPEND glfw_PKG_DEPS "wayland-egl")
 
-    list(APPEND glfw_INCLUDE_DIRS "${Wayland_INCLUDE_DIR}")
+    list(APPEND glfw_INCLUDE_DIRS "${Wayland_INCLUDE_DIRS}")
     list(APPEND glfw_LIBRARIES "${Wayland_LIBRARIES}" "${CMAKE_THREAD_LIBS_INIT}")
 
     find_package(XKBCommon REQUIRED)

--- a/src/glfw_config.h.in
+++ b/src/glfw_config.h.in
@@ -55,3 +55,6 @@
 // Define this to 1 to force use of high-performance GPU on hybrid systems
 #cmakedefine _GLFW_USE_HYBRID_HPG
 
+// Define this to 1 if xkbcommon supports the compose key
+#cmakedefine HAVE_XKBCOMMON_COMPOSE_H
+

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -26,6 +26,7 @@
 
 #include "internal.h"
 
+#include <assert.h>
 #include <linux/input.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -152,6 +153,7 @@ static void pointerHandleAxis(void* data,
             y = wl_fixed_to_double(value) * scrollFactor;
             break;
         default:
+            assert(GLFW_FALSE);
             break;
     }
 

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -176,8 +176,12 @@ static void keyboardHandleKeymap(void* data,
 {
     struct xkb_keymap* keymap;
     struct xkb_state* state;
+
+#ifdef HAVE_XKBCOMMON_COMPOSE_H
     struct xkb_compose_table* composeTable;
     struct xkb_compose_state* composeState;
+#endif
+
     char* mapStr;
     const char* locale;
 
@@ -225,6 +229,7 @@ static void keyboardHandleKeymap(void* data,
     if (!locale)
         locale = "C";
 
+#ifdef HAVE_XKBCOMMON_COMPOSE_H
     composeTable =
         xkb_compose_table_new_from_locale(_glfw.wl.xkb.context, locale,
                                           XKB_COMPOSE_COMPILE_NO_FLAGS);
@@ -244,6 +249,7 @@ static void keyboardHandleKeymap(void* data,
         _glfwInputError(GLFW_PLATFORM_ERROR,
                         "Wayland: Failed to create XKB compose table");
     }
+#endif
 
     xkb_keymap_unref(_glfw.wl.xkb.keymap);
     xkb_state_unref(_glfw.wl.xkb.state);
@@ -294,6 +300,7 @@ static int toGLFWKeyCode(uint32_t key)
     return GLFW_KEY_UNKNOWN;
 }
 
+#ifdef HAVE_XKBCOMMON_COMPOSE_H
 static xkb_keysym_t composeSymbol(xkb_keysym_t sym)
 {
     if (sym == XKB_KEY_NoSymbol || !_glfw.wl.xkb.composeState)
@@ -313,6 +320,7 @@ static xkb_keysym_t composeSymbol(xkb_keysym_t sym)
             return sym;
     }
 }
+#endif
 
 static void inputChar(_GLFWwindow* window, uint32_t key)
 {
@@ -326,7 +334,11 @@ static void inputChar(_GLFWwindow* window, uint32_t key)
 
     if (numSyms == 1)
     {
+#ifdef HAVE_XKBCOMMON_COMPOSE_H
         sym = composeSymbol(syms[0]);
+#else
+        sym = syms[0];
+#endif
         cp = _glfwKeySym2Unicode(sym);
         if (cp != -1)
         {
@@ -672,6 +684,8 @@ int _glfwPlatformInit(void)
         dlsym(_glfw.wl.xkb.handle, "xkb_state_update_mask");
     _glfw.wl.xkb.state_serialize_mods = (PFN_xkb_state_serialize_mods)
         dlsym(_glfw.wl.xkb.handle, "xkb_state_serialize_mods");
+
+#ifdef HAVE_XKBCOMMON_COMPOSE_H
     _glfw.wl.xkb.compose_table_new_from_locale = (PFN_xkb_compose_table_new_from_locale)
         dlsym(_glfw.wl.xkb.handle, "xkb_compose_table_new_from_locale");
     _glfw.wl.xkb.compose_table_unref = (PFN_xkb_compose_table_unref)
@@ -686,6 +700,7 @@ int _glfwPlatformInit(void)
         dlsym(_glfw.wl.xkb.handle, "xkb_compose_state_get_status");
     _glfw.wl.xkb.compose_state_get_one_sym = (PFN_xkb_compose_state_get_one_sym)
         dlsym(_glfw.wl.xkb.handle, "xkb_compose_state_get_one_sym");
+#endif
 
     _glfw.wl.display = wl_display_connect(NULL);
     if (!_glfw.wl.display)
@@ -740,7 +755,10 @@ void _glfwPlatformTerminate(void)
     _glfwTerminateEGL();
     _glfwTerminateJoysticksLinux();
 
+#ifdef HAVE_XKBCOMMON_COMPOSE_H
     xkb_compose_state_unref(_glfw.wl.xkb.composeState);
+#endif
+
     xkb_keymap_unref(_glfw.wl.xkb.keymap);
     xkb_state_unref(_glfw.wl.xkb.state);
     xkb_context_unref(_glfw.wl.xkb.context);

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -26,7 +26,9 @@
 
 #include <wayland-client.h>
 #include <xkbcommon/xkbcommon.h>
+#ifdef HAVE_XKBCOMMON_COMPOSE_H
 #include <xkbcommon/xkbcommon-compose.h>
+#endif
 #include <dlfcn.h>
 
 typedef VkFlags VkWaylandSurfaceCreateFlagsKHR;
@@ -78,13 +80,6 @@ typedef void (* PFN_xkb_state_unref)(struct xkb_state*);
 typedef int (* PFN_xkb_state_key_get_syms)(struct xkb_state*, xkb_keycode_t, const xkb_keysym_t**);
 typedef enum xkb_state_component (* PFN_xkb_state_update_mask)(struct xkb_state*, xkb_mod_mask_t, xkb_mod_mask_t, xkb_mod_mask_t, xkb_layout_index_t, xkb_layout_index_t, xkb_layout_index_t);
 typedef xkb_mod_mask_t (* PFN_xkb_state_serialize_mods)(struct xkb_state*, enum xkb_state_component);
-typedef struct xkb_compose_table* (* PFN_xkb_compose_table_new_from_locale)(struct xkb_context*, const char*, enum xkb_compose_compile_flags);
-typedef void (* PFN_xkb_compose_table_unref)(struct xkb_compose_table*);
-typedef struct xkb_compose_state* (* PFN_xkb_compose_state_new)(struct xkb_compose_table*, enum xkb_compose_state_flags);
-typedef void (* PFN_xkb_compose_state_unref)(struct xkb_compose_state*);
-typedef enum xkb_compose_feed_result (* PFN_xkb_compose_state_feed)(struct xkb_compose_state*, xkb_keysym_t);
-typedef enum xkb_compose_status (* PFN_xkb_compose_state_get_status)(struct xkb_compose_state*);
-typedef xkb_keysym_t (* PFN_xkb_compose_state_get_one_sym)(struct xkb_compose_state*);
 #define xkb_context_new _glfw.wl.xkb.context_new
 #define xkb_context_unref _glfw.wl.xkb.context_unref
 #define xkb_keymap_new_from_string _glfw.wl.xkb.keymap_new_from_string
@@ -95,6 +90,15 @@ typedef xkb_keysym_t (* PFN_xkb_compose_state_get_one_sym)(struct xkb_compose_st
 #define xkb_state_key_get_syms _glfw.wl.xkb.state_key_get_syms
 #define xkb_state_update_mask _glfw.wl.xkb.state_update_mask
 #define xkb_state_serialize_mods _glfw.wl.xkb.state_serialize_mods
+
+#ifdef HAVE_XKBCOMMON_COMPOSE_H
+typedef struct xkb_compose_table* (* PFN_xkb_compose_table_new_from_locale)(struct xkb_context*, const char*, enum xkb_compose_compile_flags);
+typedef void (* PFN_xkb_compose_table_unref)(struct xkb_compose_table*);
+typedef struct xkb_compose_state* (* PFN_xkb_compose_state_new)(struct xkb_compose_table*, enum xkb_compose_state_flags);
+typedef void (* PFN_xkb_compose_state_unref)(struct xkb_compose_state*);
+typedef enum xkb_compose_feed_result (* PFN_xkb_compose_state_feed)(struct xkb_compose_state*, xkb_keysym_t);
+typedef enum xkb_compose_status (* PFN_xkb_compose_state_get_status)(struct xkb_compose_state*);
+typedef xkb_keysym_t (* PFN_xkb_compose_state_get_one_sym)(struct xkb_compose_state*);
 #define xkb_compose_table_new_from_locale _glfw.wl.xkb.compose_table_new_from_locale
 #define xkb_compose_table_unref _glfw.wl.xkb.compose_table_unref
 #define xkb_compose_state_new _glfw.wl.xkb.compose_state_new
@@ -102,6 +106,7 @@ typedef xkb_keysym_t (* PFN_xkb_compose_state_get_one_sym)(struct xkb_compose_st
 #define xkb_compose_state_feed _glfw.wl.xkb.compose_state_feed
 #define xkb_compose_state_get_status _glfw.wl.xkb.compose_state_get_status
 #define xkb_compose_state_get_one_sym _glfw.wl.xkb.compose_state_get_one_sym
+#endif
 
 
 // Wayland-specific per-window data
@@ -164,7 +169,11 @@ typedef struct _GLFWlibraryWayland
         struct xkb_context*     context;
         struct xkb_keymap*      keymap;
         struct xkb_state*       state;
+
+#ifdef HAVE_XKBCOMMON_COMPOSE_H
         struct xkb_compose_state* composeState;
+#endif
+
         xkb_mod_mask_t          controlMask;
         xkb_mod_mask_t          altMask;
         xkb_mod_mask_t          shiftMask;
@@ -181,6 +190,8 @@ typedef struct _GLFWlibraryWayland
         PFN_xkb_state_key_get_syms state_key_get_syms;
         PFN_xkb_state_update_mask state_update_mask;
         PFN_xkb_state_serialize_mods state_serialize_mods;
+
+#ifdef HAVE_XKBCOMMON_COMPOSE_H
         PFN_xkb_compose_table_new_from_locale compose_table_new_from_locale;
         PFN_xkb_compose_table_unref compose_table_unref;
         PFN_xkb_compose_state_new compose_state_new;
@@ -188,6 +199,7 @@ typedef struct _GLFWlibraryWayland
         PFN_xkb_compose_state_feed compose_state_feed;
         PFN_xkb_compose_state_get_status compose_state_get_status;
         PFN_xkb_compose_state_get_one_sym compose_state_get_one_sym;
+#endif
     } xkb;
 
     _GLFWwindow*                pointerFocus;


### PR DESCRIPTION
This adds two new CI platforms, Wayland with shared libs and with static libs.

There are a few fixes for the Wayland platform bundled, notably it will disable the compose key when xkbcommon is too old to support it.