### PR TITLE
Use the _glfw_dlopen/dlsym/dlclose define

### DIFF
--- a/src/glx_context.c
+++ b/src/glx_context.c
@@ -223,7 +223,7 @@ static GLFWglproc getProcAddressGLX(const char* procname)
     else if (_glfw.glx.GetProcAddressARB)
         return _glfw.glx.GetProcAddressARB((const GLubyte*) procname);
     else
-        return dlsym(_glfw.glx.handle, procname);
+        return _glfw_dlsym(_glfw.glx.handle, procname);
 }
 
 // Destroy the OpenGL context
@@ -271,7 +271,7 @@ GLFWbool _glfwInitGLX(void)
 
     for (i = 0;  sonames[i];  i++)
     {
-        _glfw.glx.handle = dlopen(sonames[i], RTLD_LAZY | RTLD_GLOBAL);
+        _glfw.glx.handle = _glfw_dlopen(sonames[i]);
         if (_glfw.glx.handle)
             break;
     }
@@ -283,35 +283,35 @@ GLFWbool _glfwInitGLX(void)
     }
 
     _glfw.glx.GetFBConfigs =
-        dlsym(_glfw.glx.handle, "glXGetFBConfigs");
+        _glfw_dlsym(_glfw.glx.handle, "glXGetFBConfigs");
     _glfw.glx.GetFBConfigAttrib =
-        dlsym(_glfw.glx.handle, "glXGetFBConfigAttrib");
+        _glfw_dlsym(_glfw.glx.handle, "glXGetFBConfigAttrib");
     _glfw.glx.GetClientString =
-        dlsym(_glfw.glx.handle, "glXGetClientString");
+        _glfw_dlsym(_glfw.glx.handle, "glXGetClientString");
     _glfw.glx.QueryExtension =
-        dlsym(_glfw.glx.handle, "glXQueryExtension");
+        _glfw_dlsym(_glfw.glx.handle, "glXQueryExtension");
     _glfw.glx.QueryVersion =
-        dlsym(_glfw.glx.handle, "glXQueryVersion");
+        _glfw_dlsym(_glfw.glx.handle, "glXQueryVersion");
     _glfw.glx.DestroyContext =
-        dlsym(_glfw.glx.handle, "glXDestroyContext");
+        _glfw_dlsym(_glfw.glx.handle, "glXDestroyContext");
     _glfw.glx.MakeCurrent =
-        dlsym(_glfw.glx.handle, "glXMakeCurrent");
+        _glfw_dlsym(_glfw.glx.handle, "glXMakeCurrent");
     _glfw.glx.SwapBuffers =
-        dlsym(_glfw.glx.handle, "glXSwapBuffers");
+        _glfw_dlsym(_glfw.glx.handle, "glXSwapBuffers");
     _glfw.glx.QueryExtensionsString =
-        dlsym(_glfw.glx.handle, "glXQueryExtensionsString");
+        _glfw_dlsym(_glfw.glx.handle, "glXQueryExtensionsString");
     _glfw.glx.CreateNewContext =
-        dlsym(_glfw.glx.handle, "glXCreateNewContext");
+        _glfw_dlsym(_glfw.glx.handle, "glXCreateNewContext");
     _glfw.glx.CreateWindow =
-        dlsym(_glfw.glx.handle, "glXCreateWindow");
+        _glfw_dlsym(_glfw.glx.handle, "glXCreateWindow");
     _glfw.glx.DestroyWindow =
-        dlsym(_glfw.glx.handle, "glXDestroyWindow");
+        _glfw_dlsym(_glfw.glx.handle, "glXDestroyWindow");
     _glfw.glx.GetProcAddress =
-        dlsym(_glfw.glx.handle, "glXGetProcAddress");
+        _glfw_dlsym(_glfw.glx.handle, "glXGetProcAddress");
     _glfw.glx.GetProcAddressARB =
-        dlsym(_glfw.glx.handle, "glXGetProcAddressARB");
+        _glfw_dlsym(_glfw.glx.handle, "glXGetProcAddressARB");
     _glfw.glx.GetVisualFromFBConfig =
