### PR TITLE
Fix glfwTerminate() segfault when glfwInit() failed

### DIFF
--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -771,15 +771,22 @@ void _glfwPlatformTerminate(void)
     _glfwTerminateJoysticksLinux();
 
 #ifdef HAVE_XKBCOMMON_COMPOSE_H
-    xkb_compose_state_unref(_glfw.wl.xkb.composeState);
+    if (_glfw.wl.xkb.composeState)
+        xkb_compose_state_unref(_glfw.wl.xkb.composeState);
 #endif
 
-    xkb_keymap_unref(_glfw.wl.xkb.keymap);
-    xkb_state_unref(_glfw.wl.xkb.state);
-    xkb_context_unref(_glfw.wl.xkb.context);
+    if (_glfw.wl.xkb.keymap)
+        xkb_keymap_unref(_glfw.wl.xkb.keymap);
+    if (_glfw.wl.xkb.state)
+        xkb_state_unref(_glfw.wl.xkb.state);
+    if (_glfw.wl.xkb.context)
+        xkb_context_unref(_glfw.wl.xkb.context);
 
-    dlclose(_glfw.wl.xkb.handle);
-    _glfw.wl.xkb.handle = NULL;
+    if (_glfw.wl.xkb.handle)
+    {
+        _glfw_dlclose(_glfw.wl.xkb.handle);
+        _glfw.wl.xkb.handle = NULL;
+    }
 
     if (_glfw.wl.cursorTheme)
         wl_cursor_theme_destroy(_glfw.wl.cursorTheme);


### PR DESCRIPTION
All of the `_unref()` functions require a non-`NULL` argument, same for `dlclose()`.