### PR TITLE
Load libwayland-egl and libwayland-cursor at runtime

### DIFF
--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -686,7 +686,7 @@ int _glfwPlatformInit(void)
     if (!_glfw.wl.cursor.handle)
     {
         _glfwInputError(GLFW_PLATFORM_ERROR,
-                        "Wayland: Failed to open libwayland-cursor.");
+                        "Wayland: Failed to open libwayland-cursor");
         return GLFW_FALSE;
     }
 
@@ -703,7 +703,7 @@ int _glfwPlatformInit(void)
     if (!_glfw.wl.egl.handle)
     {
         _glfwInputError(GLFW_PLATFORM_ERROR,
-                        "Wayland: Failed to open libwayland-egl.");
+                        "Wayland: Failed to open libwayland-egl");
         return GLFW_FALSE;
     }
 
@@ -718,7 +718,7 @@ int _glfwPlatformInit(void)
     if (!_glfw.wl.xkb.handle)
     {
         _glfwInputError(GLFW_PLATFORM_ERROR,
-                        "Wayland: Failed to open libxkbcommon.");
+                        "Wayland: Failed to open libxkbcommon");
         return GLFW_FALSE;
     }
 
@@ -798,7 +798,7 @@ int _glfwPlatformInit(void)
         if (!_glfw.wl.cursorTheme)
         {
             _glfwInputError(GLFW_PLATFORM_ERROR,
-                            "Wayland: Unable to load default cursor theme\n");
+                            "Wayland: Unable to load default cursor theme");
             return GLFW_FALSE;
         }
         _glfw.wl.cursorSurface =

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -683,6 +683,21 @@ static void createKeyTables(void)
 
 int _glfwPlatformInit(void)
 {
+    _glfw.wl.egl.handle = _glfw_dlopen("libwayland-egl.so.1");
+    if (!_glfw.wl.egl.handle)
+    {
+        _glfwInputError(GLFW_PLATFORM_ERROR,
+                        "Wayland: Failed to open libwayland-egl.");
+        return GLFW_FALSE;
+    }
+
+    _glfw.wl.egl.window_create = (PFN_wl_egl_window_create)
+        _glfw_dlsym(_glfw.wl.egl.handle, "wl_egl_window_create");
+    _glfw.wl.egl.window_destroy = (PFN_wl_egl_window_destroy)
+        _glfw_dlsym(_glfw.wl.egl.handle, "wl_egl_window_destroy");
+    _glfw.wl.egl.window_resize = (PFN_wl_egl_window_resize)
+        _glfw_dlsym(_glfw.wl.egl.handle, "wl_egl_window_resize");
+
     _glfw.wl.xkb.handle = _glfw_dlopen("libxkbcommon.so.0");
     if (!_glfw.wl.xkb.handle)
     {
@@ -798,6 +813,11 @@ void _glfwPlatformTerminate(void)
     {
         _glfw_dlclose(_glfw.wl.xkb.handle);
         _glfw.wl.xkb.handle = NULL;
+    }
+    if (_glfw.wl.egl.handle)
+    {
+        _glfw_dlclose(_glfw.wl.egl.handle);
+        _glfw.wl.egl.handle = NULL;
     }
 
     if (_glfw.wl.cursorTheme)

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -71,6 +71,13 @@ typedef VkBool32 (APIENTRY *PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR
 #define _GLFW_PLATFORM_CONTEXT_STATE
 #define _GLFW_PLATFORM_LIBRARY_CONTEXT_STATE
 
+typedef struct wl_egl_window* (* PFN_wl_egl_window_create)(struct wl_surface*, int, int);
+typedef void (* PFN_wl_egl_window_destroy)(struct wl_egl_window*);
+typedef void (* PFN_wl_egl_window_resize)(struct wl_egl_window*, int, int, int, int);
+#define wl_egl_window_create _glfw.wl.egl.window_create
+#define wl_egl_window_destroy _glfw.wl.egl.window_destroy
+#define wl_egl_window_resize _glfw.wl.egl.window_resize
+
 typedef struct xkb_context* (* PFN_xkb_context_new)(enum xkb_context_flags);
 typedef void (* PFN_xkb_context_unref)(struct xkb_context*);
 typedef struct xkb_keymap* (* PFN_xkb_keymap_new_from_string)(struct xkb_context*, const char*, enum xkb_keymap_format, enum xkb_keymap_compile_flags);
@@ -212,6 +219,14 @@ typedef struct _GLFWlibraryWayland
 
     _GLFWwindow*                pointerFocus;
     _GLFWwindow*                keyboardFocus;
+
+    struct {
+        void*                   handle;
+
+        PFN_wl_egl_window_create window_create;
+        PFN_wl_egl_window_destroy window_destroy;
+        PFN_wl_egl_window_resize window_resize;
+    } egl;
 
 } _GLFWlibraryWayland;
 

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -71,6 +71,27 @@ typedef VkBool32 (APIENTRY *PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR
 #define _GLFW_PLATFORM_CONTEXT_STATE
 #define _GLFW_PLATFORM_LIBRARY_CONTEXT_STATE
 
+struct wl_cursor_image {
+    uint32_t width;
+    uint32_t height;
+    uint32_t hotspot_x;
+    uint32_t hotspot_y;
+    uint32_t delay;
+};
+struct wl_cursor {
+    unsigned int image_count;
+    struct wl_cursor_image** images;
+    char* name;
+};
+typedef struct wl_cursor_theme* (* PFN_wl_cursor_theme_load)(const char*, int, struct wl_shm*);
+typedef void (* PFN_wl_cursor_theme_destroy)(struct wl_cursor_theme*);
+typedef struct wl_cursor* (* PFN_wl_cursor_theme_get_cursor)(struct wl_cursor_theme*, const char*);
+typedef struct wl_buffer* (* PFN_wl_cursor_image_get_buffer)(struct wl_cursor_image*);
+#define wl_cursor_theme_load _glfw.wl.cursor.theme_load
+#define wl_cursor_theme_destroy _glfw.wl.cursor.theme_destroy
+#define wl_cursor_theme_get_cursor _glfw.wl.cursor.theme_get_cursor
+#define wl_cursor_image_get_buffer _glfw.wl.cursor.image_get_buffer
+
 typedef struct wl_egl_window* (* PFN_wl_egl_window_create)(struct wl_surface*, int, int);
 typedef void (* PFN_wl_egl_window_destroy)(struct wl_egl_window*);
 typedef void (* PFN_wl_egl_window_resize)(struct wl_egl_window*, int, int, int, int);
@@ -219,6 +240,15 @@ typedef struct _GLFWlibraryWayland
 
     _GLFWwindow*                pointerFocus;
     _GLFWwindow*                keyboardFocus;
+
+    struct {
+        void*                   handle;
+
+        PFN_wl_cursor_theme_load theme_load;
+        PFN_wl_cursor_theme_destroy theme_destroy;
+        PFN_wl_cursor_theme_get_cursor theme_get_cursor;
+        PFN_wl_cursor_image_get_buffer image_get_buffer;
+    } cursor;
 
     struct {
         void*                   handle;

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -37,7 +37,6 @@
 #include <sys/mman.h>
 #include <poll.h>
 
-#include <wayland-egl.h>
 #include <wayland-cursor.h>
 
 

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -37,8 +37,6 @@
 #include <sys/mman.h>
 #include <poll.h>
 
-#include <wayland-cursor.h>
-
 
 static void handlePing(void* data,
                        struct wl_shell_surface* shellSurface,


### PR DESCRIPTION
This depends on #1171, and loads these two helper libraries using dlopen/dlsym/dlclose.

Only libwayland-client remains.