### PR TITLE
Added missing error specification for glfwWaitEventsTimeout

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -3762,6 +3762,9 @@ GLFWAPI void glfwWaitEvents(void);
  *
  *  @param[in] timeout The maximum amount of time, in seconds, to wait.
  *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+ *  GLFW_PLATFORM_ERROR and @ref GLFW_INVALID_VALUE.
+ *
  *  @reentrancy This function must not be called from a callback.
  *
  *  @thread_safety This function must only be called from the main thread.


### PR DESCRIPTION
Hi,

This patch adds some missing documentation in `glfw3.h` about the errors `glfwWaitEventsTimeout` can raise.

Cheers.