### PR TITLE
Fix for VSync on 10.14 Mojave

### DIFF
--- a/src/nsgl_context.h
+++ b/src/nsgl_context.h
@@ -27,13 +27,21 @@
 #define _GLFW_PLATFORM_CONTEXT_STATE            _GLFWcontextNSGL nsgl
 #define _GLFW_PLATFORM_LIBRARY_CONTEXT_STATE    _GLFWlibraryNSGL nsgl
 
+#import <CoreVideo/CoreVideo.h>
+
+#include <stdatomic.h>
+
 
 // NSGL-specific per-context data
 //
 typedef struct _GLFWcontextNSGL
 {
-    id           pixelFormat;
-    id	         object;
+    id                pixelFormat;
+    id	              object;
+    CVDisplayLinkRef  displayLink;
+    atomic_int        swapInterval;
+    int               swapIntervalsPassed;
+    id                swapIntervalCond;
 
 } _GLFWcontextNSGL;
 

--- a/src/nsgl_context.m
+++ b/src/nsgl_context.m
@@ -31,6 +31,27 @@
  #define NSOpenGLContextParameterSurfaceOpacity NSOpenGLCPSurfaceOpacity
 #endif
 
+static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink,
+                                    const CVTimeStamp* now,
+                                    const CVTimeStamp* outputTime,
+                                    CVOptionFlags flagsIn,
+                                    CVOptionFlags* flagsOut,
+                                    void* userInfo)
+{
+  _GLFWwindow* window = (_GLFWwindow *) userInfo;
+  
+  const int setting = atomic_load(&window->context.nsgl.swapInterval);
+  if (setting > 0)
+  {
+    [window->context.nsgl.swapIntervalCond lock];
+    window->context.nsgl.swapIntervalsPassed++;
+    [window->context.nsgl.swapIntervalCond signal];
+    [window->context.nsgl.swapIntervalCond unlock];
+  }
+  
+  return kCVReturnSuccess;
+}
+
 static void makeContextCurrentNSGL(_GLFWwindow* window)
 {
     if (window)
@@ -43,6 +64,18 @@ static void makeContextCurrentNSGL(_GLFWwindow* window)
 
 static void swapBuffersNSGL(_GLFWwindow* window)
 {
+    const int setting = atomic_load(&window->context.nsgl.swapInterval);
+    if (setting > 0)
+    {
+        [window->context.nsgl.swapIntervalCond lock];
+        do
+        {
+            [window->context.nsgl.swapIntervalCond wait];
+        } while (window->context.nsgl.swapIntervalsPassed % setting != 0);
+        window->context.nsgl.swapIntervalsPassed = 0;
+        [window->context.nsgl.swapIntervalCond unlock];
+    }
+  
     // ARP appears to be unnecessary, but this is future-proof
     [window->context.nsgl.object flushBuffer];
 }
@@ -51,9 +84,10 @@ static void swapIntervalNSGL(int interval)
 {
     _GLFWwindow* window = _glfwPlatformGetTls(&_glfw.contextSlot);
 
-    GLint sync = interval;
-    [window->context.nsgl.object setValues:&sync
-                              forParameter:NSOpenGLContextParameterSwapInterval];
+    atomic_store(&window->context.nsgl.swapInterval, interval);
+    [window->context.nsgl.swapIntervalCond lock];
+    window->context.nsgl.swapIntervalsPassed = 0;
+    [window->context.nsgl.swapIntervalCond unlock];
 }
 
 static int extensionSupportedNSGL(const char* extension)
@@ -315,6 +349,17 @@ GLFWbool _glfwCreateContextNSGL(_GLFWwindow* window,
     window->context.extensionSupported = extensionSupportedNSGL;
     window->context.getProcAddress = getProcAddressNSGL;
     window->context.destroy = destroyContextNSGL;
+
+    CVDisplayLinkCreateWithActiveCGDisplays(&window->context.nsgl.displayLink);
+    CVDisplayLinkSetOutputCallback(window->context.nsgl.displayLink,
+                                   &displayLinkCallback,
+                                   window);
+    CVDisplayLinkSetCurrentCGDisplayFromOpenGLContext(window->context.nsgl.displayLink,
+                                                      window->context.nsgl.object,
+                                                      window->context.nsgl.pixelFormat);
+    CVDisplayLinkStart(window->context.nsgl.displayLink);
+  
+    window->context.nsgl.swapIntervalCond = [NSCondition new];
 
     return GLFW_TRUE;
 }

--- a/src/nsgl_context.m
+++ b/src/nsgl_context.m
@@ -39,7 +39,7 @@ static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink,
                                     void* userInfo)
 {
   _GLFWwindow* window = (_GLFWwindow *) userInfo;
-  
+
   const int setting = atomic_load(&window->context.nsgl.swapInterval);
   if (setting > 0)
   {
@@ -48,7 +48,7 @@ static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink,
     [window->context.nsgl.swapIntervalCond signal];
     [window->context.nsgl.swapIntervalCond unlock];
   }
-  
+
   return kCVReturnSuccess;
 }
 
@@ -75,7 +75,7 @@ static void swapBuffersNSGL(_GLFWwindow* window)
         window->context.nsgl.swapIntervalsPassed = 0;
         [window->context.nsgl.swapIntervalCond unlock];
     }
-  
+
     // ARP appears to be unnecessary, but this is future-proof
     [window->context.nsgl.object flushBuffer];
 }
@@ -358,7 +358,7 @@ GLFWbool _glfwCreateContextNSGL(_GLFWwindow* window,
                                                       window->context.nsgl.object,
                                                       window->context.nsgl.pixelFormat);
     CVDisplayLinkStart(window->context.nsgl.displayLink);
-  
+
     window->context.nsgl.swapIntervalCond = [NSCondition new];
 
     return GLFW_TRUE;

--- a/src/nsgl_context.m
+++ b/src/nsgl_context.m
@@ -355,8 +355,8 @@ GLFWbool _glfwCreateContextNSGL(_GLFWwindow* window,
                                    &displayLinkCallback,
                                    window);
     CVDisplayLinkSetCurrentCGDisplayFromOpenGLContext(window->context.nsgl.displayLink,
-                                                      window->context.nsgl.object,
-                                                      window->context.nsgl.pixelFormat);
+                                                      (CGLContextObj) window->context.nsgl.object,
+                                                      (CGLPixelFormatObj) window->context.nsgl.pixelFormat);
     CVDisplayLinkStart(window->context.nsgl.displayLink);
 
     window->context.nsgl.swapIntervalCond = [NSCondition new];


### PR DESCRIPTION
Addresses issue #1337

Fixes VSync on macOS 10.14 (Mojave) by using CVDisplayLink to synchronize frames rather than setting NSOpenGLContextParameterSwapInterval.

Based on work for SDL by @rcgordon: https://hg.libsdl.org/SDL/rev/73f3ca85ac0e