### PR TITLE
Ignore Visual Studio 2017 cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ _ReSharper*
 *.dir
 *.vcxproj*
 *.sln
+.vs/
 Win32
 x64
 Debug


### PR DESCRIPTION
Today when i'm building glfw using Visual Studio 2017, I noticed that the cache directory `.vs/` are not ignored. 

![image](https://user-images.githubusercontent.com/3838382/51403882-65db1380-1b84-11e9-8c80-18f484f6532f.png)

Since other generated files for Visual Studio are ignored, I decided to add it to `.gitignore`