### PR TITLE
Win32: Do the even processing during window resize/move

### DIFF
--- a/src/win32_init.c
+++ b/src/win32_init.c
@@ -331,7 +331,6 @@ static void createKeyTables(void)
 //
 static HWND createHelperWindow(void)
 {
-    MSG msg;
     HWND window = CreateWindowExW(WS_EX_OVERLAPPEDWINDOW,
                                   _GLFW_WNDCLASSNAME,
                                   L"GLFW message window",
@@ -365,11 +364,7 @@ static HWND createHelperWindow(void)
                                         DEVICE_NOTIFY_WINDOW_HANDLE);
     }
 
-    while (PeekMessageW(&msg, _glfw.win32.helperWindowHandle, 0, 0, PM_REMOVE))
-    {
-        TranslateMessage(&msg);
-        DispatchMessageW(&msg);
-    }
+    SwitchToFiber(_glfw.win32.messageFiber);
 
    return window;
 }
@@ -540,6 +535,40 @@ BOOL _glfwIsWindows10BuildOrGreaterWin32(WORD build)
     return RtlVerifyVersionInfo(&osvi, mask, cond) == 0;
 }
 
+// Windows message dispatch fiber
+void CALLBACK messageFiberProc(LPVOID lpFiberParameter)
+{
+    MSG msg;
+    _GLFWwindow* window;
+    (void)lpFiberParameter;
+
+    for (;;)
+    {
+        while (PeekMessageW(&msg, NULL, 0, 0, PM_REMOVE))
+        {
+            if (msg.message == WM_QUIT)
+            {
+                // NOTE: While GLFW does not itself post WM_QUIT, other processes
+                //       may post it to this one, for example Task Manager
+                // HACK: Treat WM_QUIT as a close on all windows
+
+                window = _glfw.windowListHead;
+                while (window)
+                {
+                    _glfwInputWindowCloseRequest(window);
+                    window = window->next;
+                }
+            }
+            else
+            {
+                TranslateMessage(&msg);
+                DispatchMessageW(&msg);
+            }
+        }
+
+        SwitchToFiber(_glfw.win32.mainFiber);
+    }
+}
 
 //////////////////////////////////////////////////////////////////////////
 //////                       GLFW platform API                      //////
@@ -568,6 +597,14 @@ int _glfwPlatformInit(void)
     else if (IsWindowsVistaOrGreater())
         SetProcessDPIAware();
 
+    _glfw.win32.mainFiber = ConvertThreadToFiber(NULL);
+    if (!_glfw.win32.mainFiber)
+        return GLFW_FALSE;
+
+    _glfw.win32.messageFiber = CreateFiber(0, &messageFiberProc, NULL);
+    if (!_glfw.win32.messageFiber)
+        return GLFW_FALSE;
+
     if (!_glfwRegisterWindowClassWin32())
         return GLFW_FALSE;
 
@@ -591,6 +628,9 @@ void _glfwPlatformTerminate(void)
         DestroyWindow(_glfw.win32.helperWindowHandle);
 
     _glfwUnregisterWindowClassWin32();
+
+    DeleteFiber(_glfw.win32.messageFiber);
+    ConvertFiberToThread();
 
     // Restore previous foreground lock timeout system setting
     SystemParametersInfoW(SPI_SETFOREGROUNDLOCKTIMEOUT, 0,

--- a/src/win32_platform.h
+++ b/src/win32_platform.h
@@ -310,6 +310,10 @@ typedef struct _GLFWwindowWin32
     // The last received cursor position, regardless of source
     int                 lastCursorPosX, lastCursorPosY;
 
+    // If user pressed mouse button on window title bar
+    UINT                ncMouseButton;
+    LPARAM              ncMousePos;
+
 } _GLFWwindowWin32;
 
 // Win32-specific global data
@@ -331,6 +335,8 @@ typedef struct _GLFWlibraryWin32
     RAWINPUT*           rawInput;
     int                 rawInputSize;
     UINT                mouseTrailSize;
+    LPVOID              messageFiber;
+    LPVOID              mainFiber;
 
     struct {
         HINSTANCE                       instance;

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -809,10 +809,46 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
             return 0;
         }
 
