### PR TITLE
Fix a race condition between glfwPostEmptyEvent and glfwWait***Events on X11 and Wayland

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,13 +18,13 @@ elseif (_GLFW_WIN32)
                      win32_monitor.c win32_time.c win32_thread.c win32_window.c
                      wgl_context.c egl_context.c osmesa_context.c)
 elseif (_GLFW_X11)
-    set(glfw_HEADERS ${common_HEADERS} x11_platform.h xkb_unicode.h posix_time.h
+    set(glfw_HEADERS ${common_HEADERS} x11_platform.h xkb_unicode.h unix_commons.h posix_time.h
                      posix_thread.h glx_context.h egl_context.h osmesa_context.h)
     set(glfw_SOURCES ${common_SOURCES} x11_init.c x11_monitor.c x11_window.c
                      xkb_unicode.c posix_time.c posix_thread.c glx_context.c
                      egl_context.c osmesa_context.c)
 elseif (_GLFW_WAYLAND)
-    set(glfw_HEADERS ${common_HEADERS} wl_platform.h
+    set(glfw_HEADERS ${common_HEADERS} wl_platform.h unix_commons.h
                      posix_time.h posix_thread.h xkb_unicode.h egl_context.h
                      osmesa_context.h)
     set(glfw_SOURCES ${common_SOURCES} wl_init.c wl_monitor.c wl_window.c

--- a/src/unix_commons.h
+++ b/src/unix_commons.h
@@ -1,0 +1,102 @@
+//========================================================================
+// GLFW 3.3 Unix commons - www.glfw.org
+//------------------------------------------------------------------------
+// Copyright (c) 2014 Jonas Ådahl <jadahl@gmail.com>
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would
+//    be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such, and must not
+//    be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source
+//    distribution.
+//
+//========================================================================
+
+#pragma once
+#include <fcntl.h>
+#include <unistd.h>
+#include <poll.h>
+#include <errno.h>
+
+#ifdef __NetBSD__
+#define ppoll pollts
+#endif
+
+static inline int
+initWakeup(int fds[2])
+{
+    return pipe2(fds, O_CLOEXEC | O_NONBLOCK);
+}
+
+static inline void
+wakeUp(int fd) {
+    while (write(fd, "w", 1) < 0 && errno == EINTR);
+}
+
+/*
+ * Uses ppoll to wait until an event occurs.
+ *
+ * If an event is received from the "wakeup" file descriptor,
+ *   this file descriptor is drained.
+ *
+ * @param timeout: timeout in seconds. strictly negative
+ *     values mean "no timeout".
+ */
+static inline int
+ppollWithTimeout(struct pollfd *fds, nfds_t nfds, double timeout)
+{
+    for (nfds_t i = 0; i < nfds; i++)
+    {
+        fds[i].revents = 0;
+    }
+
+    int res;
+    if(timeout >= 0.0)
+    {
+        const long seconds = (long) timeout;
+        const long nanoseconds = (long) ((timeout - seconds) * 1e9);
+        struct timespec tv = { seconds, nanoseconds };
+        res = ppoll(fds, nfds, &tv, NULL);
+    }
+    else
+    {
+        res = ppoll(fds, nfds, NULL, NULL);
+    }
+
+    if(res > 0)
+    {
+        if (fds[0].revents & POLLIN)
+        {
+            // an empty event has been posted: now that we are woken up,
+            // we can ignore other potential empty events.
+            static char drain_buf[64];
+            while(read(fds[0].fd, drain_buf, sizeof(drain_buf)) < 0 && errno == EINTR);
+        }
+    }
+    return res;
+}
+
+static inline void
+closeFds(int *fds, size_t count)
+{
+    while(count--) {
+        if (*fds > 0) {
+            close(*fds);
+            *fds = -1;
+        }
+        fds++;
+    }
+}
+

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -30,6 +30,7 @@
 #include <xkbcommon/xkbcommon-compose.h>
 #endif
 #include <dlfcn.h>
+#include <poll.h>
 
 typedef VkFlags VkWaylandSurfaceCreateFlagsKHR;
 
@@ -311,6 +312,12 @@ typedef struct _GLFWlibraryWayland
         PFN_wl_egl_window_destroy window_destroy;
         PFN_wl_egl_window_resize window_resize;
     } egl;
+
+    struct {
+        nfds_t nFds; // the number of fds that need to be polled
+        struct pollfd fds[3];
+        int wakeupFds[2];
+    } eventLoopData;
 
 } _GLFWlibraryWayland;
 

--- a/src/x11_platform.h
+++ b/src/x11_platform.h
@@ -29,6 +29,7 @@
 #include <signal.h>
 #include <stdint.h>
 #include <dlfcn.h>
+#include <poll.h>
 
 #include <X11/Xlib.h>
 #include <X11/keysym.h>
@@ -398,6 +399,12 @@ typedef struct _GLFWlibraryX11
         PFN_XRenderQueryVersion QueryVersion;
         PFN_XRenderFindVisualFormat FindVisualFormat;
     } xrender;
+
+    struct {
+        nfds_t nFds; // the number of fds that need to be polled
+        struct pollfd fds[3];
+        int wakeupFds[2];
+    } eventLoopData;
 
 } _GLFWlibraryX11;
 


### PR DESCRIPTION
This PR closes #1281 by using a self pipe to write when an empty even has been posted, and by using `ppoll` in place of `select` to wait on events.

Benchmarks on Ubuntu/x11 have shown that the timeout precision is unchanged.

@kovidgoyal tested a prior version on wayland, it was working. Since then, I had to make changes while cherrypicking from his fork. It compiles, but I couldn't test it. Could someone run this program to verify that the bug is fixed on wayland too?
https://github.com/OlivierSohn/repro-evt/blob/master/main.cpp

Thanks!