### PR TITLE
The cursor position callback is named differently example usage and example declaration

### DIFF
--- a/docs/input.dox
+++ b/docs/input.dox
@@ -245,7 +245,7 @@ If you wish to be notified when the cursor moves over the window, set a cursor
 position callback.
 
 @code
-glfwSetCursorPosCallback(window, cursor_pos_callback);
+glfwSetCursorPosCallback(window, cursor_position_callback);
 @endcode
 
 The callback functions receives the cursor position, measured in screen


### PR DESCRIPTION
In the documentation the example for `glfwSetCursorPosCallback` uses a different name for the callback function than the example function blow. In all other examples the same name is used.
