### PR TITLE
[GLES] Include proper `glext` header with GL ES 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ information on what to include when reporting a bug.
 
 ## Changelog
 
+- [GLES] Include proper `glext` headers when required with OpenGL ES 3.x
 - Added `glfwGetError` function for querying the last error code and its
   description (#970)
 - Added `glfwUpdateGamepadMappings` function for importing gamepad mappings in

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -153,21 +153,21 @@ extern "C" {
 
  #include <GLES3/gl3.h>
  #if defined(GLFW_INCLUDE_GLEXT)
-  #include <GLES2/gl2ext.h>
+  #include <GLES3/gl3ext.h>
  #endif
 
 #elif defined(GLFW_INCLUDE_ES31)
 
  #include <GLES3/gl31.h>
  #if defined(GLFW_INCLUDE_GLEXT)
-  #include <GLES2/gl2ext.h>
+  #include <GLES3/gl3ext.h>
  #endif
 
 #elif defined(GLFW_INCLUDE_ES32)
 
  #include <GLES3/gl32.h>
  #if defined(GLFW_INCLUDE_GLEXT)
-  #include <GLES2/gl2ext.h>
+  #include <GLES3/gl3ext.h>
  #endif
 
 #elif defined(GLFW_INCLUDE_GLCOREARB)


### PR DESCRIPTION
When using OpenGL ES 3.x headers, setting the `GLFW_INCLUDE_GLEXT` macro would include `GLES2/gl2ext.h` instead of the version 3 (`GLES3/gl3ext.h`).