### PR TITLE
Win32: Fix flaky GetAsyncKeyState bit for CAPITAL and NUMLOCK

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ information on what to include when reporting a bug.
                   (#1315,#1316)
 - [Win32] Bugfix: A title bar would be drawn over undecorated windows in some
                   circumstances (#1383)
+- [Win32] Bugfix: GetAsyncKeyState used flaky bit for CAPS and NUM LOCK (#1428)
 - [X11] Moved to XI2 `XI_RawMotion` for disable cursor mode motion input (#125)
 - [X11] Replaced `_GLFW_HAS_XF86VM` compile-time option with dynamic loading
 - [X11] Bugfix: `glfwGetVideoMode` would segfault on Cygwin/X

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -422,9 +422,9 @@ static int getKeyMods(void)
         mods |= GLFW_MOD_ALT;
     if ((GetKeyState(VK_LWIN) | GetKeyState(VK_RWIN)) & 0x8000)
         mods |= GLFW_MOD_SUPER;
-    if (GetKeyState(VK_CAPITAL) & 1)
+    if (GetKeyState(VK_CAPITAL) & 0x8000)
         mods |= GLFW_MOD_CAPS_LOCK;
-    if (GetKeyState(VK_NUMLOCK) & 1)
+    if (GetKeyState(VK_NUMLOCK) & 0x8000)
         mods |= GLFW_MOD_NUM_LOCK;
 
     return mods;
@@ -444,9 +444,9 @@ static int getAsyncKeyMods(void)
         mods |= GLFW_MOD_ALT;
     if ((GetAsyncKeyState(VK_LWIN) | GetAsyncKeyState(VK_RWIN)) & 0x8000)
         mods |= GLFW_MOD_SUPER;
-    if (GetAsyncKeyState(VK_CAPITAL) & 1)
+    if (GetAsyncKeyState(VK_CAPITAL) & 0x8000)
         mods |= GLFW_MOD_CAPS_LOCK;
-    if (GetAsyncKeyState(VK_NUMLOCK) & 1)
+    if (GetAsyncKeyState(VK_NUMLOCK) & 0x8000)
         mods |= GLFW_MOD_NUM_LOCK;
 
     return mods;


### PR DESCRIPTION
This bug was reported on the Chromium bug tracker at https://crbug.com/922095 and seems to have been caused by a race between 7c87948eafa63cf8b6b3d020a26189df6a6d3527 that fixed the use of the first bit, and 0e8c4ea7ce653cc7346bfe9fd5e5ab3933961934 that added support for CAPITAL and NUM_LOCK.