### PR TITLE
Implement key repeat on Wayland

### DIFF
--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -422,12 +422,25 @@ static void keyboardHandleModifiers(void* data,
     _glfw.wl.xkb.modifiers = modifiers;
 }
 
+static void keyboardHandleRepeatInfo(void* data,
+                                     struct wl_keyboard* keyboard,
+                                     int32_t rate,
+                                     int32_t delay)
+{
+    if (keyboard != _glfw.wl.keyboard)
+        return;
+
+    _glfw.wl.keyboardRepeatRate = rate;
+    _glfw.wl.keyboardRepeatDelay = delay;
+}
+
 static const struct wl_keyboard_listener keyboardListener = {
     keyboardHandleKeymap,
     keyboardHandleEnter,
     keyboardHandleLeave,
     keyboardHandleKey,
     keyboardHandleModifiers,
+    keyboardHandleRepeatInfo,
 };
 
 static void seatHandleCapabilities(void* data,
@@ -457,8 +470,15 @@ static void seatHandleCapabilities(void* data,
     }
 }
 
+static void seatHandleName(void* data,
+                           struct wl_seat* seat,
+                           const char* name)
+{
+}
+
 static const struct wl_seat_listener seatListener = {
-    seatHandleCapabilities
+    seatHandleCapabilities,
+    seatHandleName,
 };
 
 static void wmBaseHandlePing(void* data,
@@ -503,8 +523,10 @@ static void registryHandleGlobal(void* data,
     {
         if (!_glfw.wl.seat)
         {
+            _glfw.wl.seatVersion = min(4, version);
             _glfw.wl.seat =
-                wl_registry_bind(registry, name, &wl_seat_interface, 1);
+                wl_registry_bind(registry, name, &wl_seat_interface,
+                                 _glfw.wl.seatVersion);
             wl_seat_add_listener(_glfw.wl.seat, &seatListener, NULL);
         }
     }

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -437,6 +437,7 @@ static void keyboardHandleModifiers(void* data,
     _glfw.wl.xkb.modifiers = modifiers;
 }
 
+#ifdef WL_KEYBOARD_REPEAT_INFO_SINCE_VERSION
 static void keyboardHandleRepeatInfo(void* data,
                                      struct wl_keyboard* keyboard,
                                      int32_t rate,
@@ -448,6 +449,7 @@ static void keyboardHandleRepeatInfo(void* data,
     _glfw.wl.keyboardRepeatRate = rate;
     _glfw.wl.keyboardRepeatDelay = delay;
 }
+#endif
 
 static const struct wl_keyboard_listener keyboardListener = {
     keyboardHandleKeymap,
@@ -455,7 +457,9 @@ static const struct wl_keyboard_listener keyboardListener = {
     keyboardHandleLeave,
     keyboardHandleKey,
     keyboardHandleModifiers,
+#ifdef WL_KEYBOARD_REPEAT_INFO_SINCE_VERSION
     keyboardHandleRepeatInfo,
+#endif
 };
 
 static void seatHandleCapabilities(void* data,

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -329,7 +329,7 @@ static xkb_keysym_t composeSymbol(xkb_keysym_t sym)
 }
 #endif
 
-static void inputChar(_GLFWwindow* window, uint32_t key)
+static GLFWbool inputChar(_GLFWwindow* window, uint32_t key)
 {
     uint32_t code, numSyms;
     long cp;
@@ -354,6 +354,8 @@ static void inputChar(_GLFWwindow* window, uint32_t key)
             _glfwInputChar(window, cp, mods, plain);
         }
     }
+
+    return xkb_keymap_key_repeats(_glfw.wl.xkb.keymap, syms[0]);
 }
 
 static void keyboardHandleKey(void* data,
@@ -366,6 +368,7 @@ static void keyboardHandleKey(void* data,
     int keyCode;
     int action;
     _GLFWwindow* window = _glfw.wl.keyboardFocus;
+    GLFWbool shouldRepeat;
     struct itimerspec timer = {};
 
     if (!window)
@@ -380,9 +383,9 @@ static void keyboardHandleKey(void* data,
 
     if (action == GLFW_PRESS)
     {
-        inputChar(window, key);
+        shouldRepeat = inputChar(window, key);
 
-        if (_glfw.wl.keyboardRepeatRate > 0)
+        if (shouldRepeat && _glfw.wl.keyboardRepeatRate > 0)
         {
             _glfw.wl.keyboardLastKey = keyCode;
             _glfw.wl.keyboardLastScancode = key;

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -848,7 +848,7 @@ int _glfwPlatformInit(void)
 
     _glfw.wl.timerfd = -1;
     if (_glfw.wl.seatVersion >= 4)
-        _glfw.wl.timerfd = timerfd_create(CLOCK_MONOTONIC, 0);
+        _glfw.wl.timerfd = timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC);
 
     if (_glfw.wl.pointer && _glfw.wl.shm)
     {

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -781,6 +781,8 @@ int _glfwPlatformInit(void)
         _glfw_dlsym(_glfw.wl.xkb.handle, "xkb_keymap_unref");
     _glfw.wl.xkb.keymap_mod_get_index = (PFN_xkb_keymap_mod_get_index)
         _glfw_dlsym(_glfw.wl.xkb.handle, "xkb_keymap_mod_get_index");
+    _glfw.wl.xkb.keymap_key_repeats = (PFN_xkb_keymap_key_repeats)
+        _glfw_dlsym(_glfw.wl.xkb.handle, "xkb_keymap_key_repeats");
     _glfw.wl.xkb.state_new = (PFN_xkb_state_new)
         _glfw_dlsym(_glfw.wl.xkb.handle, "xkb_state_new");
     _glfw.wl.xkb.state_unref = (PFN_xkb_state_unref)

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -208,6 +208,9 @@ typedef struct _GLFWlibraryWayland
 
     int32_t                     keyboardRepeatRate;
     int32_t                     keyboardRepeatDelay;
+    int                         keyboardLastKey;
+    int                         keyboardLastScancode;
+    int                         timerfd;
     short int                   keycodes[256];
     short int                   scancodes[GLFW_KEY_LAST + 1];
 

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -105,6 +105,7 @@ typedef void (* PFN_xkb_context_unref)(struct xkb_context*);
 typedef struct xkb_keymap* (* PFN_xkb_keymap_new_from_string)(struct xkb_context*, const char*, enum xkb_keymap_format, enum xkb_keymap_compile_flags);
 typedef void (* PFN_xkb_keymap_unref)(struct xkb_keymap*);
 typedef xkb_mod_index_t (* PFN_xkb_keymap_mod_get_index)(struct xkb_keymap*, const char*);
+typedef int (* PFN_xkb_keymap_key_repeats)(struct xkb_keymap*, xkb_keycode_t);
 typedef struct xkb_state* (* PFN_xkb_state_new)(struct xkb_keymap*);
 typedef void (* PFN_xkb_state_unref)(struct xkb_state*);
 typedef int (* PFN_xkb_state_key_get_syms)(struct xkb_state*, xkb_keycode_t, const xkb_keysym_t**);
@@ -115,6 +116,7 @@ typedef xkb_mod_mask_t (* PFN_xkb_state_serialize_mods)(struct xkb_state*, enum 
 #define xkb_keymap_new_from_string _glfw.wl.xkb.keymap_new_from_string
 #define xkb_keymap_unref _glfw.wl.xkb.keymap_unref
 #define xkb_keymap_mod_get_index _glfw.wl.xkb.keymap_mod_get_index
+#define xkb_keymap_key_repeats _glfw.wl.xkb.keymap_key_repeats
 #define xkb_state_new _glfw.wl.xkb.state_new
 #define xkb_state_unref _glfw.wl.xkb.state_unref
 #define xkb_state_key_get_syms _glfw.wl.xkb.state_key_get_syms
@@ -237,6 +239,7 @@ typedef struct _GLFWlibraryWayland
         PFN_xkb_keymap_new_from_string keymap_new_from_string;
         PFN_xkb_keymap_unref keymap_unref;
         PFN_xkb_keymap_mod_get_index keymap_mod_get_index;
+        PFN_xkb_keymap_key_repeats keymap_key_repeats;
         PFN_xkb_state_new state_new;
         PFN_xkb_state_unref state_unref;
         PFN_xkb_state_key_get_syms state_key_get_syms;

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -200,11 +200,14 @@ typedef struct _GLFWlibraryWayland
     struct zwp_idle_inhibit_manager_v1*     idleInhibitManager;
 
     int                         compositorVersion;
+    int                         seatVersion;
 
     struct wl_cursor_theme*     cursorTheme;
     struct wl_surface*          cursorSurface;
     uint32_t                    pointerSerial;
 
+    int32_t                     keyboardRepeatRate;
+    int32_t                     keyboardRepeatDelay;
     short int                   keycodes[256];
     short int                   scancodes[GLFW_KEY_LAST + 1];
 


### PR DESCRIPTION
This bumps the requested `wl_seat` version in order to get a `wl_keyboard` exposing the `repeat_info` event, adds a timerfd which we `poll()`, and then we emit a key with the `GLFW_REPEAT` action.

Fixes #1108.