### PR TITLE
Trigger mouse button event when the window is not yet focused on Cocoa

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -497,6 +497,11 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
     updateCursorImage(window);
 }
 
+- (BOOL)acceptsFirstMouse:(NSEvent *)event
+{
+    return YES;
+}
+
 - (void)mouseDown:(NSEvent *)event
 {
     _glfwInputMouseClick(window,


### PR DESCRIPTION
Solves https://github.com/glfw/glfw/issues/1209

This *could* have some debate, but this is the behavior on X11 and Win32. On Cocoa, when a window is not focused, the first click currently does not trigger a mouse button callback. This fixes that.