### PR TITLE
x11 window: update cursor position on enter event

### DIFF
--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -1455,12 +1455,20 @@ static void processEvent(XEvent *event)
 
         case EnterNotify:
         {
+            // XEnterWindowEvent is XCrossingEvent
+            const int x = event->xcrossing.x;
+            const int y = event->xcrossing.y;
+
             // HACK: This is a workaround for WMs (KWM, Fluxbox) that otherwise
             //       ignore the defined cursor for hidden cursor mode
             if (window->cursorMode == GLFW_CURSOR_HIDDEN)
                 updateCursorImage(window);
 
             _glfwInputCursorEnter(window, GLFW_TRUE);
+            _glfwInputCursorPos(window, x, y);
+
+            window->x11.lastCursorPosX = x;
+            window->x11.lastCursorPosY = y;
             return;
         }
 


### PR DESCRIPTION
click events would have an incorrect position after changing workspace,
if the mouse didn't move in between.
(Another example where this matters is a new window, if it appears under
the cursor, clicking would lead the application to think the user clicked
at 0,0)

FWIW I've done this for kitty which has their own fork of glfw now, but I believe this applies here as well, and it's simple enough. If someone has time there probably are other small stuff like this to pick; until then I'll at least try to not make the rift too much bigger by submitting to both when applicable; unless you don't care either.