### PR TITLE
Fix windows build with WINVER >= Vista.

### DIFF
--- a/src/win32_platform.h
+++ b/src/win32_platform.h
@@ -120,6 +120,8 @@ typedef struct
     HRGN hRgnBlur;
     BOOL fTransitionOnMaximized;
 } DWM_BLURBEHIND;
+#else
+#include <Dwmapi.h>
 #endif /*Windows Vista*/
 
 #ifndef DPI_ENUMS_DECLARED


### PR DESCRIPTION
In 32e78aeb2 the definition of DWM_BLURBEHIND in win32_platform.h was
moved behind a WINVER < 0x0600 preprocessor check (< Vista). This broke
the build for WINVER >= 0x0600 since DWM_BLURBEHIND is not defined.

Starting with Vista DWM_BLURBEHIND is available in Dwmapi.h (see [1]).
So we can just include the header directly on Vista and above.

[1]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa969500(v=vs.85).aspx