### PR TITLE
Win32 support for GLFW_KEY_KP_EQUAL fixes #1315

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ information on what to include when reporting a bug.
 - [Win32] Bugfix: The HID device notification was not unregistered (#1170)
 - [Win32] Bugfix: `glfwCreateWindow` activated window even with `GLFW_FOCUSED`
                   hint set to false (#1179,#1180)
+- [Win32] Bugfix: Added GLFW_KEY_KP_EQUAL support (#1315)
 - [X11] Moved to XI2 `XI_RawMotion` for disable cursor mode motion input (#125)
 - [X11] Replaced `_GLFW_HAS_XF86VM` compile-time option with dynamic loading
 - [X11] Bugfix: `glfwGetVideoMode` would segfault on Cygwin/X

--- a/src/win32_init.c
+++ b/src/win32_init.c
@@ -309,6 +309,7 @@ static void createKeyTables(void)
     _glfw.win32.keycodes[0x053] = GLFW_KEY_KP_DECIMAL;
     _glfw.win32.keycodes[0x135] = GLFW_KEY_KP_DIVIDE;
     _glfw.win32.keycodes[0x11C] = GLFW_KEY_KP_ENTER;
+    _glfw.win32.keycodes[0x059] = GLFW_KEY_KP_EQUAL;
     _glfw.win32.keycodes[0x037] = GLFW_KEY_KP_MULTIPLY;
     _glfw.win32.keycodes[0x04A] = GLFW_KEY_KP_SUBTRACT;
 


### PR DESCRIPTION
Added support for GLFW_KEY_KP_EQUAL according to information on the relevant scancode from @RobertK92. Note that I do not have this key so can't test.