### PR TITLE
Fix disabled cursor mode over remote desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ information on what to include when reporting a bug.
 - [Win32] Bugfix: The HID device notification was not unregistered (#1170)
 - [Win32] Bugfix: `glfwCreateWindow` activated window even with `GLFW_FOCUSED`
                   hint set to false (#1179,#1180)
+- [Win32] Bugfix: Disabled cursor mode did not work over remote desktop (#1276)
 - [X11] Moved to XI2 `XI_RawMotion` for disable cursor mode motion input (#125)
 - [X11] Replaced `_GLFW_HAS_XF86VM` compile-time option with dynamic loading
 - [X11] Bugfix: `glfwGetVideoMode` would segfault on Cygwin/X
@@ -458,6 +459,7 @@ skills.
  - Santi Zupancic
  - Jonas Ådahl
  - Lasse Öörni
+ - Pokechu22
  - All the unmentioned and anonymous contributors in the GLFW community, for bug
    reports, patches, feedback, testing and encouragement
 

--- a/src/win32_platform.h
+++ b/src/win32_platform.h
@@ -279,6 +279,10 @@ typedef struct _GLFWwindowWin32
 
     // The last received cursor position, regardless of source
     int                 lastCursorPosX, lastCursorPosY;
+    // Cached center positions
+    int                 centerX, centerY;
+    // An invisible cursor, needed for special cases (see WM_INPUT handler)
+    HCURSOR             blankCursor;
 
 } _GLFWwindowWin32;
 

--- a/tests/cursor.c
+++ b/tests/cursor.c
@@ -205,6 +205,14 @@ static void key_callback(GLFWwindow* window, int key, int scancode, int action, 
         case GLFW_KEY_6:
             glfwSetCursor(window, standard_cursors[5]);
             break;
+
+        case GLFW_KEY_M:
+        {
+            int width, height;
+            glfwGetWindowSize(window, &width, &height);
+            glfwSetCursorPos(window, width / 2, height / 2);
+            break;
+        }
     }
 }
 


### PR DESCRIPTION
There were two major issues:

- RDP uses MOUSE_MOVE_ABSOLUTE for its input events, and the
implementation of this was incorrect.  Although poorly documented,
the values actually range from 0-65535 and represent monitor positions,
instead of being positions beforehand.  The equally poorly documented
MOUSE_VIRTUAL_DESKTOP flag specifies whether or not to use the
SCREEN or VIRTUALSCREEN system metrics.

- Using `SetCursor(NULL)` causes `SetCursorPos` to behave incorrectly
over RDP; it doesn't actually move it on the connected machine.
This has been fixed by creating an invisible cursor, which does
get moved correctly.

Aside from that, the center of the window is now cached and the cursor
test now supports pressing M to move the cursor to the center.

Fixes #1276.