### PR TITLE
Use memfd_create() and seals if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,7 +273,9 @@ if (_GLFW_WAYLAND)
     list(APPEND glfw_INCLUDE_DIRS "${XKBCOMMON_INCLUDE_DIRS}")
 
     include(CheckIncludeFiles)
+    include(CheckFunctionExists)
     check_include_files(xkbcommon/xkbcommon-compose.h HAVE_XKBCOMMON_COMPOSE_H)
+    check_function_exists(memfd_create HAVE_MEMFD_CREATE)
 
     if (NOT ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux"))
         find_package(EpollShim)

--- a/src/glfw_config.h.in
+++ b/src/glfw_config.h.in
@@ -57,4 +57,6 @@
 
 // Define this to 1 if xkbcommon supports the compose key
 #cmakedefine HAVE_XKBCOMMON_COMPOSE_H
+// Define this to 1 if the libc supports memfd_create()
+#cmakedefine HAVE_MEMFD_CREATE
 


### PR DESCRIPTION
This allows the compositor to avoid having to setup and teardown a
SIGBUS signal handler whenever it needs to read from this surface, as it
knows we won’t be able to shrink the file and so doesn’t have to protect
against that.

This codepath will only be used on Linux ≥ 3.17 with glibc ≥ 2.27, and
possibly other kernels and libc.  The former code will continue to be
used as a fallback, either if memfd_create() fails or if it isn’t
available.