### PR TITLE
Fix HDEVNOTIFY handle leak

### DIFF
--- a/src/win32_init.c
+++ b/src/win32_init.c
@@ -351,9 +351,10 @@ static HWND createHelperWindow(void)
         dbi.dbcc_devicetype = DBT_DEVTYP_DEVICEINTERFACE;
         dbi.dbcc_classguid = GUID_DEVINTERFACE_HID;
 
-        RegisterDeviceNotificationW(window,
-                                    (DEV_BROADCAST_HDR*) &dbi,
-                                    DEVICE_NOTIFY_WINDOW_HANDLE);
+        _glfw.win32.deviceNotificationHandle =
+            RegisterDeviceNotificationW(window,
+                                        (DEV_BROADCAST_HDR*) &dbi,
+                                        DEVICE_NOTIFY_WINDOW_HANDLE);
     }
 
     while (PeekMessageW(&msg, _glfw.win32.helperWindowHandle, 0, 0, PM_REMOVE))
@@ -543,6 +544,9 @@ int _glfwPlatformInit(void)
 
 void _glfwPlatformTerminate(void)
 {
+    if (_glfw.win32.deviceNotificationHandle)
+        UnregisterDeviceNotification(_glfw.win32.deviceNotificationHandle);
+
     if (_glfw.win32.helperWindowHandle)
         DestroyWindow(_glfw.win32.helperWindowHandle);
 

--- a/src/win32_platform.h
+++ b/src/win32_platform.h
@@ -288,6 +288,7 @@ typedef struct _GLFWwindowWin32
 typedef struct _GLFWlibraryWin32
 {
     HWND                helperWindowHandle;
+    HDEVNOTIFY          deviceNotificationHandle;
     DWORD               foregroundLockTimeout;
     int                 acquiredMonitorCount;
     char*               clipboardString;


### PR DESCRIPTION
Added a call to UnregisterDeviceNotification with a handle obtained from RegisterDeviceNotificationW

This fixes memory debugger errors such as:
```
Error #1: LEAK 40 direct bytes 0x0d0ca300-0x0d0ca328 + 620 indirect bytes
# 0 replace_RtlAllocateHeap                      [d:\drmemory_package\common\alloc_replace.c:3770]
# 1 SECHOST.dll!I_ScRegisterDeviceNotification  +0x7e     (0x7424178f <SECHOST.dll+0x1178f>)
# 2 USER32.dll!GetDC                            +0xdd2    (0x73f10913 <USER32.dll+0x60913>)
# 3 USER32.dll!RegisterDeviceNotificationW      +0x31     (0x73ec75e2 <USER32.dll+0x175e2>)
# 4 createHelperWindow                           [(...)glfw/src/win32_init.c:330]
# 5 _glfwPlatformInit                            [(...)glfw/src/win32_init.c:418]
```