### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,7 +79,7 @@ endif()
 
 # Make GCC and Clang warn about declarations that VS 2010 and 2012 won't accept
 # for all source files that VS will build
-if (${CMAKE_C_COMPILER_ID} STREQUAL GNU OR ${CMAKE_C_COMPILER_ID} STREQUAL Clang)
+if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
     if (WIN32)
         set(windows_SOURCES ${glfw_SOURCES})
     else()


### PR DESCRIPTION
I was getting an error in this cmake file when using 3.10.2 on linux. Here was the error message I was getting:

[cmake] CMake Error at external/glfw/src/CMakeLists.txt:82 (if):
[cmake]   if given arguments:
[cmake] 
[cmake]     "STREQUAL" "GNU" "OR" "STREQUAL" "Clang"
[cmake] 
[cmake]   Unknown arguments specified

Adding the quotes around the cmake variables seems to do the trick. That was also done with the STREQUAL condition earlier on line 66.