### PR TITLE
Fix for macOS mojave not rendering the OpenGL view on window start

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -343,6 +343,10 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
 
 - (void)windowDidBecomeKey:(NSNotification *)notification
 {
+    // Fix for macOS mojave not rendering the OpenGL view on window start
+    if (window->context.client != GLFW_NO_API)
+        [window->context.nsgl.object update];
+
     if (_glfw.ns.disabledCursorWindow == window)
         centerCursor(window);
 


### PR DESCRIPTION
Fixes #1334 

Note that this just a simplified version of the commit kovidgoyal/kitty@b82e74f as mentioned by @kovidgoyal in #1334.

I really wanted there to be a more elegant solution than this, but this seemed to be the simplest fix I could come up with that still seemed to work.

I don't mind if this isn't used at all. Just wanted to provide an option for a potential solution.