### PR TITLE
Implement clipboard support

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -4928,8 +4928,6 @@ GLFWAPI int glfwGetGamepadState(int jid, GLFWgamepadstate* state);
  *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
  *  GLFW_PLATFORM_ERROR.
  *
- *  @remark @wayland Clipboard is currently unimplemented.
- *
  *  @pointer_lifetime The specified string is copied before this function
  *  returns.
  *
@@ -4957,8 +4955,6 @@ GLFWAPI void glfwSetClipboardString(GLFWwindow* window, const char* string);
  *
  *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
  *  GLFW_PLATFORM_ERROR.
- *
- *  @remark @wayland Clipboard is currently unimplemented.
  *
  *  @pointer_lifetime The returned string is allocated and freed by GLFW.  You
  *  should not free it yourself.  It is valid until the next call to @ref

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -99,7 +99,7 @@ static void pointerHandleEnter(void* data,
     }
 
     window->wl.decorations.focus = focus;
-    _glfw.wl.pointerSerial = serial;
+    _glfw.wl.serial = serial;
     _glfw.wl.pointerFocus = window;
 
     window->wl.hovered = GLFW_TRUE;
@@ -120,7 +120,7 @@ static void pointerHandleLeave(void* data,
 
     window->wl.hovered = GLFW_FALSE;
 
-    _glfw.wl.pointerSerial = serial;
+    _glfw.wl.serial = serial;
     _glfw.wl.pointerFocus = NULL;
     _glfwInputCursorEnter(window, GLFW_FALSE);
 }
@@ -158,7 +158,7 @@ static void setCursor(_GLFWwindow* window, const char* name)
     buffer = wl_cursor_image_get_buffer(image);
     if (!buffer)
         return;
