### PR TITLE
MacOS replace green fullscreen button with zoom button

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -1093,7 +1093,7 @@ static GLFWbool createNativeWindow(_GLFWwindow* window,
         if (wndconfig->resizable)
         {
             const NSWindowCollectionBehavior behavior =
-                NSWindowCollectionBehaviorFullScreenPrimary |
+                NSWindowCollectionBehaviorFullScreenAuxiliary |
                 NSWindowCollectionBehaviorManaged;
             [window->ns.object setCollectionBehavior:behavior];
         }


### PR DESCRIPTION
In an attempt to fix issue #1216 of mixing the native fullscreen feature with glfw's method of fullscreen I forced the green fullscreen button to be replaced by the old zoom button. This prevents the user from entering native fullscreen mode. This has been tested on macOS High Sierra 10.3.3 only.

See https://developer.apple.com/library/content/releasenotes/AppKit/RN-AppKit/#10_11Window under NSWindow Implicit Full Screen.

Admittedly, this is a hack to prevent macOS from implicitly marking a window as fullscreen capable, which might change in the future. So the way to go would be to actually support native fullscreen mode on macOS.