-        dlsym(_glfw.glx.handle, "glXGetVisualFromFBConfig");
+        _glfw_dlsym(_glfw.glx.handle, "glXGetVisualFromFBConfig");
 
     if (!_glfw.glx.GetFBConfigs ||
         !_glfw.glx.GetFBConfigAttrib ||
@@ -428,7 +428,7 @@ void _glfwTerminateGLX(void)
 
     if (_glfw.glx.handle)
     {
-        dlclose(_glfw.glx.handle);
+        _glfw_dlclose(_glfw.glx.handle);
         _glfw.glx.handle = NULL;
     }
 }

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -683,7 +683,7 @@ static void createKeyTables(void)
 
 int _glfwPlatformInit(void)
 {
-    _glfw.wl.xkb.handle = dlopen("libxkbcommon.so.0", RTLD_LAZY | RTLD_GLOBAL);
+    _glfw.wl.xkb.handle = _glfw_dlopen("libxkbcommon.so.0");
     if (!_glfw.wl.xkb.handle)
     {
         _glfwInputError(GLFW_PLATFORM_ERROR,
@@ -692,41 +692,41 @@ int _glfwPlatformInit(void)
     }
 
     _glfw.wl.xkb.context_new = (PFN_xkb_context_new)
-        dlsym(_glfw.wl.xkb.handle, "xkb_context_new");
+        _glfw_dlsym(_glfw.wl.xkb.handle, "xkb_context_new");
     _glfw.wl.xkb.context_unref = (PFN_xkb_context_unref)
-        dlsym(_glfw.wl.xkb.handle, "xkb_context_unref");
+        _glfw_dlsym(_glfw.wl.xkb.handle, "xkb_context_unref");
     _glfw.wl.xkb.keymap_new_from_string = (PFN_xkb_keymap_new_from_string)
-        dlsym(_glfw.wl.xkb.handle, "xkb_keymap_new_from_string");
+        _glfw_dlsym(_glfw.wl.xkb.handle, "xkb_keymap_new_from_string");
     _glfw.wl.xkb.keymap_unref = (PFN_xkb_keymap_unref)
-        dlsym(_glfw.wl.xkb.handle, "xkb_keymap_unref");
+        _glfw_dlsym(_glfw.wl.xkb.handle, "xkb_keymap_unref");
     _glfw.wl.xkb.keymap_mod_get_index = (PFN_xkb_keymap_mod_get_index)
-        dlsym(_glfw.wl.xkb.handle, "xkb_keymap_mod_get_index");
+        _glfw_dlsym(_glfw.wl.xkb.handle, "xkb_keymap_mod_get_index");
     _glfw.wl.xkb.state_new = (PFN_xkb_state_new)
-        dlsym(_glfw.wl.xkb.handle, "xkb_state_new");
+        _glfw_dlsym(_glfw.wl.xkb.handle, "xkb_state_new");
     _glfw.wl.xkb.state_unref = (PFN_xkb_state_unref)
-        dlsym(_glfw.wl.xkb.handle, "xkb_state_unref");
+        _glfw_dlsym(_glfw.wl.xkb.handle, "xkb_state_unref");
     _glfw.wl.xkb.state_key_get_syms = (PFN_xkb_state_key_get_syms)
-        dlsym(_glfw.wl.xkb.handle, "xkb_state_key_get_syms");
+        _glfw_dlsym(_glfw.wl.xkb.handle, "xkb_state_key_get_syms");
     _glfw.wl.xkb.state_update_mask = (PFN_xkb_state_update_mask)
-        dlsym(_glfw.wl.xkb.handle, "xkb_state_update_mask");
+        _glfw_dlsym(_glfw.wl.xkb.handle, "xkb_state_update_mask");
     _glfw.wl.xkb.state_serialize_mods = (PFN_xkb_state_serialize_mods)
-        dlsym(_glfw.wl.xkb.handle, "xkb_state_serialize_mods");
+        _glfw_dlsym(_glfw.wl.xkb.handle, "xkb_state_serialize_mods");
 
 #ifdef HAVE_XKBCOMMON_COMPOSE_H
     _glfw.wl.xkb.compose_table_new_from_locale = (PFN_xkb_compose_table_new_from_locale)
-        dlsym(_glfw.wl.xkb.handle, "xkb_compose_table_new_from_locale");
+        _glfw_dlsym(_glfw.wl.xkb.handle, "xkb_compose_table_new_from_locale");
     _glfw.wl.xkb.compose_table_unref = (PFN_xkb_compose_table_unref)
-        dlsym(_glfw.wl.xkb.handle, "xkb_compose_table_unref");
+        _glfw_dlsym(_glfw.wl.xkb.handle, "xkb_compose_table_unref");
     _glfw.wl.xkb.compose_state_new = (PFN_xkb_compose_state_new)
-        dlsym(_glfw.wl.xkb.handle, "xkb_compose_state_new");
+        _glfw_dlsym(_glfw.wl.xkb.handle, "xkb_compose_state_new");
     _glfw.wl.xkb.compose_state_unref = (PFN_xkb_compose_state_unref)
-        dlsym(_glfw.wl.xkb.handle, "xkb_compose_state_unref");
+        _glfw_dlsym(_glfw.wl.xkb.handle, "xkb_compose_state_unref");
     _glfw.wl.xkb.compose_state_feed = (PFN_xkb_compose_state_feed)
-        dlsym(_glfw.wl.xkb.handle, "xkb_compose_state_feed");
+        _glfw_dlsym(_glfw.wl.xkb.handle, "xkb_compose_state_feed");
     _glfw.wl.xkb.compose_state_get_status = (PFN_xkb_compose_state_get_status)
-        dlsym(_glfw.wl.xkb.handle, "xkb_compose_state_get_status");
+        _glfw_dlsym(_glfw.wl.xkb.handle, "xkb_compose_state_get_status");
     _glfw.wl.xkb.compose_state_get_one_sym = (PFN_xkb_compose_state_get_one_sym)
-        dlsym(_glfw.wl.xkb.handle, "xkb_compose_state_get_one_sym");
+        _glfw_dlsym(_glfw.wl.xkb.handle, "xkb_compose_state_get_one_sym");
 #endif
 
     _glfw.wl.display = wl_display_connect(NULL);

--- a/src/x11_init.c
+++ b/src/x11_init.c
@@ -461,17 +461,17 @@ static void detectEWMH(void)
 //
 static GLFWbool initExtensions(void)
 {
-    _glfw.x11.vidmode.handle = dlopen("libXxf86vm.so.1", RTLD_LAZY | RTLD_GLOBAL);
+    _glfw.x11.vidmode.handle = _glfw_dlopen("libXxf86vm.so.1");
     if (_glfw.x11.vidmode.handle)
     {
         _glfw.x11.vidmode.QueryExtension = (PFN_XF86VidModeQueryExtension)
-            dlsym(_glfw.x11.vidmode.handle, "XF86VidModeQueryExtension");
+            _glfw_dlsym(_glfw.x11.vidmode.handle, "XF86VidModeQueryExtension");
         _glfw.x11.vidmode.GetGammaRamp = (PFN_XF86VidModeGetGammaRamp)
-            dlsym(_glfw.x11.vidmode.handle, "XF86VidModeGetGammaRamp");
+            _glfw_dlsym(_glfw.x11.vidmode.handle, "XF86VidModeGetGammaRamp");
         _glfw.x11.vidmode.SetGammaRamp = (PFN_XF86VidModeSetGammaRamp)
-            dlsym(_glfw.x11.vidmode.handle, "XF86VidModeSetGammaRamp");
+            _glfw_dlsym(_glfw.x11.vidmode.handle, "XF86VidModeSetGammaRamp");
         _glfw.x11.vidmode.GetGammaRampSize = (PFN_XF86VidModeGetGammaRampSize)
-            dlsym(_glfw.x11.vidmode.handle, "XF86VidModeGetGammaRampSize");
+            _glfw_dlsym(_glfw.x11.vidmode.handle, "XF86VidModeGetGammaRampSize");
 
         _glfw.x11.vidmode.available =
             XF86VidModeQueryExtension(_glfw.x11.display,
@@ -479,13 +479,13 @@ static GLFWbool initExtensions(void)
                                       &_glfw.x11.vidmode.errorBase);
     }
 
-    _glfw.x11.xi.handle = dlopen("libXi.so.6", RTLD_LAZY | RTLD_GLOBAL);
+    _glfw.x11.xi.handle = _glfw_dlopen("libXi.so.6");
     if (_glfw.x11.xi.handle)
     {
         _glfw.x11.xi.QueryVersion = (PFN_XIQueryVersion)
-            dlsym(_glfw.x11.xi.handle, "XIQueryVersion");
+            _glfw_dlsym(_glfw.x11.xi.handle, "XIQueryVersion");
         _glfw.x11.xi.SelectEvents = (PFN_XISelectEvents)
-            dlsym(_glfw.x11.xi.handle, "XISelectEvents");
+            _glfw_dlsym(_glfw.x11.xi.handle, "XISelectEvents");
 
         if (XQueryExtension(_glfw.x11.display,
                             "XInputExtension",
@@ -505,45 +505,45 @@ static GLFWbool initExtensions(void)
         }
     }
 
-    _glfw.x11.randr.handle = dlopen("libXrandr.so.2", RTLD_LAZY | RTLD_GLOBAL);
+    _glfw.x11.randr.handle = _glfw_dlopen("libXrandr.so.2");
     if (_glfw.x11.randr.handle)
     {
         _glfw.x11.randr.AllocGamma = (PFN_XRRAllocGamma)
-            dlsym(_glfw.x11.randr.handle, "XRRAllocGamma");
+            _glfw_dlsym(_glfw.x11.randr.handle, "XRRAllocGamma");
         _glfw.x11.randr.FreeGamma = (PFN_XRRFreeGamma)
-            dlsym(_glfw.x11.randr.handle, "XRRFreeGamma");
+            _glfw_dlsym(_glfw.x11.randr.handle, "XRRFreeGamma");
         _glfw.x11.randr.FreeCrtcInfo = (PFN_XRRFreeCrtcInfo)
-            dlsym(_glfw.x11.randr.handle, "XRRFreeCrtcInfo");
+            _glfw_dlsym(_glfw.x11.randr.handle, "XRRFreeCrtcInfo");
         _glfw.x11.randr.FreeGamma = (PFN_XRRFreeGamma)
-            dlsym(_glfw.x11.randr.handle, "XRRFreeGamma");
+            _glfw_dlsym(_glfw.x11.randr.handle, "XRRFreeGamma");
         _glfw.x11.randr.FreeOutputInfo = (PFN_XRRFreeOutputInfo)
-            dlsym(_glfw.x11.randr.handle, "XRRFreeOutputInfo");
+            _glfw_dlsym(_glfw.x11.randr.handle, "XRRFreeOutputInfo");
         _glfw.x11.randr.FreeScreenResources = (PFN_XRRFreeScreenResources)
-            dlsym(_glfw.x11.randr.handle, "XRRFreeScreenResources");
+            _glfw_dlsym(_glfw.x11.randr.handle, "XRRFreeScreenResources");
         _glfw.x11.randr.GetCrtcGamma = (PFN_XRRGetCrtcGamma)
-            dlsym(_glfw.x11.randr.handle, "XRRGetCrtcGamma");
+            _glfw_dlsym(_glfw.x11.randr.handle, "XRRGetCrtcGamma");
         _glfw.x11.randr.GetCrtcGammaSize = (PFN_XRRGetCrtcGammaSize)
-            dlsym(_glfw.x11.randr.handle, "XRRGetCrtcGammaSize");
+            _glfw_dlsym(_glfw.x11.randr.handle, "XRRGetCrtcGammaSize");
         _glfw.x11.randr.GetCrtcInfo = (PFN_XRRGetCrtcInfo)
-            dlsym(_glfw.x11.randr.handle, "XRRGetCrtcInfo");
+            _glfw_dlsym(_glfw.x11.randr.handle, "XRRGetCrtcInfo");
         _glfw.x11.randr.GetOutputInfo = (PFN_XRRGetOutputInfo)
-            dlsym(_glfw.x11.randr.handle, "XRRGetOutputInfo");
+            _glfw_dlsym(_glfw.x11.randr.handle, "XRRGetOutputInfo");
         _glfw.x11.randr.GetOutputPrimary = (PFN_XRRGetOutputPrimary)
-            dlsym(_glfw.x11.randr.handle, "XRRGetOutputPrimary");
+            _glfw_dlsym(_glfw.x11.randr.handle, "XRRGetOutputPrimary");
         _glfw.x11.randr.GetScreenResourcesCurrent = (PFN_XRRGetScreenResourcesCurrent)
-            dlsym(_glfw.x11.randr.handle, "XRRGetScreenResourcesCurrent");
+            _glfw_dlsym(_glfw.x11.randr.handle, "XRRGetScreenResourcesCurrent");
         _glfw.x11.randr.QueryExtension = (PFN_XRRQueryExtension)
-            dlsym(_glfw.x11.randr.handle, "XRRQueryExtension");
+            _glfw_dlsym(_glfw.x11.randr.handle, "XRRQueryExtension");
         _glfw.x11.randr.QueryVersion = (PFN_XRRQueryVersion)
-            dlsym(_glfw.x11.randr.handle, "XRRQueryVersion");
+            _glfw_dlsym(_glfw.x11.randr.handle, "XRRQueryVersion");
         _glfw.x11.randr.SelectInput = (PFN_XRRSelectInput)
-            dlsym(_glfw.x11.randr.handle, "XRRSelectInput");
+            _glfw_dlsym(_glfw.x11.randr.handle, "XRRSelectInput");
         _glfw.x11.randr.SetCrtcConfig = (PFN_XRRSetCrtcConfig)
-            dlsym(_glfw.x11.randr.handle, "XRRSetCrtcConfig");
+            _glfw_dlsym(_glfw.x11.randr.handle, "XRRSetCrtcConfig");
         _glfw.x11.randr.SetCrtcGamma = (PFN_XRRSetCrtcGamma)
-            dlsym(_glfw.x11.randr.handle, "XRRSetCrtcGamma");
+            _glfw_dlsym(_glfw.x11.randr.handle, "XRRSetCrtcGamma");
         _glfw.x11.randr.UpdateConfiguration = (PFN_XRRUpdateConfiguration)
-            dlsym(_glfw.x11.randr.handle, "XRRUpdateConfiguration");
+            _glfw_dlsym(_glfw.x11.randr.handle, "XRRUpdateConfiguration");
 
         if (XRRQueryExtension(_glfw.x11.display,
                               &_glfw.x11.randr.eventBase,
@@ -593,26 +593,26 @@ static GLFWbool initExtensions(void)
                        RROutputChangeNotifyMask);
     }
 
-    _glfw.x11.xcursor.handle = dlopen("libXcursor.so.1", RTLD_LAZY | RTLD_GLOBAL);
+    _glfw.x11.xcursor.handle = _glfw_dlopen("libXcursor.so.1");
     if (_glfw.x11.xcursor.handle)
     {
         _glfw.x11.xcursor.ImageCreate = (PFN_XcursorImageCreate)
-            dlsym(_glfw.x11.xcursor.handle, "XcursorImageCreate");
+            _glfw_dlsym(_glfw.x11.xcursor.handle, "XcursorImageCreate");
         _glfw.x11.xcursor.ImageDestroy = (PFN_XcursorImageDestroy)
-            dlsym(_glfw.x11.xcursor.handle, "XcursorImageDestroy");
+            _glfw_dlsym(_glfw.x11.xcursor.handle, "XcursorImageDestroy");
         _glfw.x11.xcursor.ImageLoadCursor = (PFN_XcursorImageLoadCursor)
-            dlsym(_glfw.x11.xcursor.handle, "XcursorImageLoadCursor");
+            _glfw_dlsym(_glfw.x11.xcursor.handle, "XcursorImageLoadCursor");
     }
 
-    _glfw.x11.xinerama.handle = dlopen("libXinerama.so.1", RTLD_LAZY | RTLD_GLOBAL);
+    _glfw.x11.xinerama.handle = _glfw_dlopen("libXinerama.so.1");
     if (_glfw.x11.xinerama.handle)
     {
         _glfw.x11.xinerama.IsActive = (PFN_XineramaIsActive)
-            dlsym(_glfw.x11.xinerama.handle, "XineramaIsActive");
+            _glfw_dlsym(_glfw.x11.xinerama.handle, "XineramaIsActive");
         _glfw.x11.xinerama.QueryExtension = (PFN_XineramaQueryExtension)
-            dlsym(_glfw.x11.xinerama.handle, "XineramaQueryExtension");
+            _glfw_dlsym(_glfw.x11.xinerama.handle, "XineramaQueryExtension");
         _glfw.x11.xinerama.QueryScreens = (PFN_XineramaQueryScreens)
-            dlsym(_glfw.x11.xinerama.handle, "XineramaQueryScreens");
+            _glfw_dlsym(_glfw.x11.xinerama.handle, "XineramaQueryScreens");
 
         if (XineramaQueryExtension(_glfw.x11.display,
                                    &_glfw.x11.xinerama.major,
@@ -644,22 +644,22 @@ static GLFWbool initExtensions(void)
         }
     }
 
-    _glfw.x11.x11xcb.handle = dlopen("libX11-xcb.so.1", RTLD_LAZY | RTLD_GLOBAL);
+    _glfw.x11.x11xcb.handle = _glfw_dlopen("libX11-xcb.so.1");
     if (_glfw.x11.x11xcb.handle)
     {
         _glfw.x11.x11xcb.GetXCBConnection = (PFN_XGetXCBConnection)
-            dlsym(_glfw.x11.x11xcb.handle, "XGetXCBConnection");
+            _glfw_dlsym(_glfw.x11.x11xcb.handle, "XGetXCBConnection");
     }
 
-    _glfw.x11.xrender.handle = dlopen("libXrender.so.1", RTLD_LAZY | RTLD_GLOBAL);
+    _glfw.x11.xrender.handle = _glfw_dlopen("libXrender.so.1");
     if (_glfw.x11.xrender.handle)
     {
         _glfw.x11.xrender.QueryExtension = (PFN_XRenderQueryExtension)
-            dlsym(_glfw.x11.xrender.handle, "XRenderQueryExtension");
+            _glfw_dlsym(_glfw.x11.xrender.handle, "XRenderQueryExtension");
         _glfw.x11.xrender.QueryVersion = (PFN_XRenderQueryVersion)
-            dlsym(_glfw.x11.xrender.handle, "XRenderQueryVersion");
+            _glfw_dlsym(_glfw.x11.xrender.handle, "XRenderQueryVersion");
         _glfw.x11.xrender.FindVisualFormat = (PFN_XRenderFindVisualFormat)
-            dlsym(_glfw.x11.xrender.handle, "XRenderFindVisualFormat");
+            _glfw_dlsym(_glfw.x11.xrender.handle, "XRenderFindVisualFormat");
 
         if (XRenderQueryExtension(_glfw.x11.display,
                                   &_glfw.x11.xrender.errorBase,
@@ -1002,25 +1002,25 @@ void _glfwPlatformTerminate(void)
 
     if (_glfw.x11.x11xcb.handle)
     {
-        dlclose(_glfw.x11.x11xcb.handle);
+        _glfw_dlclose(_glfw.x11.x11xcb.handle);
         _glfw.x11.x11xcb.handle = NULL;
     }
 
     if (_glfw.x11.xcursor.handle)
     {
-        dlclose(_glfw.x11.xcursor.handle);
+        _glfw_dlclose(_glfw.x11.xcursor.handle);
         _glfw.x11.xcursor.handle = NULL;
     }
 
     if (_glfw.x11.randr.handle)
     {
-        dlclose(_glfw.x11.randr.handle);
+        _glfw_dlclose(_glfw.x11.randr.handle);
         _glfw.x11.randr.handle = NULL;
     }
 
     if (_glfw.x11.xinerama.handle)
     {
-        dlclose(_glfw.x11.xinerama.handle);
+        _glfw_dlclose(_glfw.x11.xinerama.handle);
         _glfw.x11.xinerama.handle = NULL;
     }
 


### PR DESCRIPTION
The only functional difference is the change from `RTLD_GLOBAL` to `RTLD_LOCAL`, which is more correct in our case as we never want to expose loaded symbols to other shared objects.