### PR TITLE
DPI aware standard cursor icons

### DIFF
--- a/src/win32_platform.h
+++ b/src/win32_platform.h
@@ -61,6 +61,9 @@
 // GLFW uses DirectInput8 interfaces
 #define DIRECTINPUT_VERSION 0x0800
 
+// Enable standard cursors images defines
+#define OEMRESOURCE
+
 #include <wctype.h>
 #include <windows.h>
 #include <dinput.h>

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -1999,24 +1999,25 @@ int _glfwPlatformCreateCursor(_GLFWcursor* cursor,
 
 int _glfwPlatformCreateStandardCursor(_GLFWcursor* cursor, int shape)
 {
-    LPCWSTR name = NULL;
+    int id = 0;
 
     if (shape == GLFW_ARROW_CURSOR)
-        name = IDC_ARROW;
+        id = OCR_NORMAL;
     else if (shape == GLFW_IBEAM_CURSOR)
-        name = IDC_IBEAM;
+        id = OCR_IBEAM;
     else if (shape == GLFW_CROSSHAIR_CURSOR)
-        name = IDC_CROSS;
+        id = OCR_CROSS;
     else if (shape == GLFW_HAND_CURSOR)
-        name = IDC_HAND;
+        id = OCR_HAND;
     else if (shape == GLFW_HRESIZE_CURSOR)
-        name = IDC_SIZEWE;
+        id = OCR_SIZEWE;
     else if (shape == GLFW_VRESIZE_CURSOR)
-        name = IDC_SIZENS;
+        id = OCR_SIZENS;
     else
         return GLFW_FALSE;
 
-    cursor->win32.handle = CopyCursor(LoadCursorW(NULL, name));
+    cursor->win32.handle =
+            (HCURSOR)LoadImage(NULL, MAKEINTRESOURCE(id), IMAGE_CURSOR, 0, 0, LR_DEFAULTSIZE | LR_SHARED);
     if (!cursor->win32.handle)
     {
         _glfwInputErrorWin32(GLFW_PLATFORM_ERROR,


### PR DESCRIPTION
Since [LoadCursor doesn't support dpi virtualization](https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-loadcursora#dpi-virtualization), it leads to wrong scaling of user pointer cursor icon on multihead Windows setup in case if connected monitors have different dpi.

Changelist replaces `LoadCursor` with `LoadImage` to redirect correct scaling job to OS by setting `LR_DEFAULTSIZE`. `LR_SHARED` is required there since standard icons images are used and it assures that memory will be reused for similar cursor icons.

Normal "standard" cursor size after app started on primary monitor:

![normal-cursor-size](https://user-images.githubusercontent.com/1928902/52584830-ce43aa80-2e3b-11e9-9490-4fdb6dbdef2d.png)

Oversized cursor issue after external monitor with lower DPI pluged-in as primary display:

![cursor-size-lower-dpi](https://user-images.githubusercontent.com/1928902/52584882-f3d0b400-2e3b-11e9-8ce5-4dfcf304bf44.png)