### PR TITLE
Implement xdg-shell in addition to wl_shell

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ script:
           sudo dpkg -i extra-cmake-modules_5.38.0a-0ubuntu1_amd64.deb;
           git clone git://anongit.freedesktop.org/wayland/wayland-protocols;
           pushd wayland-protocols;
-          git checkout 1.6 && ./autogen.sh --prefix=/usr && make && sudo make install;
+          git checkout 1.12 && ./autogen.sh --prefix=/usr && make && sudo make install;
           popd;
       fi
     - cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} -DGLFW_USE_WAYLAND=${USE_WAYLAND} ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,7 +277,7 @@ if (_GLFW_WAYLAND)
 
     find_package(Wayland REQUIRED Client Cursor Egl)
     find_package(WaylandScanner REQUIRED)
-    find_package(WaylandProtocols 1.6 REQUIRED)
+    find_package(WaylandProtocols 1.12 REQUIRED)
 
     list(APPEND glfw_PKG_DEPS "wayland-egl")
 

--- a/docs/compat.dox
+++ b/docs/compat.dox
@@ -101,6 +101,15 @@ GLFW uses xkbcommon 0.5.0 to provide compose key support.  When it has been
 built against an older xkbcommon, the compose key will be disabled even if it
 has been configured in the compositor.
 
