### PR TITLE
Single GLRC for multiple windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ option(GLFW_BUILD_TESTS "Build the GLFW test programs" ON)
 option(GLFW_BUILD_DOCS "Build the GLFW documentation" ON)
 option(GLFW_INSTALL "Generate installation target" ON)
 option(GLFW_VULKAN_STATIC "Use the Vulkan loader statically linked into application" OFF)
+option(GLFW_OPENGL_SINGLE_GLRC "Build the GLFW to use only a single OpenGL render context" OFF)
 
 if (UNIX)
     option(GLFW_USE_OSMESA "Use OSMesa for offscreen context creation" OFF)
@@ -71,6 +72,10 @@ find_package(Vulkan)
 if (GLFW_BUILD_DOCS)
     set(DOXYGEN_SKIP_DOT TRUE)
     find_package(Doxygen)
+endif()
+
+if (GLFW_OPENGL_SINGLE_GLRC)
+    add_definitions(-D_GLFW_OPENGL_SINGLE_GLRC)
 endif()
 
 #--------------------------------------------------------------------

--- a/src/glx_context.c
+++ b/src/glx_context.c
@@ -238,7 +238,14 @@ static void destroyContextGLX(_GLFWwindow* window)
 
     if (window->context.glx.handle)
     {
+#ifdef _GLFW_OPENGL_SINGLE_GLRC
+        if (window->context.customctx)
+        {
+            glXDestroyContext(_glfw.x11.display, window->context.glx.handle);
+        }
+#else
         glXDestroyContext(_glfw.x11.display, window->context.glx.handle);
+#endif
         window->context.glx.handle = NULL;
     }
 }
