### PR TITLE
Win32: Fix _glfwPlatformShowWindow() from activating the window

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ information on what to include when reporting a bug.
 - [Win32] Bugfix: Undecorated windows did not maximize to workarea (#899)
 - [Win32] Bugfix: Window was resized twice when entering full screen (#1085)
 - [Win32] Bugfix: The HID device notification was not unregistered (#1170)
+- [Win32] Bugfix: `glfwCreateWindow` activated window even with `GLFW_FOCUSED` 
+                  hint set to false (#1179)  
 - [X11] Moved to XI2 `XI_RawMotion` for disable cursor mode motion input (#125)
 - [X11] Replaced `_GLFW_HAS_XF86VM` compile-time option with dynamic loading
 - [X11] Bugfix: `glfwGetVideoMode` would segfault on Cygwin/X

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -1451,7 +1451,7 @@ void _glfwPlatformMaximizeWindow(_GLFWwindow* window)
 
 void _glfwPlatformShowWindow(_GLFWwindow* window)
 {
-    ShowWindow(window->win32.handle, SW_SHOW);
+    ShowWindow(window->win32.handle, SW_SHOWNA);
 }
 
 void _glfwPlatformHideWindow(_GLFWwindow* window)


### PR DESCRIPTION
Fix suggestion, as discussed in #1179 
