### PR TITLE
Disable non-client painting on borderless windows

### DIFF
--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -1161,6 +1161,19 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
             DragFinish(drop);
             return 0;
         }
+
+        case WM_NCACTIVATE:
+        case WM_NCPAINT:
+        {
+            // HACK: Prevent title bar artifacts from appearing after restoring
+            //       a minimized borderless window
+            if (!window->decorated)
+            {
+                return TRUE;
+            }
+
+            break;
+        }
     }
 
     return DefWindowProcW(hWnd, uMsg, wParam, lParam);


### PR DESCRIPTION
Fixes an issue where a small title bar and window caption buttons were being painted after restoring a minimized undecorated window.

OS: Windows 10
GLFW: master branch

Steps to reproduce:

Repeatedly clicking the window's icon _on the task bar_ will cause the window to alternate between minimized and restored. Prior to this change, restoring the window causes the following title bar and caption buttons to be rendered in the upper left hand corner of the window.

![image](https://user-images.githubusercontent.com/221559/48686757-a968cf80-eb8b-11e8-9a32-a0a347cc0594.png)

```c
#include "GLFW/glfw3.h"

void key_callback(GLFWwindow* window, int key, int scancode, int action, int mods) {
    if (key == GLFW_KEY_ESCAPE) {
        glfwSetWindowShouldClose(window, GLFW_TRUE);
    }
}

int main() {
    glfwInit();
    glfwWindowHint(GLFW_DECORATED, GLFW_FALSE);
    GLFWwindow* window = glfwCreateWindow(800, 600, "GLFW Window", NULL, NULL);
    glfwSetKeyCallback(window, key_callback);
    while (!glfwWindowShouldClose(window)) {
        glfwWaitEvents();
    }
    glfwTerminate();
}
```
