### PR TITLE
Add support for Wayland on FreeBSD and other OSes

### DIFF
--- a/CMake/modules/FindEpollShim.cmake
+++ b/CMake/modules/FindEpollShim.cmake
@@ -1,0 +1,17 @@
+# Find EpollShim
+# Once done, this will define
+#
+#   EPOLLSHIM_FOUND - System has EpollShim
+#   EPOLLSHIM_INCLUDE_DIRS - The EpollShim include directories
+#   EPOLLSHIM_LIBRARIES - The libraries needed to use EpollShim
+
+find_path(EPOLLSHIM_INCLUDE_DIRS NAMES sys/epoll.h sys/timerfd.h HINTS /usr/local/include/libepoll-shim)
+find_library(EPOLLSHIM_LIBRARIES NAMES epoll-shim libepoll-shim HINTS /usr/local/lib)
+
+if (EPOLLSHIM_INCLUDE_DIRS AND EPOLLSHIM_LIBRARIES)
+	set(EPOLLSHIM_FOUND TRUE)
+endif (EPOLLSHIM_INCLUDE_DIRS AND EPOLLSHIM_LIBRARIES)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(EPOLLSHIM DEFAULT_MSG EPOLLSHIM_LIBRARIES EPOLLSHIM_INCLUDE_DIRS)
+mark_as_advanced(EPOLLSHIM_INCLUDE_DIRS EPOLLSHIM_LIBRARIES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,6 +280,14 @@ if (_GLFW_WAYLAND)
 
     include(CheckIncludeFiles)
     check_include_files(xkbcommon/xkbcommon-compose.h HAVE_XKBCOMMON_COMPOSE_H)
+
+    if (NOT ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux"))
+        find_package(EpollShim)
+        if (EPOLLSHIM_FOUND)
+            list(APPEND glfw_INCLUDE_DIRS "${EPOLLSHIM_INCLUDE_DIRS}")
+            list(APPEND glfw_LIBRARIES "${EPOLLSHIM_LIBRARIES}")
+        endif()
+    endif()
 endif()
 
 #--------------------------------------------------------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,20 +23,12 @@ elseif (_GLFW_X11)
     set(glfw_SOURCES ${common_SOURCES} x11_init.c x11_monitor.c x11_window.c
                      xkb_unicode.c posix_time.c posix_thread.c glx_context.c
                      egl_context.c osmesa_context.c)
-
-    if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
-        set(glfw_HEADERS ${glfw_HEADERS} linux_joystick.h)
-        set(glfw_SOURCES ${glfw_SOURCES} linux_joystick.c)
-    else()
-        set(glfw_HEADERS ${glfw_HEADERS} null_joystick.h)
-        set(glfw_SOURCES ${glfw_SOURCES} null_joystick.c)
-    endif()
 elseif (_GLFW_WAYLAND)
-    set(glfw_HEADERS ${common_HEADERS} wl_platform.h linux_joystick.h
+    set(glfw_HEADERS ${common_HEADERS} wl_platform.h
                      posix_time.h posix_thread.h xkb_unicode.h egl_context.h
                      osmesa_context.h)
     set(glfw_SOURCES ${common_SOURCES} wl_init.c wl_monitor.c wl_window.c
-                     linux_joystick.c posix_time.c posix_thread.c xkb_unicode.c
+                     posix_time.c posix_thread.c xkb_unicode.c
                      egl_context.c osmesa_context.c)
 
     ecm_add_wayland_client_protocol(glfw_SOURCES
@@ -71,6 +63,16 @@ elseif (_GLFW_OSMESA)
                      posix_time.h posix_thread.h osmesa_context.h)
     set(glfw_SOURCES ${common_SOURCES} null_init.c null_monitor.c null_window.c
                      null_joystick.c posix_time.c posix_thread.c osmesa_context.c)
+endif()
+
+if (_GLFW_X11 OR _GLFW_WAYLAND)
+    if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+        set(glfw_HEADERS ${glfw_HEADERS} linux_joystick.h)
+        set(glfw_SOURCES ${glfw_SOURCES} linux_joystick.c)
+    else()
+        set(glfw_HEADERS ${glfw_HEADERS} null_joystick.h)
+        set(glfw_SOURCES ${glfw_SOURCES} null_joystick.c)
+    endif()
 endif()
 
 if (APPLE)

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -1046,8 +1046,10 @@ int _glfwPlatformInit(void)
     // Sync so we got all initial output events
     wl_display_roundtrip(_glfw.wl.display);
 
+#ifdef __linux__
     if (!_glfwInitJoysticksLinux())
         return GLFW_FALSE;
+#endif
 
     _glfwInitTimerPOSIX();
 
@@ -1073,7 +1075,9 @@ int _glfwPlatformInit(void)
 
 void _glfwPlatformTerminate(void)
 {
+#ifdef __linux__
     _glfwTerminateJoysticksLinux();
+#endif
     _glfwTerminateEGL();
     if (_glfw.wl.egl.handle)
     {

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -47,7 +47,11 @@ typedef VkBool32 (APIENTRY *PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR
 
 #include "posix_thread.h"
 #include "posix_time.h"
+#ifdef __linux__
 #include "linux_joystick.h"
+#else
+#include "null_joystick.h"
+#endif
 #include "xkb_unicode.h"
 #include "egl_context.h"
 #include "osmesa_context.h"


### PR DESCRIPTION
re: #1219.

Mostly just ifdefs Linux joystick support to Linux. I also added linking to libepoll-shim in CMake though.

BTW, any plans for selecting between Wayland and X11 dynamically (on the fly) like the big toolkits (incl. SDL) do? [Some projects](https://github.com/kovidgoyal/kitty) are already implementing this by themselves — by building two copies of bundled glfw and dlopen'ing one of them depending on the desired backend…