### PR TITLE
Prevent a race between surface destruction and focus

### DIFF
--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -49,6 +49,10 @@ static void pointerHandleEnter(void* data,
                                wl_fixed_t sx,
                                wl_fixed_t sy)
 {
+    // Happens in the case we just destroyed the surface.
+    if (!surface)
+        return;
+
     _GLFWwindow* window = wl_surface_get_user_data(surface);
 
     _glfw.wl.pointerSerial = serial;
@@ -280,6 +284,10 @@ static void keyboardHandleEnter(void* data,
                                 struct wl_surface* surface,
                                 struct wl_array* keys)
 {
+    // Happens in the case we just destroyed the surface.
+    if (!surface)
+        return;
+
     _GLFWwindow* window = wl_surface_get_user_data(surface);
 
     _glfw.wl.keyboardFocus = window;


### PR DESCRIPTION
The Wayland protocol is asynchronous, by the time we destroy a surface,
the compositor may have sent a wl_keyboard::enter or wl_pointer::enter
events which now point to no surface, yet we receive it after.

To prevent this race, we can just ignore any enter event targetting a
NULL surface.

Fixes #1150.