### PR TITLE
Use HiDPI cursors on scale>1 monitors on Wayland

### DIFF
--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -1067,6 +1067,8 @@ int _glfwPlatformInit(void)
                             "Wayland: Unable to load default cursor theme");
             return GLFW_FALSE;
         }
+        // If this happens to be NULL, we just fallback to the scale=1 version.
+        _glfw.wl.cursorThemeHiDPI = wl_cursor_theme_load(NULL, 64, _glfw.wl.shm);
         _glfw.wl.cursorSurface =
             wl_compositor_create_surface(_glfw.wl.compositor);
         _glfw.wl.cursorTimerfd = timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC);
@@ -1105,6 +1107,8 @@ void _glfwPlatformTerminate(void)
 
     if (_glfw.wl.cursorTheme)
         wl_cursor_theme_destroy(_glfw.wl.cursorTheme);
+    if (_glfw.wl.cursorThemeHiDPI)
+        wl_cursor_theme_destroy(_glfw.wl.cursorThemeHiDPI);
     if (_glfw.wl.cursor.handle)
     {
         _glfw_dlclose(_glfw.wl.cursor.handle);

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -335,6 +335,7 @@ typedef struct _GLFWmonitorWayland
 typedef struct _GLFWcursorWayland
 {
     struct wl_cursor*           cursor;
+    struct wl_cursor*           cursorHiDPI;
     struct wl_buffer*           buffer;
     int                         width, height;
     int                         xhot, yhot;

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -240,6 +240,7 @@ typedef struct _GLFWlibraryWayland
     int                         seatVersion;
 
     struct wl_cursor_theme*     cursorTheme;
+    struct wl_cursor_theme*     cursorThemeHiDPI;
     struct wl_surface*          cursorSurface;
     int                         cursorTimerfd;
     uint32_t                    pointerSerial;

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -721,6 +721,7 @@ setCursorImage(_GLFWcursorWayland* cursorWayland)
                           surface,
                           cursorWayland->xhot,
                           cursorWayland->yhot);
+    wl_surface_set_buffer_scale(surface, 1);
     wl_surface_attach(surface, buffer, 0, 0);
     wl_surface_damage(surface, 0, 0,
                       cursorWayland->width, cursorWayland->height);


### PR DESCRIPTION
This prevents them from looking blurry.

Note that only the NULL cursor and the ones used for decorations (resize, etc.) are rendered at scale=2 currently.  The cursors created by glfwCreateStandardCursor() and glfwCreateCursor() contain a single image which is specified to be scale=1.

In the future, GLFWcursor should be extended to support that usecase, as well as animations.