### PR TITLE
Implement window decorations

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -2453,10 +2453,11 @@ GLFWAPI void glfwWindowHintString(int hint, const char* value);
  *  GLFW_X11_CLASS_NAME and @ref GLFW_X11_INSTANCE_NAME window hints to override
  *  this.
  *
- *  @remark @wayland The window frame is currently unimplemented, as if
- *  [GLFW_DECORATED](@ref GLFW_DECORATED_hint) was always set to `GLFW_FALSE`.
- *  A compositor can still emit close, resize or maximize events, using for
- *  example a keybind mechanism.
+ *  @remark @wayland The window frame is currently very simple, only allowing
+ *  window resize or move.  A compositor can still emit close, maximize or
+ *  fullscreen events, using for example a keybind mechanism.  Additionally,
+ *  the wp_viewporter protocol is required for this feature, otherwise the
+ *  window will not be decorated.
  *
  *  @remark @wayland A full screen window will not attempt to change the mode,
  *  no matter what the requested size or refresh rate.
@@ -2897,10 +2898,6 @@ GLFWAPI void glfwGetFramebufferSize(GLFWwindow* window, int* width, int* height)
  *
  *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
  *  GLFW_PLATFORM_ERROR.
- *
- *  @remark @wayland The window frame is currently unimplemented, as if
- *  [GLFW_DECORATED](@ref GLFW_DECORATED_hint) was always set to `GLFW_FALSE`,
- *  so the returned values will always be zero.
  *
  *  @thread_safety This function must only be called from the main thread.
  *

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,6 +45,10 @@ elseif (_GLFW_WAYLAND)
         BASENAME xdg-shell)
     ecm_add_wayland_client_protocol(glfw_SOURCES
         PROTOCOL
+        "${WAYLAND_PROTOCOLS_PKGDATADIR}/stable/viewporter/viewporter.xml"
+        BASENAME viewporter)
+    ecm_add_wayland_client_protocol(glfw_SOURCES
+        PROTOCOL
         "${WAYLAND_PROTOCOLS_PKGDATADIR}/unstable/relative-pointer/relative-pointer-unstable-v1.xml"
         BASENAME relative-pointer-unstable-v1)
     ecm_add_wayland_client_protocol(glfw_SOURCES

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -108,7 +108,7 @@ static void pointerHandleMotion(void* data,
 }
 
 static void pointerHandleButton(void* data,
-                                struct wl_pointer* wl_pointer,
+                                struct wl_pointer* pointer,
                                 uint32_t serial,
                                 uint32_t time,
                                 uint32_t button,
@@ -135,7 +135,7 @@ static void pointerHandleButton(void* data,
 }
 
 static void pointerHandleAxis(void* data,
-                              struct wl_pointer* wl_pointer,
+                              struct wl_pointer* pointer,
                               uint32_t time,
                               uint32_t axis,
                               wl_fixed_t value)

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -54,6 +54,8 @@ static void pointerHandleEnter(void* data,
         return;
 
     _GLFWwindow* window = wl_surface_get_user_data(surface);
+    if (!window)
+        return;
 
     _glfw.wl.pointerSerial = serial;
     _glfw.wl.pointerFocus = window;
@@ -280,6 +282,8 @@ static void keyboardHandleEnter(void* data,
         return;
 
     _GLFWwindow* window = wl_surface_get_user_data(surface);
+    if (!window)
+        return;
 
     _glfw.wl.keyboardFocus = window;
     _glfwInputWindowFocus(window, GLFW_TRUE);

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -527,6 +527,11 @@ static void registryHandleGlobal(void* data,
             wl_registry_bind(registry, name, &wl_compositor_interface,
                              _glfw.wl.compositorVersion);
     }
+    else if (strcmp(interface, "wl_subcompositor") == 0)
+    {
+        _glfw.wl.subcompositor =
+            wl_registry_bind(registry, name, &wl_subcompositor_interface, 1);
+    }
     else if (strcmp(interface, "wl_shm") == 0)
     {
         _glfw.wl.shm =

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -558,6 +558,11 @@ static void registryHandleGlobal(void* data,
             wl_registry_bind(registry, name, &xdg_wm_base_interface, 1);
         xdg_wm_base_add_listener(_glfw.wl.wmBase, &wmBaseListener, NULL);
     }
+    else if (strcmp(interface, "wp_viewporter") == 0)
+    {
+        _glfw.wl.viewporter =
+            wl_registry_bind(registry, name, &wp_viewporter_interface, 1);
+    }
     else if (strcmp(interface, "zwp_relative_pointer_manager_v1") == 0)
     {
         _glfw.wl.relativePointerManager =

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -1095,12 +1095,16 @@ void _glfwPlatformTerminate(void)
 
     if (_glfw.wl.cursorSurface)
         wl_surface_destroy(_glfw.wl.cursorSurface);
+    if (_glfw.wl.subcompositor)
+        wl_subcompositor_destroy(_glfw.wl.subcompositor);
     if (_glfw.wl.compositor)
         wl_compositor_destroy(_glfw.wl.compositor);
     if (_glfw.wl.shm)
         wl_shm_destroy(_glfw.wl.shm);
     if (_glfw.wl.shell)
         wl_shell_destroy(_glfw.wl.shell);
+    if (_glfw.wl.viewporter)
+        wp_viewporter_destroy(_glfw.wl.viewporter);
     if (_glfw.wl.wmBase)
         xdg_wm_base_destroy(_glfw.wl.wmBase);
     if (_glfw.wl.pointer)

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -53,6 +53,7 @@ typedef VkBool32 (APIENTRY *PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR
 #include "osmesa_context.h"
 
 #include "wayland-xdg-shell-client-protocol.h"
+#include "wayland-viewporter-client-protocol.h"
 #include "wayland-relative-pointer-unstable-v1-client-protocol.h"
 #include "wayland-pointer-constraints-unstable-v1-client-protocol.h"
 #include "wayland-idle-inhibit-unstable-v1-client-protocol.h"
@@ -197,6 +198,7 @@ typedef struct _GLFWlibraryWayland
     struct wl_pointer*          pointer;
     struct wl_keyboard*         keyboard;
     struct xdg_wm_base*         wmBase;
+    struct wp_viewporter*       viewporter;
     struct zwp_relative_pointer_manager_v1* relativePointerManager;
     struct zwp_pointer_constraints_v1*      pointerConstraints;
     struct zwp_idle_inhibit_manager_v1*     idleInhibitManager;

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -141,6 +141,26 @@ typedef xkb_keysym_t (* PFN_xkb_compose_state_get_one_sym)(struct xkb_compose_st
 #define xkb_compose_state_get_one_sym _glfw.wl.xkb.compose_state_get_one_sym
 #endif
 
+#define _GLFW_DECORATION_WIDTH 4
+#define _GLFW_DECORATION_TOP 24
+
+typedef enum _GLFWdecorationSideWayland
+{
+    mainWindow,
+    topDecoration,
+    leftDecoration,
+    rightDecoration,
+    bottomDecoration,
+
+} _GLFWdecorationSideWayland;
+
+typedef struct _GLFWdecorationWayland
+{
+    struct wl_surface*          surface;
+    struct wl_subsurface*       subsurface;
+    struct wp_viewport*         viewport;
+
+} _GLFWdecorationWayland;
 
 // Wayland-specific per-window data
 //
@@ -182,6 +202,12 @@ typedef struct _GLFWwindowWayland
 
     // This is a hack to prevent auto-iconification on creation.
     GLFWbool                    justCreated;
+
+    struct {
+        struct wl_buffer*                  buffer;
+        _GLFWdecorationWayland             top, left, right, bottom;
+        int                                focus;
+    } decorations;
 
 } _GLFWwindowWayland;
 

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -143,6 +143,8 @@ typedef xkb_keysym_t (* PFN_xkb_compose_state_get_one_sym)(struct xkb_compose_st
 
 #define _GLFW_DECORATION_WIDTH 4
 #define _GLFW_DECORATION_TOP 24
+#define _GLFW_DECORATION_VERTICAL (_GLFW_DECORATION_TOP + _GLFW_DECORATION_WIDTH)
+#define _GLFW_DECORATION_HORIZONTAL (2 * _GLFW_DECORATION_WIDTH)
 
 typedef enum _GLFWdecorationSideWayland
 {

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -192,6 +192,7 @@ typedef struct _GLFWlibraryWayland
     struct wl_display*          display;
     struct wl_registry*         registry;
     struct wl_compositor*       compositor;
+    struct wl_subcompositor*    subcompositor;
     struct wl_shell*            shell;
     struct wl_shm*              shm;
     struct wl_seat*             seat;

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -63,6 +63,10 @@ static void handleConfigure(void* data,
             width -= _GLFW_DECORATION_HORIZONTAL;
             height -= _GLFW_DECORATION_VERTICAL;
         }
+        if (width < 1)
+            width = 1;
+        if (height < 1)
+            height = 1;
 
         if (window->numer != GLFW_DONT_CARE && window->denom != GLFW_DONT_CARE)
         {

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -58,6 +58,12 @@ static void handleConfigure(void* data,
 
     if (!window->monitor)
     {
+        if (window->decorated)
+        {
+            width -= 2 * _GLFW_DECORATION_WIDTH;
+            height -= _GLFW_DECORATION_TOP + _GLFW_DECORATION_WIDTH;
+        }
+
         if (window->numer != GLFW_DONT_CARE && window->denom != GLFW_DONT_CARE)
         {
             aspectRatio = (float)width / (float)height;

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -254,6 +254,24 @@ static void createDecorations(_GLFWwindow* window)
                      window->wl.width + 2 * _GLFW_DECORATION_WIDTH, _GLFW_DECORATION_WIDTH);
 }
 
+static void destroyDecoration(_GLFWdecorationWayland* decoration)
+{
+    if (decoration->surface)
+        wl_surface_destroy(decoration->surface);
+    if (decoration->subsurface)
+        wl_subsurface_destroy(decoration->subsurface);
+    if (decoration->viewport)
+        wp_viewport_destroy(decoration->viewport);
+}
+
+static void destroyDecorations(_GLFWwindow* window)
+{
+    destroyDecoration(&window->wl.decorations.top);
+    destroyDecoration(&window->wl.decorations.left);
+    destroyDecoration(&window->wl.decorations.right);
+    destroyDecoration(&window->wl.decorations.bottom);
+}
+
 static void resizeWindow(_GLFWwindow* window, int width, int height)
 {
     wl_egl_window_resize(window->wl.native, width, height, 0, 0);
@@ -782,6 +800,8 @@ void _glfwPlatformDestroyWindow(_GLFWwindow* window)
 
     if (window->context.destroy)
         window->context.destroy(window);
+
+    destroyDecorations(window);
 
     if (window->wl.native)
         wl_egl_window_destroy(window->wl.native);

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -279,7 +279,7 @@ static void resizeWindow(_GLFWwindow* window, int width, int height)
 {
     wl_egl_window_resize(window->wl.native, width, height, 0, 0);
 
-    if (!_glfw.wl.viewporter)
+    if (!_glfw.wl.viewporter || !window->wl.decorations.top.surface)
         return;
 
     // Top decoration.
@@ -443,7 +443,8 @@ static GLFWbool createSurface(_GLFWwindow* window,
     if (!window->wl.transparent)
         setOpaqueRegion(window);
 
-    createDecorations(window);
+    if (window->decorated && !window->monitor)
+        createDecorations(window);
 
     return GLFW_TRUE;
 }
@@ -938,14 +939,17 @@ void _glfwPlatformGetWindowFrameSize(_GLFWwindow* window,
                                      int* left, int* top,
                                      int* right, int* bottom)
 {
-    if (top)
-        *top = _GLFW_DECORATION_TOP;
-    if (left)
-        *left = _GLFW_DECORATION_WIDTH;
-    if (right)
-        *right = _GLFW_DECORATION_WIDTH;
-    if (bottom)
-        *bottom = _GLFW_DECORATION_WIDTH;
+    if (window->decorated && !window->monitor)
+    {
+        if (top)
+            *top = _GLFW_DECORATION_TOP;
+        if (left)
+            *left = _GLFW_DECORATION_WIDTH;
+        if (right)
+            *right = _GLFW_DECORATION_WIDTH;
+        if (bottom)
+            *bottom = _GLFW_DECORATION_WIDTH;
+    }
 }
 
 void _glfwPlatformGetWindowContentScale(_GLFWwindow* window,
@@ -1109,10 +1113,13 @@ void _glfwPlatformSetWindowResizable(_GLFWwindow* window, GLFWbool enabled)
 
 void _glfwPlatformSetWindowDecorated(_GLFWwindow* window, GLFWbool enabled)
 {
-    if (enabled)
-        createDecorations(window);
-    else
-        destroyDecorations(window);
+    if (!window->monitor)
+    {
+        if (enabled)
+            createDecorations(window);
+        else
+            destroyDecorations(window);
+    }
 }
 
 void _glfwPlatformSetWindowFloating(_GLFWwindow* window, GLFWbool enabled)

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -238,6 +238,9 @@ static void createDecorations(_GLFWwindow* window)
     unsigned char data[] = { 224, 224, 224, 255 };
     const GLFWimage image = { 1, 1, data };
 
+    if (!_glfw.wl.viewporter)
+        return;
+
     struct wl_buffer* buffer = createShmBuffer(&image);
 
     createDecoration(&window->wl.decorations.top, window->wl.surface, buffer,
@@ -275,6 +278,9 @@ static void destroyDecorations(_GLFWwindow* window)
 static void resizeWindow(_GLFWwindow* window, int width, int height)
 {
     wl_egl_window_resize(window->wl.native, width, height, 0, 0);
+
+    if (!_glfw.wl.viewporter)
+        return;
 
     // Top decoration.
     wp_viewport_set_destination(window->wl.decorations.top.viewport, width, _GLFW_DECORATION_TOP);

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -898,8 +898,14 @@ void _glfwPlatformGetWindowFrameSize(_GLFWwindow* window,
                                      int* left, int* top,
                                      int* right, int* bottom)
 {
-    // TODO: will need a proper implementation once decorations are
-    // implemented, but for now just leave everything as 0.
+    if (top)
+        *top = _GLFW_DECORATION_TOP;
+    if (left)
+        *left = _GLFW_DECORATION_WIDTH;
+    if (right)
+        *right = _GLFW_DECORATION_WIDTH;
+    if (bottom)
+        *bottom = _GLFW_DECORATION_WIDTH;
 }
 
 void _glfwPlatformGetWindowContentScale(_GLFWwindow* window,

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -516,7 +516,7 @@ handleEvents(int timeout)
  * is set to ENOSPC. If posix_fallocate() is not supported, program may
  * receive SIGBUS on accessing mmap()'ed file contents instead.
  */
-int
+static int
 createAnonymousFile(off_t size)
 {
     static const char template[] = "/glfw-shared-XXXXXX";

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -58,7 +58,7 @@ static void handleConfigure(void* data,
 
     if (!window->monitor)
     {
-        if (window->decorated)
+        if (_glfw.wl.viewporter && window->decorated)
         {
             width -= _GLFW_DECORATION_HORIZONTAL;
             height -= _GLFW_DECORATION_VERTICAL;
@@ -308,7 +308,7 @@ static void resizeWindow(_GLFWwindow* window)
     _glfwInputFramebufferSize(window, scaledWidth, scaledHeight);
     _glfwInputWindowContentScale(window, scale, scale);
 
-    if (!_glfw.wl.viewporter || !window->wl.decorations.top.surface)
+    if (!window->wl.decorations.top.surface)
         return;
 
     // Top decoration.

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -1106,9 +1106,10 @@ void _glfwPlatformSetWindowResizable(_GLFWwindow* window, GLFWbool enabled)
 
 void _glfwPlatformSetWindowDecorated(_GLFWwindow* window, GLFWbool enabled)
 {
-    // TODO
-    _glfwInputError(GLFW_PLATFORM_ERROR,
-                    "Wayland: Window attribute setting not implemented yet");
+    if (enabled)
+        createDecorations(window);
+    else
+        destroyDecorations(window);
 }
 
 void _glfwPlatformSetWindowFloating(_GLFWwindow* window, GLFWbool enabled)

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -247,18 +247,23 @@ static void createDecorations(_GLFWwindow* window)
     if (!_glfw.wl.viewporter)
         return;
 
-    struct wl_buffer* buffer = createShmBuffer(&image);
+    if (!window->wl.decorations.buffer)
+        window->wl.decorations.buffer = createShmBuffer(&image);
 
-    createDecoration(&window->wl.decorations.top, window->wl.surface, buffer,
+    createDecoration(&window->wl.decorations.top, window->wl.surface,
+                     window->wl.decorations.buffer,
                      0, -_GLFW_DECORATION_TOP,
                      window->wl.width, _GLFW_DECORATION_TOP);
-    createDecoration(&window->wl.decorations.left, window->wl.surface, buffer,
+    createDecoration(&window->wl.decorations.left, window->wl.surface,
+                     window->wl.decorations.buffer,
                      -_GLFW_DECORATION_WIDTH, -_GLFW_DECORATION_TOP,
                      _GLFW_DECORATION_WIDTH, window->wl.height + _GLFW_DECORATION_TOP);
-    createDecoration(&window->wl.decorations.right, window->wl.surface, buffer,
+    createDecoration(&window->wl.decorations.right, window->wl.surface,
+                     window->wl.decorations.buffer,
                      window->wl.width, -_GLFW_DECORATION_TOP,
                      _GLFW_DECORATION_WIDTH, window->wl.height + _GLFW_DECORATION_TOP);
-    createDecoration(&window->wl.decorations.bottom, window->wl.surface, buffer,
+    createDecoration(&window->wl.decorations.bottom, window->wl.surface,
+                     window->wl.decorations.buffer,
                      -_GLFW_DECORATION_WIDTH, window->wl.height,
                      window->wl.width + _GLFW_DECORATION_HORIZONTAL, _GLFW_DECORATION_WIDTH);
 }
@@ -837,6 +842,8 @@ void _glfwPlatformDestroyWindow(_GLFWwindow* window)
         window->context.destroy(window);
 
     destroyDecorations(window);
+    if (window->wl.decorations.buffer)
+        wl_buffer_destroy(window->wl.decorations.buffer);
 
     if (window->wl.native)
         wl_egl_window_destroy(window->wl.native);

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -271,6 +271,9 @@ static void destroyDecoration(_GLFWdecorationWayland* decoration)
         wl_subsurface_destroy(decoration->subsurface);
     if (decoration->viewport)
         wp_viewport_destroy(decoration->viewport);
+    decoration->surface = NULL;
+    decoration->subsurface = NULL;
+    decoration->viewport = NULL;
 }
 
 static void destroyDecorations(_GLFWwindow* window)
@@ -476,6 +479,7 @@ static void setFullscreen(_GLFWwindow* window, _GLFWmonitor* monitor, int refres
             monitor->wl.output);
     }
     setIdleInhibitor(window, GLFW_TRUE);
+    destroyDecorations(window);
 }
 
 static GLFWbool createShellSurface(_GLFWwindow* window)
@@ -1073,6 +1077,8 @@ void _glfwPlatformSetWindowMonitor(_GLFWwindow* window,
         else if (window->wl.shellSurface)
             wl_shell_surface_set_toplevel(window->wl.shellSurface);
         setIdleInhibitor(window, GLFW_FALSE);
+        if (window->decorated)
+            createDecorations(window);
     }
     _glfwInputWindowMonitor(window, monitor);
 }


### PR DESCRIPTION
This PR implements window decorations on Wayland.

The current design is to allocate a single buffer mapped from a single pixel, and to scale it using a `wp_viewport` on each of the four surfaces.  This prevents buttons and text from being drawn there, but at least for text I’m not sure we want that inside of GLFW.

Resizing from the left, top-left or top side moves the right and bottom sides while they should stay in place, I’m not sure why, but I wouldn’t consider that a blocker either.

Disabling decorations, fullscreen, maximizing, and hidpi have all been tested now.

Here is how it looks on Weston: 
![wayland-screenshot](https://user-images.githubusercontent.com/7755816/34307137-df015120-e746-11e7-9608-e0646576758f.png)

Fixes #1068.