### PR TITLE
input: Fix issues with XInput on Windows

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -227,6 +227,19 @@ GLFWAPI int glfwInit(void)
     memset(&_glfw, 0, sizeof(_glfw));
     _glfw.hints.init = _glfwInitHints;
 
+    {
+        int i;
+
+        for (i = 0;  _glfwDefaultMappings[i];  i++)
+        {
+            if (!_glfwInputUpdateGamepadMappings(_glfwDefaultMappings[i]))
+            {
+                terminate();
+                return GLFW_FALSE;
+            }
+        }
+    }
+
     if (!_glfwPlatformInit())
     {
         terminate();
@@ -247,19 +260,6 @@ GLFWAPI int glfwInit(void)
     _glfw.timer.offset = _glfwPlatformGetTimerValue();
 
     glfwDefaultWindowHints();
-
-    {
-        int i;
-
-        for (i = 0;  _glfwDefaultMappings[i];  i++)
-        {
-            if (!glfwUpdateGamepadMappings(_glfwDefaultMappings[i]))
-            {
-                terminate();
-                return GLFW_FALSE;
-            }
-        }
-    }
 
     return GLFW_TRUE;
 }

--- a/src/input.c
+++ b/src/input.c
@@ -1083,14 +1083,12 @@ GLFWAPI GLFWjoystickfun glfwSetJoystickCallback(GLFWjoystickfun cbfun)
     return cbfun;
 }
 
-GLFWAPI int glfwUpdateGamepadMappings(const char* string)
+int _glfwInputUpdateGamepadMappings(const char* string)
 {
     int jid;
     const char* c = string;
 
     assert(string != NULL);
-
-    _GLFW_REQUIRE_INIT_OR_RETURN(GLFW_FALSE);
 
     while (*c)
     {
@@ -1141,6 +1139,13 @@ GLFWAPI int glfwUpdateGamepadMappings(const char* string)
     }
 
     return GLFW_TRUE;
+}
+
+GLFWAPI int glfwUpdateGamepadMappings(const char* string)
+{
+    _GLFW_REQUIRE_INIT_OR_RETURN(GLFW_FALSE);
+
+    return _glfwInputUpdateGamepadMappings(string);
 }
 
 GLFWAPI int glfwJoystickIsGamepad(int jid)

--- a/src/internal.h
+++ b/src/internal.h
@@ -722,6 +722,8 @@ void _glfwInputJoystickAxis(_GLFWjoystick* js, int axis, float value);
 void _glfwInputJoystickButton(_GLFWjoystick* js, int button, char value);
 void _glfwInputJoystickHat(_GLFWjoystick* js, int hat, char value);
 
+int _glfwInputUpdateGamepadMappings(const char* string);
+
 void _glfwInputMonitor(_GLFWmonitor* monitor, int action, int placement);
 void _glfwInputMonitorWindow(_GLFWmonitor* monitor, _GLFWwindow* window);
 


### PR DESCRIPTION
glfwInit() will call _glfwPlatformInit(), which on Win32 will call
_glfwInitJoysticksWin32(), which will try to create an XInput gamepad
using the SDL device ID for XInput. However, at this point in time, the
default mappings for controllers hasn't been initialized, so we end up
with an XInput gamepad with no mappings.

Fix this by loading the mappings before calling glfwInit().