@@ -495,112 +502,132 @@ GLFWbool _glfwCreateContextGLX(_GLFWwindow* window,
 
     _glfwGrabErrorHandlerX11();
 
-    if (_glfw.glx.ARB_create_context)
+#ifdef _GLFW_OPENGL_SINGLE_GLRC
+    if(share)
     {
-        int index = 0, mask = 0, flags = 0;
-
-        if (ctxconfig->client == GLFW_OPENGL_API)
-        {
-            if (ctxconfig->forward)
-                flags |= GLX_CONTEXT_FORWARD_COMPATIBLE_BIT_ARB;
-
-            if (ctxconfig->profile == GLFW_OPENGL_CORE_PROFILE)
-                mask |= GLX_CONTEXT_CORE_PROFILE_BIT_ARB;
-            else if (ctxconfig->profile == GLFW_OPENGL_COMPAT_PROFILE)
-                mask |= GLX_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB;
-        }
-        else
-            mask |= GLX_CONTEXT_ES2_PROFILE_BIT_EXT;
-
-        if (ctxconfig->debug)
-            flags |= GLX_CONTEXT_DEBUG_BIT_ARB;
-
-        if (ctxconfig->robustness)
-        {
-            if (_glfw.glx.ARB_create_context_robustness)
-            {
-                if (ctxconfig->robustness == GLFW_NO_RESET_NOTIFICATION)
-                {
-                    setAttrib(GLX_CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB,
-                              GLX_NO_RESET_NOTIFICATION_ARB);
-                }
-                else if (ctxconfig->robustness == GLFW_LOSE_CONTEXT_ON_RESET)
-                {
-                    setAttrib(GLX_CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB,
-                              GLX_LOSE_CONTEXT_ON_RESET_ARB);
-                }
-
-                flags |= GLX_CONTEXT_ROBUST_ACCESS_BIT_ARB;
-            }
-        }
-
-        if (ctxconfig->release)
-        {
-            if (_glfw.glx.ARB_context_flush_control)
-            {
-                if (ctxconfig->release == GLFW_RELEASE_BEHAVIOR_NONE)
-                {
-                    setAttrib(GLX_CONTEXT_RELEASE_BEHAVIOR_ARB,
-                              GLX_CONTEXT_RELEASE_BEHAVIOR_NONE_ARB);
-                }
-                else if (ctxconfig->release == GLFW_RELEASE_BEHAVIOR_FLUSH)
-                {
-                    setAttrib(GLX_CONTEXT_RELEASE_BEHAVIOR_ARB,
-                              GLX_CONTEXT_RELEASE_BEHAVIOR_FLUSH_ARB);
-                }
-            }
-        }
-
-        if (ctxconfig->noerror)
-        {
-            if (_glfw.glx.ARB_create_context_no_error)
-                setAttrib(GLX_CONTEXT_OPENGL_NO_ERROR_ARB, GLFW_TRUE);
-        }
-
-        // NOTE: Only request an explicitly versioned context when necessary, as
-        //       explicitly requesting version 1.0 does not always return the
-        //       highest version supported by the driver
-        if (ctxconfig->major != 1 || ctxconfig->minor != 0)
-        {
-            setAttrib(GLX_CONTEXT_MAJOR_VERSION_ARB, ctxconfig->major);
-            setAttrib(GLX_CONTEXT_MINOR_VERSION_ARB, ctxconfig->minor);
-        }
-
-        if (mask)
-            setAttrib(GLX_CONTEXT_PROFILE_MASK_ARB, mask);
-
-        if (flags)
-            setAttrib(GLX_CONTEXT_FLAGS_ARB, flags);
-
-        setAttrib(None, None);
-
-        window->context.glx.handle =
-            _glfw.glx.CreateContextAttribsARB(_glfw.x11.display,
-                                              native,
-                                              share,
-                                              True,
-                                              attribs);
-
-        // HACK: This is a fallback for broken versions of the Mesa
-        //       implementation of GLX_ARB_create_context_profile that fail
-        //       default 1.0 context creation with a GLXBadProfileARB error in
-        //       violation of the extension spec
-        if (!window->context.glx.handle)
-        {
-            if (_glfw.x11.errorCode == _glfw.glx.errorBase + GLXBadProfileARB &&
-                ctxconfig->client == GLFW_OPENGL_API &&
-                ctxconfig->profile == GLFW_OPENGL_ANY_PROFILE &&
-                ctxconfig->forward == GLFW_FALSE)
-            {
-                window->context.glx.handle =
-                    createLegacyContextGLX(window, native, share);
-            }
-        }
+        // Use shared context instead of creating a new one
+        window->context.wgl.handle = share;
+        window->context.customctx = GLFW_FALSE;
     }
     else
     {
-        window->context.glx.handle =
-            createLegacyContextGLX(window, native, share);
+        // Create new GL render context
+        window->context.glx.handle = NULL;
+        window->context.customctx = GLFW_TRUE;
+    }
+#endif
+
+#ifdef _GLFW_OPENGL_SINGLE_GLRC
+    if (!window->context.glx.handle)
+#endif
+    {
+        if (_glfw.glx.ARB_create_context)
+        {
+            int index = 0, mask = 0, flags = 0;
+
+            if (ctxconfig->client == GLFW_OPENGL_API)
+            {
+                if (ctxconfig->forward)
+                    flags |= GLX_CONTEXT_FORWARD_COMPATIBLE_BIT_ARB;
+
+                if (ctxconfig->profile == GLFW_OPENGL_CORE_PROFILE)
+                    mask |= GLX_CONTEXT_CORE_PROFILE_BIT_ARB;
+                else if (ctxconfig->profile == GLFW_OPENGL_COMPAT_PROFILE)
+                    mask |= GLX_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB;
+            }
+            else
+                mask |= GLX_CONTEXT_ES2_PROFILE_BIT_EXT;
+
+            if (ctxconfig->debug)
+                flags |= GLX_CONTEXT_DEBUG_BIT_ARB;
+
+            if (ctxconfig->robustness)
+            {
+                if (_glfw.glx.ARB_create_context_robustness)
+                {
+                    if (ctxconfig->robustness == GLFW_NO_RESET_NOTIFICATION)
+                    {
+                        setAttrib(GLX_CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB,
+                                  GLX_NO_RESET_NOTIFICATION_ARB);
+                    }
+                    else if (ctxconfig->robustness == GLFW_LOSE_CONTEXT_ON_RESET)
+                    {
+                        setAttrib(GLX_CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB,
+                                  GLX_LOSE_CONTEXT_ON_RESET_ARB);
+                    }
+
+                    flags |= GLX_CONTEXT_ROBUST_ACCESS_BIT_ARB;
+                }
+            }
+
+            if (ctxconfig->release)
+            {
+                if (_glfw.glx.ARB_context_flush_control)
+                {
+                    if (ctxconfig->release == GLFW_RELEASE_BEHAVIOR_NONE)
+                    {
+                        setAttrib(GLX_CONTEXT_RELEASE_BEHAVIOR_ARB,
+                                  GLX_CONTEXT_RELEASE_BEHAVIOR_NONE_ARB);
+                    }
+                    else if (ctxconfig->release == GLFW_RELEASE_BEHAVIOR_FLUSH)
+                    {
+                        setAttrib(GLX_CONTEXT_RELEASE_BEHAVIOR_ARB,
+                                  GLX_CONTEXT_RELEASE_BEHAVIOR_FLUSH_ARB);
+                    }
+                }
+            }
+
+            if (ctxconfig->noerror)
+            {
+                if (_glfw.glx.ARB_create_context_no_error)
+                    setAttrib(GLX_CONTEXT_OPENGL_NO_ERROR_ARB, GLFW_TRUE);
+            }
+
+            // NOTE: Only request an explicitly versioned context when necessary, as
+            //       explicitly requesting version 1.0 does not always return the
+            //       highest version supported by the driver
+            if (ctxconfig->major != 1 || ctxconfig->minor != 0)
+            {
+                setAttrib(GLX_CONTEXT_MAJOR_VERSION_ARB, ctxconfig->major);
+                setAttrib(GLX_CONTEXT_MINOR_VERSION_ARB, ctxconfig->minor);
+            }
+
+            if (mask)
+                setAttrib(GLX_CONTEXT_PROFILE_MASK_ARB, mask);
+
+            if (flags)
+                setAttrib(GLX_CONTEXT_FLAGS_ARB, flags);
+
+            setAttrib(None, None);
+
+            window->context.glx.handle =
+                _glfw.glx.CreateContextAttribsARB(_glfw.x11.display,
+                                                    native,
+                                                    share,
+                                                    True,
+                                                    attribs);
+
+            // HACK: This is a fallback for broken versions of the Mesa
+            //       implementation of GLX_ARB_create_context_profile that fail
+            //       default 1.0 context creation with a GLXBadProfileARB error in
+            //       violation of the extension spec
+            if (!window->context.glx.handle)
+            {
+                if (_glfw.x11.errorCode == _glfw.glx.errorBase + GLXBadProfileARB &&
+                    ctxconfig->client == GLFW_OPENGL_API &&
+                    ctxconfig->profile == GLFW_OPENGL_ANY_PROFILE &&
+                    ctxconfig->forward == GLFW_FALSE)
+                {
+                    window->context.glx.handle =
+                        createLegacyContextGLX(window, native, share);
+                }
+            }
+        }
+        else
+        {
+            window->context.glx.handle =
+                createLegacyContextGLX(window, native, share);
+        }
     }
 
     _glfwReleaseErrorHandlerX11();

--- a/src/glx_context.c
+++ b/src/glx_context.c
@@ -506,7 +506,7 @@ GLFWbool _glfwCreateContextGLX(_GLFWwindow* window,
     if(share)
     {
         // Use shared context instead of creating a new one
-        window->context.wgl.handle = share;
+        window->context.glx.handle = share;
         window->context.customctx = GLFW_FALSE;
     }
     else

--- a/src/internal.h
+++ b/src/internal.h
@@ -341,6 +341,11 @@ struct _GLFWcontext
     int                 profile;
     int                 robustness;
     int                 release;
+#ifdef _GLFW_OPENGL_SINGLE_GLRC
+    // Specifies whether this _GLFWcontext has its own GLRC object.
+    // If not, it must not delete the GLRC object on destruction.
+    GLFWbool            customctx;
+#endif
 
     PFNGLGETSTRINGIPROC GetStringi;
     PFNGLGETINTEGERVPROC GetIntegerv;

--- a/src/wgl_context.c
+++ b/src/wgl_context.c
@@ -697,7 +697,23 @@ GLFWbool _glfwCreateContextWGL(_GLFWwindow* window,
     }
     else
     {
+#ifdef _GLFW_OPENGL_SINGLE_GLRC
+        if (share)
+        {
+            // Use shared context instead of creating a new one
+            window->context.wgl.handle = share;
+            window->context.customctx = GLFW_FALSE;
+        }
+        else
+        {
+            // Create new GL render context
+            window->context.wgl.handle = wglCreateContext(window->context.wgl.dc);
+            window->context.customctx = GLFW_TRUE;
+        }
+#else
         window->context.wgl.handle = wglCreateContext(window->context.wgl.dc);
+#endif
+
         if (!window->context.wgl.handle)
         {
             _glfwInputErrorWin32(GLFW_VERSION_UNAVAILABLE,
@@ -705,6 +721,7 @@ GLFWbool _glfwCreateContextWGL(_GLFWwindow* window,
             return GLFW_FALSE;
         }
 
+#ifndef _GLFW_OPENGL_SINGLE_GLRC
         if (share)
         {
             if (!wglShareLists(share, window->context.wgl.handle))
@@ -714,6 +731,7 @@ GLFWbool _glfwCreateContextWGL(_GLFWwindow* window,
                 return GLFW_FALSE;
             }
         }
+#endif
     }
 
     window->context.makeCurrent = makeContextCurrentWGL;


### PR DESCRIPTION
In my branch `single-GLRC` I added a new CMake option `GLFW_OPENGL_SINGLE_GLRC` (OFF by default), to let GLFW create only a single OpenGL context but to be used for multiple windows when a shared context is specified.

I'm using it to have multiple windows but avoiding resource management of OpenGL objects that are not sharable between contexts: [Vertex Array Objects](https://www.khronos.org/opengl/wiki/Vertex_Specification#Vertex_Array_Object) and [Query Objects](https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_occlusion_query.txt) for instance.

For this implementation, I added the global macro `_GLFW_OPENGL_SINGLE_GLRC` (when the respective CMake option is ON) and the following member to the `_GLFWcontext` struct:
```c
#ifdef _GLFW_OPENGL_SINGLE_GLRC
    // Specifies whether this _GLFWcontext has its own GLRC object.
    // If not, it must not delete the GLRC object on destruction.
    GLFWbool            customctx;
#endif
```

I implemented it for Windows (WGL), Linux (GLX), and MacOS (NSGL) contexts, but not for EGL.
I tested the implementation with the "sharing" Example on _Windows 10_, _Kubuntu 17.10_ (VirtualBox), and _macOS High Sierra_.

The functions `wglMakeCurrent` and `glXMakeCurrent` functions allow to specify a new drawable but the previous GL context can remain. On MacOS, the view is exchanged:
```c
static void makeContextCurrentNSGL(_GLFWwindow* window)
{
    ...
#ifdef _GLFW_OPENGL_SINGLE_GLRC
        [window->context.nsgl.object setView:window->ns.view];
#endif
        [window->context.nsgl.object makeCurrentContext];
    ...
}
```