+GLFW uses the [xdg-shell
+protocol](https://cgit.freedesktop.org/wayland/wayland-protocols/tree/stable/xdg-shell/xdg-shell.xml)
+to provide better window management.  This protocol is part of
+wayland-protocols 1.12, and mandatory at build time.  If the running compositor
+does not support this protocol, the older [wl_shell
+interface](https://cgit.freedesktop.org/wayland/wayland/tree/protocol/wayland.xml#n972)
+will be used instead.  This will result in a worse integration with the
+desktop, especially on tiling compositors.
+
 GLFW uses the [relative pointer
 protocol](https://cgit.freedesktop.org/wayland/wayland-protocols/tree/unstable/relative-pointer/relative-pointer-unstable-v1.xml)
 alongside the [pointer constraints

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -2459,10 +2459,6 @@ GLFWAPI void glfwWindowHintString(int hint, const char* value);
  *  @remark @wayland A full screen window will not attempt to change the mode,
  *  no matter what the requested size or refresh rate.
  *
- *  @remark @wayland The wl_shell protocol does not support window
- *  icons, the window will inherit the one defined in the application's
- *  desktop file, so this function emits @ref GLFW_PLATFORM_ERROR.
- *
  *  @remark @wayland Screensaver inhibition requires the idle-inhibit protocol
  *  to be implemented in the user's compositor.
  *
@@ -2606,9 +2602,9 @@ GLFWAPI void glfwSetWindowTitle(GLFWwindow* window, const char* title);
  *  [Bundle Programming Guide](https://developer.apple.com/library/mac/documentation/CoreFoundation/Conceptual/CFBundles/)
  *  in the Mac Developer Library.
  *
- *  @remark @wayland The wl_shell protocol does not support icons, the window
- *  will inherit the one defined in the application's desktop file, so this
- *  function emits @ref GLFW_PLATFORM_ERROR.
+ *  @remark @wayland There is no existing protocol to change an icon, the
+ *  window will thus inherit the one defined in the application's desktop file.
+ *  This function always emits @ref GLFW_PLATFORM_ERROR.
  *
  *  @thread_safety This function must only be called from the main thread.
  *
@@ -3016,7 +3012,8 @@ GLFWAPI void glfwSetWindowOpacity(GLFWwindow* window, float opacity);
  *  GLFW_PLATFORM_ERROR.
  *
  *  @remark @wayland There is no concept of iconification in wl_shell, this
- *  function will always emit @ref GLFW_PLATFORM_ERROR.
+ *  function will emit @ref GLFW_PLATFORM_ERROR when using this deprecated
+ *  protocol.
  *
  *  @thread_safety This function must only be called from the main thread.
  *
@@ -3541,7 +3538,7 @@ GLFWAPI GLFWwindowfocusfun glfwSetWindowFocusCallback(GLFWwindow* window, GLFWwi
  *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
  *
  *  @remark @wayland The wl_shell protocol has no concept of iconification,
- *  this callback will never be called.
+ *  this callback will never be called when using this deprecated protocol.
  *
  *  @thread_safety This function must only be called from the main thread.
  *

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,6 +41,10 @@ elseif (_GLFW_WAYLAND)
 
     ecm_add_wayland_client_protocol(glfw_SOURCES
         PROTOCOL
+        "${WAYLAND_PROTOCOLS_PKGDATADIR}/stable/xdg-shell/xdg-shell.xml"
+        BASENAME xdg-shell)
+    ecm_add_wayland_client_protocol(glfw_SOURCES
+        PROTOCOL
         "${WAYLAND_PROTOCOLS_PKGDATADIR}/unstable/relative-pointer/relative-pointer-unstable-v1.xml"
         BASENAME relative-pointer-unstable-v1)
     ecm_add_wayland_client_protocol(glfw_SOURCES

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -470,6 +470,17 @@ static const struct wl_seat_listener seatListener = {
     seatHandleCapabilities
 };
 
+static void wmBaseHandlePing(void* data,
+                             struct xdg_wm_base* wmBase,
+                             uint32_t serial)
+{
+    xdg_wm_base_pong(wmBase, serial);
+}
+
+static const struct xdg_wm_base_listener wmBaseListener = {
+    wmBaseHandlePing
+};
+
 static void registryHandleGlobal(void* data,
                                  struct wl_registry* registry,
                                  uint32_t name,
@@ -505,6 +516,12 @@ static void registryHandleGlobal(void* data,
                 wl_registry_bind(registry, name, &wl_seat_interface, 1);
             wl_seat_add_listener(_glfw.wl.seat, &seatListener, NULL);
         }
+    }
+    else if (strcmp(interface, "xdg_wm_base") == 0)
+    {
+        _glfw.wl.wmBase =
+            wl_registry_bind(registry, name, &xdg_wm_base_interface, 1);
+        xdg_wm_base_add_listener(_glfw.wl.wmBase, &wmBaseListener, NULL);
     }
     else if (strcmp(interface, "zwp_relative_pointer_manager_v1") == 0)
     {
@@ -851,6 +868,8 @@ void _glfwPlatformTerminate(void)
         wl_shm_destroy(_glfw.wl.shm);
     if (_glfw.wl.shell)
         wl_shell_destroy(_glfw.wl.shell);
+    if (_glfw.wl.wmBase)
+        xdg_wm_base_destroy(_glfw.wl.wmBase);
     if (_glfw.wl.pointer)
         wl_pointer_destroy(_glfw.wl.pointer);
     if (_glfw.wl.keyboard)

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -52,6 +52,7 @@ typedef VkBool32 (APIENTRY *PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR
 #include "egl_context.h"
 #include "osmesa_context.h"
 
+#include "wayland-xdg-shell-client-protocol.h"
 #include "wayland-relative-pointer-unstable-v1-client-protocol.h"
 #include "wayland-pointer-constraints-unstable-v1-client-protocol.h"
 #include "wayland-idle-inhibit-unstable-v1-client-protocol.h"
@@ -152,6 +153,11 @@ typedef struct _GLFWwindowWayland
     struct wl_shell_surface*    shellSurface;
     struct wl_callback*         callback;
 
+    struct {
+        struct xdg_surface*     surface;
+        struct xdg_toplevel*    toplevel;
+    } xdg;
+
     _GLFWcursor*                currentCursor;
     double                      cursorPosX, cursorPosY;
 
@@ -185,6 +191,7 @@ typedef struct _GLFWlibraryWayland
     struct wl_seat*             seat;
     struct wl_pointer*          pointer;
     struct wl_keyboard*         keyboard;
+    struct xdg_wm_base*         wmBase;
     struct zwp_relative_pointer_manager_v1* relativePointerManager;
     struct zwp_pointer_constraints_v1*      pointerConstraints;
     struct zwp_idle_inhibit_manager_v1*     idleInhibitManager;

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -177,6 +177,9 @@ typedef struct _GLFWwindowWayland
 
     struct zwp_idle_inhibitor_v1*          idleInhibitor;
 
+    // This is a hack to prevent auto-iconification on creation.
+    GLFWbool                    justCreated;
+
 } _GLFWwindowWayland;
 
 // Wayland-specific global data

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -236,10 +236,21 @@ static GLFWbool createSurface(_GLFWwindow* window,
 
 static GLFWbool createShellSurface(_GLFWwindow* window)
 {
+    if (!_glfw.wl.shell)
+    {
+        _glfwInputError(GLFW_PLATFORM_ERROR,
+                        "Wayland: wl_shell protocol not available");
+        return GLFW_FALSE;
+    }
+
     window->wl.shellSurface = wl_shell_get_shell_surface(_glfw.wl.shell,
                                                          window->wl.surface);
     if (!window->wl.shellSurface)
+    {
+        _glfwInputError(GLFW_PLATFORM_ERROR,
+                        "Wayland: Shell surface creation failed");
         return GLFW_FALSE;
+    }
 
     wl_shell_surface_add_listener(window->wl.shellSurface,
                                   &shellSurfaceListener,

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -393,10 +393,12 @@ static GLFWbool createXdgSurface(_GLFWwindow* window)
     if (window->wl.title)
         xdg_toplevel_set_title(window->wl.xdg.toplevel, window->wl.title);
 
-    xdg_toplevel_set_min_size(window->wl.xdg.toplevel,
-                              window->minwidth, window->minheight);
-    xdg_toplevel_set_max_size(window->wl.xdg.toplevel,
-                              window->maxwidth, window->maxheight);
+    if (window->minwidth != GLFW_DONT_CARE && window->minheight != GLFW_DONT_CARE)
+        xdg_toplevel_set_min_size(window->wl.xdg.toplevel,
+                                  window->minwidth, window->minheight);
+    if (window->maxwidth != GLFW_DONT_CARE && window->maxheight != GLFW_DONT_CARE)
+        xdg_toplevel_set_max_size(window->wl.xdg.toplevel,
+                                  window->maxwidth, window->maxheight);
 
     if (window->monitor)
     {

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -420,6 +420,7 @@ static GLFWbool createXdgSurface(_GLFWwindow* window)
     }
 
     wl_surface_commit(window->wl.surface);
+    wl_display_roundtrip(_glfw.wl.display);
 
     return GLFW_TRUE;
 }

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -318,22 +318,25 @@ static void xdgToplevelHandleConfigure(void* data,
         }
     }
 
-    if (!maximized && !fullscreen)
+    if (width != 0 && height != 0)
     {
-        if (window->numer != GLFW_DONT_CARE && window->denom != GLFW_DONT_CARE)
+        if (!maximized && !fullscreen)
         {
-            aspectRatio = (float)width / (float)height;
-            targetRatio = (float)window->numer / (float)window->denom;
-            if (aspectRatio < targetRatio)
-                height = width / targetRatio;
-            else if (aspectRatio > targetRatio)
-                width = height * targetRatio;
+            if (window->numer != GLFW_DONT_CARE && window->denom != GLFW_DONT_CARE)
+            {
+                aspectRatio = (float)width / (float)height;
+                targetRatio = (float)window->numer / (float)window->denom;
+                if (aspectRatio < targetRatio)
+                    height = width / targetRatio;
+                else if (aspectRatio > targetRatio)
+                    width = height * targetRatio;
+            }
         }
-    }
 
-    _glfwInputWindowSize(window, width, height);
-    _glfwPlatformSetWindowSize(window, width, height);
-    _glfwInputWindowDamage(window);
+        _glfwInputWindowSize(window, width, height);
+        _glfwPlatformSetWindowSize(window, width, height);
+        _glfwInputWindowDamage(window);
+    }
 
     if (!activated && window->autoIconify)
         _glfwPlatformIconifyWindow(window);

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -816,11 +816,14 @@ void _glfwPlatformMaximizeWindow(_GLFWwindow* window)
 
 void _glfwPlatformShowWindow(_GLFWwindow* window)
 {
-    if (_glfw.wl.wmBase && !window->wl.xdg.toplevel)
-        createXdgSurface(window);
-    else if (!window->wl.shellSurface)
-        createShellSurface(window);
-    window->wl.visible = GLFW_TRUE;
+    if (!window->wl.visible)
+    {
+        if (_glfw.wl.wmBase)
+            createXdgSurface(window);
+        else if (!window->wl.shellSurface)
+            createShellSurface(window);
+        window->wl.visible = GLFW_TRUE;
+    }
 }
 
 void _glfwPlatformHideWindow(_GLFWwindow* window)

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -338,9 +338,10 @@ static void xdgToplevelHandleConfigure(void* data,
         _glfwInputWindowDamage(window);
     }
 
-    if (!activated && window->autoIconify)
+    if (!window->wl.justCreated && !activated && window->autoIconify)
         _glfwPlatformIconifyWindow(window);
     _glfwInputWindowFocus(window, activated);
+    window->wl.justCreated = GLFW_FALSE;
 }
 
 static void xdgToplevelHandleClose(void* data,
@@ -561,6 +562,7 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
                               const _GLFWctxconfig* ctxconfig,
                               const _GLFWfbconfig* fbconfig)
 {
+    window->wl.justCreated = GLFW_TRUE;
     window->wl.transparent = fbconfig->transparent;
 
     if (!createSurface(window, wndconfig))


### PR DESCRIPTION
This protocol matches desktops much better than the deprecated wl_shell, fixing a bunch of race conditions, removing undefined behaviour, adding missing features, and generally providing a much more user-friendly experience.

Since most compositors don’t support it yet, the wl_shell_surface role is kept as fallback for now.

I haven’t tested this new code at all, since my compositor doesn’t support it yet, hence the help wanted label.