### PR TITLE
Manage correctly the key combination Ctrl + Tab under macOS

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -643,6 +643,36 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
     [super updateTrackingAreas];
 }
 
+- (BOOL)performKeyEquivalent:(NSEvent *)nsevent
+{
+    // At the moment the only reason we define this method
+    // is Ctrl-tab key event never reaching any view at all.
+    // After -performKeyEquivalent: returns NO on all responders,
+    // we receve Ctrl-tab in our QNSWindow's -sendEvent:,
+    // but somehow it never reaches QNSView's -keyDown:.
+    // Apparently, it's treated in a special (and undocumented)
+    // way by Cocoa. 'Illegal' but really nice, clear and safe solution
+    // would be to define _wantsKeyDownForEvent, but it's a
+    // private/undocumented API.
+    if ([[self window] firstResponder] == self)
+    {
+        const NSUInteger modifierFlags = [nsevent modifierFlags];
+        NSString *chs = [nsevent charactersIgnoringModifiers];
+        if (modifierFlags & NSControlKeyMask)
+        {
+            if ([chs characterAtIndex:0] == NSTabCharacter)
+            {
+                if (![[NSApp mainMenu] performKeyEquivalent:nsevent])
+                {
+                    [self keyDown:nsevent];
+                }
+                return YES;
+            }
+        }
+    }
+    return NO;
+}
+
 - (void)keyDown:(NSEvent *)event
 {
     const int key = translateKey([event keyCode]);

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -658,7 +658,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
     {
         const NSUInteger modifierFlags = [nsevent modifierFlags];
         NSString *chs = [nsevent charactersIgnoringModifiers];
-        if (modifierFlags & NSControlKeyMask)
+        if (modifierFlags & NSEventModifierFlagControl)
         {
             if ([chs characterAtIndex:0] == NSTabCharacter)
             {


### PR DESCRIPTION
From qutebrowser/qutebrowser#2142 and specifically this [comment](https://github.com/qutebrowser/qutebrowser/issues/2142#issuecomment-263254133):
> The combination CTRL + Tab is specially handled by OSX/Cocoa text input method.

At least two solutions exists ([here](https://bugreports.qt.io/browse/QTBUG-8596?focusedCommentId=321526&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-321526) and [there](https://codereview.qt-project.org/#/c/161214/1/src/plugins/platforms/cocoa/qnsview.mm)) to fix the problem. However, the first one use a private/undocumented API. The second is used by this PR.

**NOTE**: I am not the author of the proposed code.