### PR TITLE
CMake: enable policy CMP0077.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,11 @@ if (POLICY CMP0054)
     cmake_policy(SET CMP0054 NEW)
 endif()
 
+if (POLICY CMP0077)
+    # option() honors normal variables
+    cmake_policy(SET CMP0077 NEW)
+endif()
+
 set(GLFW_VERSION_MAJOR "3")
 set(GLFW_VERSION_MINOR "3")
 set(GLFW_VERSION_PATCH "0")


### PR DESCRIPTION
This policy makes it easier for users to set library option()s when used
as CMake subproject.