### PR TITLE
Input improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ information on what to include when reporting a bug.
 - Added `GLFW_OSMESA_CONTEXT_API` for creating OpenGL contexts with
   [OSMesa](https://www.mesa3d.org/osmesa.html) (#281)
 - Added `GenerateMappings.cmake` script for updating gamepad mappings
+- Added `GLFW_MULTI` key/button state for handling of double-click/multi-press
 - Made `glfwCreateWindowSurface` emit an error when the window has a context
   (#1194,#1205)
 - Deprecated window parameter of clipboard string functions
@@ -194,6 +195,7 @@ information on what to include when reporting a bug.
 - Bugfix: The scancode for synthetic key release events was always zero
 - Bugfix: The generated Doxyfile did not handle paths with spaces (#1081)
 - [Win32] Added system error strings to relevant GLFW error descriptions (#733)
+- [Win32] Added 'WM_NBUTTONDBLCLK' message support
 - [Win32] Moved to `WM_INPUT` for disabled cursor mode motion input (#125)
 - [Win32] Removed XInput circular deadzone from joystick axis data (#1045)
 - [Win32] Bugfix: Undecorated windows could not be iconified by the user (#861)
@@ -386,6 +388,7 @@ skills.
  - Jack Moffitt
  - Jeff Molofee
  - Pierre Morel
+ - Romain Moret
  - Jon Morton
  - Pierre Moulon
  - Martins Mozeiko

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -310,6 +310,13 @@ extern "C" {
  *  @ingroup input
  */
 #define GLFW_REPEAT                 2
+/*! @brief The key or mouse button was pressed multiple times (e.g. double-click).
+ *
+ *  The key or mouse button was pressed multiple times (e.g. double-click).
+ *
+ *  @ingroup input
+ */
+#define GLFW_MULTI                  3
 /*! @} */
 
 /*! @defgroup hat_state Joystick hat states

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -705,14 +705,21 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
         case WM_RBUTTONUP:
         case WM_MBUTTONUP:
         case WM_XBUTTONUP:
+        case WM_LBUTTONDBLCLK:
+        case WM_RBUTTONDBLCLK:
+        case WM_MBUTTONDBLCLK:
+        case WM_XBUTTONDBLCLK:
         {
             int i, button, action;
 
-            if (uMsg == WM_LBUTTONDOWN || uMsg == WM_LBUTTONUP)
+            if (uMsg == WM_LBUTTONDOWN || uMsg == WM_LBUTTONUP ||
+                uMsg == WM_LBUTTONDBLCLK)
                 button = GLFW_MOUSE_BUTTON_LEFT;
-            else if (uMsg == WM_RBUTTONDOWN || uMsg == WM_RBUTTONUP)
+            else if (uMsg == WM_RBUTTONDOWN || uMsg == WM_RBUTTONUP ||
+                     uMsg == WM_RBUTTONDBLCLK)
                 button = GLFW_MOUSE_BUTTON_RIGHT;
-            else if (uMsg == WM_MBUTTONDOWN || uMsg == WM_MBUTTONUP)
+            else if (uMsg == WM_MBUTTONDOWN || uMsg == WM_MBUTTONUP ||
+                     uMsg == WM_MBUTTONDBLCLK)
                 button = GLFW_MOUSE_BUTTON_MIDDLE;
             else if (GET_XBUTTON_WPARAM(wParam) == XBUTTON1)
                 button = GLFW_MOUSE_BUTTON_4;
@@ -724,12 +731,20 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
             {
                 action = GLFW_PRESS;
             }
-            else
+            else if (uMsg == WM_LBUTTONUP || uMsg == WM_RBUTTONUP ||
+                     uMsg == WM_MBUTTONUP || uMsg == WM_XBUTTONUP)
+            {
                 action = GLFW_RELEASE;
+            }
+            else
+            {
+                action = GLFW_MULTI;
+            }
 
             for (i = 0;  i <= GLFW_MOUSE_BUTTON_LAST;  i++)
             {
-                if (window->mouseButtons[i] == GLFW_PRESS)
+                if (window->mouseButtons[i] == GLFW_PRESS ||
+                    window->mouseButtons[i] == GLFW_MULTI)
                     break;
             }
 
@@ -740,14 +755,17 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
 
             for (i = 0;  i <= GLFW_MOUSE_BUTTON_LAST;  i++)
             {
-                if (window->mouseButtons[i] == GLFW_PRESS)
+                if (window->mouseButtons[i] == GLFW_PRESS ||
+                    window->mouseButtons[i] == GLFW_MULTI)
                     break;
             }
 
             if (i > GLFW_MOUSE_BUTTON_LAST)
                 ReleaseCapture();
 
-            if (uMsg == WM_XBUTTONDOWN || uMsg == WM_XBUTTONUP)
+            if (uMsg == WM_XBUTTONDOWN ||
+                uMsg == WM_XBUTTONUP ||
+                uMsg == WM_XBUTTONDBLCLK)
                 return TRUE;
 
             return 0;
@@ -1151,7 +1169,7 @@ GLFWbool _glfwRegisterWindowClassWin32(void)
 
     ZeroMemory(&wc, sizeof(wc));
     wc.cbSize        = sizeof(wc);
-    wc.style         = CS_HREDRAW | CS_VREDRAW | CS_OWNDC;
+    wc.style         = CS_HREDRAW | CS_VREDRAW | CS_OWNDC | CS_DBLCLKS;
     wc.lpfnWndProc   = (WNDPROC) windowProc;
     wc.hInstance     = GetModuleHandleW(NULL);
     wc.hCursor       = LoadCursorW(NULL, IDC_ARROW);

--- a/src/window.c
+++ b/src/window.c
@@ -60,7 +60,8 @@ void _glfwInputWindowFocus(_GLFWwindow* window, GLFWbool focused)
 
         for (button = 0;  button <= GLFW_MOUSE_BUTTON_LAST;  button++)
         {
-            if (window->mouseButtons[button] == GLFW_PRESS)
+            if (window->mouseButtons[button] == GLFW_PRESS ||
+                window->mouseButtons[button] == GLFW_MULTI)
                 _glfwInputMouseClick(window, button, GLFW_RELEASE, 0);
         }
     }

--- a/tests/events.c
+++ b/tests/events.c
@@ -203,6 +203,8 @@ static const char* get_action_name(int action)
             return "released";
         case GLFW_REPEAT:
             return "repeated";
+        case GLFW_MULTI:
+            return "multi";
     }
 
     return "caused unknown action";


### PR DESCRIPTION
On win32, native double-click support is done by:
1. Add 'CS_DBLCLKS' flag to the window class style
2. Adding handling for the four WM_NBUTTONDBLCLK message types (L, M, R and X buttons)

The message sequence for a double-click then is: WM_NBUTTONDOWN => WN_NBUTTONUP => WN_NBUTTONDBLCLK => WN_NBUTTONUP (as indicated in the Remarks section [here](https://msdn.microsoft.com/en-us/library/windows/desktop/ms645606(v=vs.85).aspx))

Therefore, handling double-click in GLFW can be done by adding a 'GLFW_MULTI' state for mouse buttons. Input sequence on double-click then becomes: GLFW_PRESS => GLFW_RELEASE => GLFW_MULTI => GLFW_RELEASE, the GLFW_MULTI state now indicates that the second press event is a native double-click.
There is no need to change the acquire/release sequence, as the second click is handled as a regular mouse down event, and will be followed by a mouse up.
