### PR TITLE
Fix missing check for _NET_WM_STATE

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ information on what to include when reporting a bug.
 - [X11] Bugfix: Selection I/O reported but did not support `COMPOUND_TEXT`
 - [X11] Bugfix: Latin-1 text read from selections was not converted to UTF-8
 - [X11] Bugfix: NVidia EGL would segfault if unloaded before closing the display
+- [X11] Bugfix: Checking window maximized attrib could crash some WMs
 - [Linux] Added workaround for missing `SYN_DROPPED` in pre-2.6.39 kernel
           headers (#1196)
 - [Linux] Moved to evdev for joystick input (#906,#1005)

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -2450,6 +2450,14 @@ int _glfwPlatformWindowMaximized(_GLFWwindow* window)
     Atom* states;
     unsigned long i;
     GLFWbool maximized = GLFW_FALSE;
+
+    if (!_glfw.x11.NET_WM_STATE ||
+        !_glfw.x11.NET_WM_STATE_MAXIMIZED_VERT ||
+        !_glfw.x11.NET_WM_STATE_MAXIMIZED_HORZ)
+    {
+        return maximized;
+    }
+
     const unsigned long count =
         _glfwGetWindowPropertyX11(window->x11.handle,
                                   _glfw.x11.NET_WM_STATE,


### PR DESCRIPTION
I am using a tiling WM (XMonad) which doesn't support the NET_WM_STATE atom out-of-the-box, and whenver I call glfwGetWindowAttrib(window, GLFW_MAXIMIZED), I get a crash:

```                                                
X Error of failed request:  BadAtom (invalid Atom parameter)                                                                                                                                                                      
  Major opcode of failed request:  20 (X_GetProperty)                                                                                                                                                                               
  Atom id in failed request:  0x0                                                                                                                                                                                                 
  Serial number of failed request:  168                                                                                                                                                                                             
  Current serial number in output stream:  168
```

Other functions that get or set NET_WM_STATE check for the atom being null. The fix is to add a simple check to _glfwPlatformWindowMaximized.