-    wl_pointer_set_cursor(_glfw.wl.pointer, _glfw.wl.pointerSerial,
+    wl_pointer_set_cursor(_glfw.wl.pointer, _glfw.wl.serial,
                           surface,
                           image->hotspot_x / scale,
                           image->hotspot_y / scale);
@@ -309,7 +309,7 @@ static void pointerHandleButton(void* data,
     if (window->wl.decorations.focus != mainWindow)
         return;
 
-    _glfw.wl.pointerSerial = serial;
+    _glfw.wl.serial = serial;
 
     /* Makes left, right and middle 0, 1 and 2. Overall order follows evdev
      * codes. */
@@ -478,6 +478,7 @@ static void keyboardHandleEnter(void* data,
             return;
     }
 
+    _glfw.wl.serial = serial;
     _glfw.wl.keyboardFocus = window;
     _glfwInputWindowFocus(window, GLFW_TRUE);
 }
@@ -492,6 +493,7 @@ static void keyboardHandleLeave(void* data,
     if (!window)
         return;
 
+    _glfw.wl.serial = serial;
     _glfw.wl.keyboardFocus = NULL;
     _glfwInputWindowFocus(window, GLFW_FALSE);
 }
@@ -575,6 +577,7 @@ static void keyboardHandleKey(void* data,
     action = state == WL_KEYBOARD_KEY_STATE_PRESSED
             ? GLFW_PRESS : GLFW_RELEASE;
 
+    _glfw.wl.serial = serial;
     _glfwInputKey(window, keyCode, key, action,
                   _glfw.wl.xkb.modifiers);
 
@@ -605,6 +608,8 @@ static void keyboardHandleModifiers(void* data,
 {
     xkb_mod_mask_t mask;
     unsigned int modifiers = 0;
+
+    _glfw.wl.serial = serial;
 
     if (!_glfw.wl.xkb.keymap)
         return;

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -1196,6 +1196,14 @@ int _glfwPlatformInit(void)
             wl_data_device_manager_get_data_device(_glfw.wl.dataDeviceManager,
                                                    _glfw.wl.seat);
         wl_data_device_add_listener(_glfw.wl.dataDevice, &dataDeviceListener, NULL);
+        _glfw.wl.clipboardString = malloc(4096);
+        if (!_glfw.wl.clipboardString)
+        {
+            _glfwInputError(GLFW_PLATFORM_ERROR,
+                            "Wayland: Unable to allocate clipboard memory");
+            return GLFW_FALSE;
+        }
+        _glfw.wl.clipboardSize = 4096;
     }
 
     return GLFW_TRUE;
@@ -1285,6 +1293,9 @@ void _glfwPlatformTerminate(void)
         close(_glfw.wl.timerfd);
     if (_glfw.wl.cursorTimerfd >= 0)
         close(_glfw.wl.cursorTimerfd);
+
+    if (_glfw.wl.clipboardString)
+        free(_glfw.wl.clipboardString);
 }
 
 const char* _glfwPlatformGetVersionString(void)

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -1263,6 +1263,8 @@ void _glfwPlatformTerminate(void)
         zxdg_decoration_manager_v1_destroy(_glfw.wl.decorationManager);
     if (_glfw.wl.wmBase)
         xdg_wm_base_destroy(_glfw.wl.wmBase);
+    if (_glfw.wl.dataSource)
+        wl_data_source_destroy(_glfw.wl.dataSource);
     if (_glfw.wl.dataDevice)
         wl_data_device_destroy(_glfw.wl.dataDevice);
     if (_glfw.wl.dataOffer)
@@ -1296,6 +1298,8 @@ void _glfwPlatformTerminate(void)
 
     if (_glfw.wl.clipboardString)
         free(_glfw.wl.clipboardString);
+    if (_glfw.wl.clipboardSendString)
+        free(_glfw.wl.clipboardSendString);
 }
 
 const char* _glfwPlatformGetVersionString(void)

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -256,6 +256,8 @@ typedef struct _GLFWlibraryWayland
     int32_t                     keyboardRepeatDelay;
     int                         keyboardLastKey;
     int                         keyboardLastScancode;
+    char*                       clipboardString;
+    size_t                      clipboardSize;
     int                         timerfd;
     short int                   keycodes[256];
     short int                   scancodes[GLFW_KEY_LAST + 1];

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -247,7 +247,7 @@ typedef struct _GLFWlibraryWayland
     struct wl_cursor_theme*     cursorThemeHiDPI;
     struct wl_surface*          cursorSurface;
     int                         cursorTimerfd;
-    uint32_t                    pointerSerial;
+    uint32_t                    serial;
 
     int32_t                     keyboardRepeatRate;
     int32_t                     keyboardRepeatDelay;

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -233,6 +233,9 @@ typedef struct _GLFWlibraryWayland
     struct wl_seat*             seat;
     struct wl_pointer*          pointer;
     struct wl_keyboard*         keyboard;
+    struct wl_data_device_manager*          dataDeviceManager;
+    struct wl_data_device*      dataDevice;
+    struct wl_data_offer*       dataOffer;
     struct xdg_wm_base*         wmBase;
     struct zxdg_decoration_manager_v1*      decorationManager;
     struct wp_viewporter*       viewporter;

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -236,6 +236,7 @@ typedef struct _GLFWlibraryWayland
     struct wl_data_device_manager*          dataDeviceManager;
     struct wl_data_device*      dataDevice;
     struct wl_data_offer*       dataOffer;
+    struct wl_data_source*      dataSource;
     struct xdg_wm_base*         wmBase;
     struct zxdg_decoration_manager_v1*      decorationManager;
     struct wp_viewporter*       viewporter;
@@ -258,6 +259,8 @@ typedef struct _GLFWlibraryWayland
     int                         keyboardLastScancode;
     char*                       clipboardString;
     size_t                      clipboardSize;
+    char*                       clipboardSendString;
+    size_t                      clipboardSendSize;
     int                         timerfd;
     short int                   keycodes[256];
     short int                   scancodes[GLFW_KEY_LAST + 1];

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -779,7 +779,7 @@ static void setCursorImage(_GLFWwindow* window,
         cursorWayland->yhot = image->hotspot_y;
     }
 
-    wl_pointer_set_cursor(_glfw.wl.pointer, _glfw.wl.pointerSerial,
+    wl_pointer_set_cursor(_glfw.wl.pointer, _glfw.wl.serial,
                           surface,
                           cursorWayland->xhot / scale,
                           cursorWayland->yhot / scale);
@@ -1501,7 +1501,7 @@ static void lockPointer(_GLFWwindow* window)
     window->wl.pointerLock.relativePointer = relativePointer;
     window->wl.pointerLock.lockedPointer = lockedPointer;
 
-    wl_pointer_set_cursor(_glfw.wl.pointer, _glfw.wl.pointerSerial,
+    wl_pointer_set_cursor(_glfw.wl.pointer, _glfw.wl.serial,
                           NULL, 0, 0);
 }
 
@@ -1565,8 +1565,7 @@ void _glfwPlatformSetCursor(_GLFWwindow* window, _GLFWcursor* cursor)
     }
     else if (window->cursorMode == GLFW_CURSOR_HIDDEN)
     {
-        wl_pointer_set_cursor(_glfw.wl.pointer, _glfw.wl.pointerSerial,
-                              NULL, 0, 0);
+        wl_pointer_set_cursor(_glfw.wl.pointer, _glfw.wl.serial, NULL, 0, 0);
     }
 }
 


### PR DESCRIPTION
Clipboard support was one of the last missing features in the Wayland backend.

The current API is not adapted to a highly asynchronous protocol such as Wayland, but fixing that will have to wait 4.0 so I did what I could. The main issue is in `glfwGetClipboardString()`, which has to dispatch the request and block until the client sending the clipboard data is done, which could potentially take a very long time. A good way to reach this state is to copy from another Wayland client, `kill -STOP` it, and paste in the GLFW program, it will then block until we `kill -CONT` the other one. A possible solution against this issue would be to set a timer and place a handler for SIGALRM, but in the general case we can expect other clients to be well-behaved.

Supersedes #358, from which one commit has been extracted but the rest has been written from scratch.