### PR TITLE
Avoid hardcoded ramp size 256 in glfwSetGamma

### DIFF
--- a/src/cocoa_monitor.m
+++ b/src/cocoa_monitor.m
@@ -467,9 +467,14 @@ void _glfwPlatformGetVideoMode(_GLFWmonitor* monitor, GLFWvidmode *mode)
     CVDisplayLinkRelease(link);
 }
 
+int _glfwPlatformGetGammaRampSize(_GLFWmonitor* monitor)
+{
+    return CGDisplayGammaTableCapacity(monitor->ns.displayID);
+}
+
 void _glfwPlatformGetGammaRamp(_GLFWmonitor* monitor, GLFWgammaramp* ramp)
 {
-    uint32_t i, size = CGDisplayGammaTableCapacity(monitor->ns.displayID);
+    uint32_t i, size = _glfwPlatformGetGammaRampSize(monitor);
     CGGammaValue* values = calloc(size * 3, sizeof(CGGammaValue));
 
     CGGetDisplayTransferByTable(monitor->ns.displayID,

--- a/src/internal.h
+++ b/src/internal.h
@@ -611,6 +611,7 @@ void _glfwPlatformGetMonitorContentScale(_GLFWmonitor* monitor,
                                          float* xscale, float* yscale);
 GLFWvidmode* _glfwPlatformGetVideoModes(_GLFWmonitor* monitor, int* count);
 void _glfwPlatformGetVideoMode(_GLFWmonitor* monitor, GLFWvidmode* mode);
+int  _glfwPlatformGetGammaRampSize(_GLFWmonitor* monitor);
 void _glfwPlatformGetGammaRamp(_GLFWmonitor* monitor, GLFWgammaramp* ramp);
 void _glfwPlatformSetGammaRamp(_GLFWmonitor* monitor, const GLFWgammaramp* ramp);
 

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -427,8 +427,8 @@ GLFWAPI const GLFWvidmode* glfwGetVideoMode(GLFWmonitor* handle)
 
 GLFWAPI void glfwSetGamma(GLFWmonitor* handle, float gamma)
 {
-    int i;
-    unsigned short values[256];
+    int i, size;
+    unsigned short *values;
     GLFWgammaramp ramp;
     assert(handle != NULL);
 
@@ -440,12 +440,19 @@ GLFWAPI void glfwSetGamma(GLFWmonitor* handle, float gamma)
         return;
     }
 
-    for (i = 0;  i < 256;  i++)
+    size = _glfwPlatformGetGammaRampSize((_GLFWmonitor*) handle);
+
+    if (size < 2)
+        return;
+
+    values = malloc(size * sizeof(unsigned short));
+
+    for (i = 0;  i < size;  i++)
     {
         float value;
 
         // Calculate intensity
-        value = i / 255.f;
+        value = 1.f / (size - 1) * i;
         // Apply gamma curve
         value = powf(value, 1.f / gamma) * 65535.f + 0.5f;
 
@@ -459,9 +466,10 @@ GLFWAPI void glfwSetGamma(GLFWmonitor* handle, float gamma)
     ramp.red = values;
     ramp.green = values;
     ramp.blue = values;
-    ramp.size = 256;
+    ramp.size = size;
 
     glfwSetGammaRamp(handle, &ramp);
+    free(values);
 }
 
 GLFWAPI const GLFWgammaramp* glfwGetGammaRamp(GLFWmonitor* handle)

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -431,13 +431,10 @@ GLFWAPI void glfwSetGamma(GLFWmonitor* handle, float gamma)
     unsigned short values[256];
     GLFWgammaramp ramp;
     assert(handle != NULL);
-    assert(gamma == gamma);
-    assert(gamma >= 0.f);
-    assert(gamma <= FLT_MAX);
 
     _GLFW_REQUIRE_INIT();
 
-    if (gamma != gamma || gamma <= 0.f || gamma > FLT_MAX)
+    if (!(gamma > 0.f && 1.f / gamma != 0.f))
     {
         _glfwInputError(GLFW_INVALID_VALUE, "Invalid gamma value %f", gamma);
         return;

--- a/src/null_monitor.c
+++ b/src/null_monitor.c
@@ -58,6 +58,11 @@ void _glfwPlatformGetVideoMode(_GLFWmonitor* monitor, GLFWvidmode* mode)
 {
 }
 
+int _glfwPlatformGetGammaRampSize(_GLFWmonitor* monitor)
+{
+    return 0;
+}
+
 void _glfwPlatformGetGammaRamp(_GLFWmonitor* monitor, GLFWgammaramp* ramp)
 {
 }

--- a/src/win32_monitor.c
+++ b/src/win32_monitor.c
@@ -455,6 +455,11 @@ void _glfwPlatformGetVideoMode(_GLFWmonitor* monitor, GLFWvidmode* mode)
                   &mode->blueBits);
 }
 
+int _glfwPlatformGetGammaRampSize(_GLFWmonitor* monitor)
+{
+    return 256;
+}
+
 void _glfwPlatformGetGammaRamp(_GLFWmonitor* monitor, GLFWgammaramp* ramp)
 {
     HDC dc;

--- a/src/wl_monitor.c
+++ b/src/wl_monitor.c
@@ -182,17 +182,15 @@ void _glfwPlatformGetVideoMode(_GLFWmonitor* monitor, GLFWvidmode* mode)
 
 void _glfwPlatformGetGammaRamp(_GLFWmonitor* monitor, GLFWgammaramp* ramp)
 {
-    // TODO
     _glfwInputError(GLFW_PLATFORM_ERROR,
-                    "Wayland: Gamma ramp getting not supported yet");
+                    "Wayland: Gamma ramp access it not available");
 }
 
 void _glfwPlatformSetGammaRamp(_GLFWmonitor* monitor,
                                const GLFWgammaramp* ramp)
 {
-    // TODO
     _glfwInputError(GLFW_PLATFORM_ERROR,
-                    "Wayland: Gamma ramp setting not supported yet");
+                    "Wayland: Gamma ramp access is not available");
 }
 
 

--- a/src/wl_monitor.c
+++ b/src/wl_monitor.c
@@ -180,6 +180,11 @@ void _glfwPlatformGetVideoMode(_GLFWmonitor* monitor, GLFWvidmode* mode)
     *mode = monitor->modes[monitor->wl.currentMode];
 }
 
+int _glfwPlatformGetGammaRampSize(_GLFWmonitor* monitor)
+{
+    return 0;
+}
+
 void _glfwPlatformGetGammaRamp(_GLFWmonitor* monitor, GLFWgammaramp* ramp)
 {
     _glfwInputError(GLFW_PLATFORM_ERROR,


### PR DESCRIPTION
This fixes unexpected failure to change gamma on X11 if the hardware is using a larger ramp (1024 entries per channel in my case).

This introduces a new internal function `_glfwPlatformGetGammaRampSize` and uses it to setup ramps of current size in glfwSetGamma.

The first two commits make small cleanups noticed when preparing the change.

Thanks!