### PR TITLE
Bump required wayland-protocols version, and fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,10 +52,14 @@ matrix:
 script:
     - mkdir build
     - cd build
-    - if test -n "${USE_WAYLAND}"; then wget https://mirrors.kernel.org/ubuntu/pool/universe/e/extra-cmake-modules/extra-cmake-modules_5.38.0a-0ubuntu1_amd64.deb; fi
-    - if test -n "${USE_WAYLAND}"; then sudo dpkg -i extra-cmake-modules_5.38.0a-0ubuntu1_amd64.deb; fi
-    - if test -n "${USE_WAYLAND}"; then git clone git://anongit.freedesktop.org/wayland/wayland-protocols; fi
-    - if test -n "${USE_WAYLAND}"; then pushd wayland-protocols; ./autogen.sh --prefix=/usr; make -j; sudo make install; popd; fi
+    - if test -n "${USE_WAYLAND}";
+          then wget https://mirrors.kernel.org/ubuntu/pool/universe/e/extra-cmake-modules/extra-cmake-modules_5.38.0a-0ubuntu1_amd64.deb;
+          sudo dpkg -i extra-cmake-modules_5.38.0a-0ubuntu1_amd64.deb;
+          git clone git://anongit.freedesktop.org/wayland/wayland-protocols;
+          pushd wayland-protocols;
+          git checkout 1.6 && ./autogen.sh --prefix=/usr && make && sudo make install;
+          popd;
+      fi
     - cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} -DGLFW_USE_WAYLAND=${USE_WAYLAND} ..
     - cmake --build .
 notifications:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,7 +278,7 @@ if (_GLFW_WAYLAND)
 
     find_package(Wayland REQUIRED Client Cursor Egl)
     find_package(WaylandScanner REQUIRED)
-    find_package(WaylandProtocols 1.1 REQUIRED)
+    find_package(WaylandProtocols 1.6 REQUIRED)
 
     list(APPEND glfw_PKG_DEPS "wayland-egl")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,7 +49,7 @@ elseif (_GLFW_WAYLAND)
         BASENAME pointer-constraints-unstable-v1)
     ecm_add_wayland_client_protocol(glfw_SOURCES
         PROTOCOL
-        ${WAYLAND_PROTOCOLS_PKGDATADIR}/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml
+        "${WAYLAND_PROTOCOLS_PKGDATADIR}/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml"
         BASENAME idle-inhibit-unstable-v1)
 elseif (_GLFW_MIR)
     set(glfw_HEADERS ${common_HEADERS} mir_platform.h linux_joystick.h


### PR DESCRIPTION
Also make the CI build using this version, to catch potential mismatch when we’ll bump it again in the future.