### PR TITLE
Facilitate embedding GLFW objects into user static libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,10 +304,12 @@ endif()
 # Export GLFW library dependencies
 #--------------------------------------------------------------------
 foreach(arg ${glfw_PKG_DEPS})
-    set(GLFW_PKG_DEPS "${GLFW_PKG_DEPS} ${arg}")
+    set(GLFW_PKG_DEPS "${GLFW_PKG_DEPS} ${arg}" CACHE INTERNAL
+        "GLFW pkg-config Requires.private")
 endforeach()
 foreach(arg ${glfw_PKG_LIBS})
-    set(GLFW_PKG_LIBS "${GLFW_PKG_LIBS} ${arg}")
+    set(GLFW_PKG_LIBS "${GLFW_PKG_LIBS} ${arg}" CACHE INTERNAL
+        "GLFW pkg-config Libs.private")
 endforeach()
 
 #--------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ information on what to include when reporting a bug.
  - [NSGL] Removed enforcement of forward-compatible flag for core contexts
  - Export CMake `GLFW_PKG_DEPS` and `GLFW_PKG_LIBS` to parent scope for use
   in client pkg-configs (#1307)
+- Added a `glfw_objlib` CMake OBJECT library target for embedding into static
+  libraries (#1307)
 
 
 ## Contact

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ information on what to include when reporting a bug.
  - [X11] Bugfix: Content scale fallback value could be inconsistent (#1578)
  - [Wayland] Bugfix: The `GLFW_HAND_CURSOR` shape used the wrong image (#1432)
  - [NSGL] Removed enforcement of forward-compatible flag for core contexts
+ - Export CMake `GLFW_PKG_DEPS` and `GLFW_PKG_LIBS` to parent scope for use
+  in client pkg-configs (#1307)
 
 
 ## Contact

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,31 +92,35 @@ if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR
         COMPILE_FLAGS -Wdeclaration-after-statement)
 endif()
 
-add_library(glfw ${glfw_SOURCES} ${glfw_HEADERS})
+add_library(glfw_objlib OBJECT ${glfw_SOURCES} ${glfw_HEADERS})
+add_library(glfw $<TARGET_OBJECTS:glfw_objlib>)
+set_target_properties(glfw_objlib PROPERTIES POSITION_INDEPENDENT_CODE ON)
 set_target_properties(glfw PROPERTIES
                       OUTPUT_NAME ${GLFW_LIB_NAME}
                       VERSION ${GLFW_VERSION_MAJOR}.${GLFW_VERSION_MINOR}
                       SOVERSION ${GLFW_VERSION_MAJOR}
-                      POSITION_INDEPENDENT_CODE ON
                       FOLDER "GLFW3")
 
 if (${CMAKE_VERSION} VERSION_EQUAL "3.1.0" OR
     ${CMAKE_VERSION} VERSION_GREATER "3.1.0")
 
-    set_target_properties(glfw PROPERTIES C_STANDARD 99)
+    set_target_properties(glfw_objlib PROPERTIES C_STANDARD 99)
 else()
     # Remove this fallback when removing support for CMake version less than 3.1
-    target_compile_options(glfw PRIVATE
+    target_compile_options(glfw_objlib PRIVATE
                            "$<$<C_COMPILER_ID:AppleClang>:-std=c99>"
                            "$<$<C_COMPILER_ID:Clang>:-std=c99>"
                            "$<$<C_COMPILER_ID:GNU>:-std=c99>")
 endif()
 
-target_compile_definitions(glfw PRIVATE _GLFW_USE_CONFIG_H)
+target_compile_definitions(glfw_objlib PRIVATE _GLFW_USE_CONFIG_H)
+target_include_directories(glfw_objlib PUBLIC
+                           "$<BUILD_INTERFACE:${GLFW_SOURCE_DIR}/include>"
+                           "$<INSTALL_INTERFACE:${CMAKE_INSTALL_FULL_INCLUDEDIR}>")
 target_include_directories(glfw PUBLIC
                            "$<BUILD_INTERFACE:${GLFW_SOURCE_DIR}/include>"
-                           "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
-target_include_directories(glfw PRIVATE
+                           "$<INSTALL_INTERFACE:${CMAKE_INSTALL_FULL_INCLUDEDIR}>")
+target_include_directories(glfw_objlib PRIVATE
                            "${GLFW_SOURCE_DIR}/src"
                            "${GLFW_BINARY_DIR}/src"
                            ${glfw_INCLUDE_DIRS})
@@ -125,11 +129,11 @@ target_include_directories(glfw PRIVATE
 # the inclusion of stddef.h (by glfw3.h), which is itself included before
 # win32_platform.h.  We define them here until a saner solution can be found
 # NOTE: MinGW-w64 and Visual C++ do /not/ need this hack.
-target_compile_definitions(glfw PRIVATE
+target_compile_definitions(glfw_objlib PRIVATE
                            "$<$<BOOL:${MINGW}>:UNICODE;WINVER=0x0501>")
 
 # Enable a reasonable set of warnings (no, -Wextra is not reasonable)
-target_compile_options(glfw PRIVATE
+target_compile_options(glfw_objlib PRIVATE
                        "$<$<C_COMPILER_ID:AppleClang>:-Wall>"
                        "$<$<C_COMPILER_ID:Clang>:-Wall>"
                        "$<$<C_COMPILER_ID:GNU>:-Wall>")
@@ -151,10 +155,10 @@ if (BUILD_SHARED_LIBS)
             set_target_properties(glfw PROPERTIES IMPORT_SUFFIX "dll.lib")
         endif()
 
-	target_compile_definitions(glfw INTERFACE GLFW_DLL)
+        target_compile_definitions(glfw_objlib INTERFACE GLFW_DLL)
     elseif (APPLE)
         # Add -fno-common to work around a bug in Apple's GCC
-        target_compile_options(glfw PRIVATE "-fno-common")
+        target_compile_options(glfw_objlib PRIVATE "-fno-common")
 
         set_target_properties(glfw PROPERTIES
                               INSTALL_NAME_DIR "${CMAKE_INSTALL_LIBDIR}")
@@ -162,7 +166,7 @@ if (BUILD_SHARED_LIBS)
 
     if (UNIX)
         # Hide symbols not explicitly tagged for export from the shared library
-        target_compile_options(glfw PRIVATE "-fvisibility=hidden")
+        target_compile_options(glfw_objlib PRIVATE "-fvisibility=hidden")
     endif()
 
     target_link_libraries(glfw PRIVATE ${glfw_LIBRARIES})
@@ -171,7 +175,7 @@ else()
 endif()
 
 if (MSVC)
-    target_compile_definitions(glfw PRIVATE _CRT_SECURE_NO_WARNINGS)
+    target_compile_definitions(glfw_objlib PRIVATE _CRT_SECURE_NO_WARNINGS)
 endif()
 
 if (GLFW_INSTALL)


### PR DESCRIPTION
Some projects (e.g. [raylib](https://github.com/raysan5/raylib/commit/b588af5ce22691bb143dcd784858e3c331c4a1e6#diff-f4de6a139c953f4ef27acdbc4f3d5d68), [nanogui](https://github.com/wjakob/glfw/commit/695b66d104e8a5ece8e6e55f0121ea24e9124d03#diff-95e351a3805a1dafa85bf20b81d086e6)) ship a static library that has GLFW
included (and reexports its symbols). Unfortunately, it's not possible to do so portably with the
current CMake setup.

[The proper  (CMake 2.8.8+) way](https://cmake.org/pipermail/cmake/2014-August/058235.html) seems to be to define a [CMake `OBJECT` library](https://cmake.org/cmake/help/v3.5/command/add_library.html#object-libraries) target and use
that as source for the `glfw` target.

- User code that is interested in the `glfw` target is unaffected and can
keep using it normally.
- User code that wants the objects to link into a static library just
needs to supply `$<TARGET_OBJECTS:glfw_objlib>` as part of the source.

After building the static library, it might be desirable to include it in the generated
pkg-config file. For that the other commit exports `GLFW_PKG_DEPS` and `GLFW_PKG_LIBS`
for use in client code.