+        case WM_NCLBUTTONDOWN:
+        {
+            if (wParam == HTCAPTION)
+            {
+                window->win32.ncMouseButton = uMsg;
+                window->win32.ncMousePos = lParam;
+                OutputDebugStringA("down started\n");
+                return 0;
+            }
+            break;
+        }
+
+        case WM_NCMOUSEMOVE:
+        {
+            if (window->win32.ncMouseButton)
+            {
+                if (GET_X_LPARAM(window->win32.ncMousePos) != GET_X_LPARAM(lParam) ||
+                    GET_Y_LPARAM(window->win32.ncMousePos) != GET_Y_LPARAM(lParam))
+                {
+                    DefWindowProcW(hWnd, window->win32.ncMouseButton, HTCAPTION, window->win32.ncMousePos);
+                    window->win32.ncMouseButton = 0;
+                }
+            }
+            break;
+        }
+
         case WM_MOUSEMOVE:
         {
             const int x = GET_X_LPARAM(lParam);
             const int y = GET_Y_LPARAM(lParam);
+
+            if (window->win32.ncMouseButton)
+            {
+                if (GET_X_LPARAM(window->win32.ncMousePos) != x ||
+                    GET_Y_LPARAM(window->win32.ncMousePos) != y)
+                {
+                    DefWindowProcW(hWnd, window->win32.ncMouseButton, HTCAPTION, window->win32.ncMousePos);
+                    window->win32.ncMouseButton = 0;
+                }
+            }
 
             // Disabled cursor motion input is provided by WM_INPUT
             if (window->cursorMode == GLFW_CURSOR_DISABLED)
@@ -918,6 +954,7 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
             if (window->cursorMode == GLFW_CURSOR_DISABLED)
                 enableCursor(window);
 
+            SetTimer(hWnd, 1, 1, NULL);
             break;
         }
 
@@ -929,6 +966,16 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
             if (window->cursorMode == GLFW_CURSOR_DISABLED)
                 disableCursor(window);
 
+            KillTimer(hWnd, 1);
+            break;
+        }
+
+        case WM_TIMER:
+        {
+            if (wParam == 1)
+            {
+                SwitchToFiber(_glfw.win32.mainFiber);
+            }
             break;
         }
 
@@ -1847,31 +1894,10 @@ void _glfwPlatformSetWindowOpacity(_GLFWwindow* window, float opacity)
 
 void _glfwPlatformPollEvents(void)
 {
-    MSG msg;
     HWND handle;
     _GLFWwindow* window;
 
-    while (PeekMessageW(&msg, NULL, 0, 0, PM_REMOVE))
-    {
-        if (msg.message == WM_QUIT)
-        {
-            // NOTE: While GLFW does not itself post WM_QUIT, other processes
-            //       may post it to this one, for example Task Manager
-            // HACK: Treat WM_QUIT as a close on all windows
-
-            window = _glfw.windowListHead;
-            while (window)
-            {
-                _glfwInputWindowCloseRequest(window);
-                window = window->next;
-            }
-        }
-        else
-        {
-            TranslateMessage(&msg);
-            DispatchMessageW(&msg);
-        }
-    }
+    SwitchToFiber(_glfw.win32.messageFiber);
 
     handle = GetActiveWindow();
     if (handle)


### PR DESCRIPTION
This change provides workaround for Windows modal event loop while window is being resized/moved.
User can continue using their standard "while" event loop in main thread to do updates in their application.

Change includes two parts:

* Move message dispatching in separate fiber. This allows to "break out" the modal event loop. This is done by using timer which fires after 1msec on window resize/move event. After timer fires, the control returns to main code. There is pretty much no performance overhead for switching fibers in this situation.

* Handle non-client left mouse click on title bar. Otherwise Windows does not return in DefWindowProc. Easy way to do this is to defer calling DefWindowProc on WM_NCLBUTTONDOWN message. Wait until user moves mouse (WMNC_MOUSEMOVE or WM_MOUSEMOVE) and then deliver original message. For example, exact same thing is done in [Google Chromium](https://chromium.googlesource.com/chromium/src/+/master/ui/views/win/hwnd_message_handler.cc#3187) source code.

This fixes issues like #1231, #561, #185.
