### PR TITLE
Adds a `glfwInitVulkan` function to provide a vkGetInstanceProcAddr.

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ information on what to include when reporting a bug.
 - Added `GLFW_OSMESA_CONTEXT_API` for creating OpenGL contexts with
   [OSMesa](https://www.mesa3d.org/osmesa.html) (#281)
 - Added `GenerateMappings.cmake` script for updating gamepad mappings
+- Added `glfwInitVulkan` to init Vulkan with a custom loader
 - Made `glfwCreateWindowSurface` emit an error when the window has a context
   (#1194,#1205)
 - Deprecated window parameter of clipboard string functions

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -5287,6 +5287,29 @@ GLFWAPI int glfwExtensionSupported(const char* extension);
  */
 GLFWAPI GLFWglproc glfwGetProcAddress(const char* procname);
 
+/*! @brief Initializes the Vulkan support with the given Vulkan loader
+ *  function.
+ *
+ *  The passed pointer must be a valid vkGetInstanceProcAddr function
+ *  retrieved from the Vulkan loader. Calling this funciton is optional, and
+ *  GLFW attempts to locate the Vulkan loader automatically if this function is
+ *  not called explicitely.
+ *
+ *  @return `GLFW_TRUE` if initializing Vulkan was successful, or `GLFW_FALSE`
+ *  otherwise.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function may be called from any thread.
+ *
+ *  @sa @ref vulkan_support
+ *
+ *  @since Added in version 3.3.
+ *
+ *  @ingroup vulkan
+ */
+GLFWAPI int glfwInitVulkan(void* getInstanceProcAddr);
+
 /*! @brief Returns whether the Vulkan loader and an ICD have been found.
  *
  *  This function returns whether the Vulkan loader and any minimally functional


### PR DESCRIPTION
This allows an application to handle locating and loading a vulkan loader, but still use GLFW to handle the native window support.