### PR TITLE
Include the null byte in joystick path

### DIFF
--- a/src/linux_joystick.c
+++ b/src/linux_joystick.c
@@ -228,7 +228,7 @@ static GLFWbool openJoystickDevice(const char* path)
         return GLFW_FALSE;
     }
 
-    strncpy(linjs.path, path, sizeof(linjs.path));
+    strncpy(linjs.path, path, sizeof(linjs.path) - 1);
     memcpy(&js->linjs, &linjs, sizeof(linjs));
 
     pollAbsState(js);


### PR DESCRIPTION
This potential bug was found thanks to gcc 8’s `-Wstringop-truncation` warning.