### PR TITLE
give parent projects finer control over install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,10 @@ if (POLICY CMP0054)
     cmake_policy(SET CMP0054 NEW)
 endif()
 
+if (POLICY CMP0077)
+    cmake_policy(SET CMP0077 NEW)
+endif()
+
 set(GLFW_VERSION_MAJOR "3")
 set(GLFW_VERSION_MINOR "3")
 set(GLFW_VERSION_PATCH "0")
@@ -17,15 +21,76 @@ set(GLFW_VERSION_FULL "${GLFW_VERSION}.${GLFW_VERSION_PATCH}${GLFW_VERSION_EXTRA
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
+#--------------------------------------------------------------------
+# Main project options
+#--------------------------------------------------------------------
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option(GLFW_BUILD_EXAMPLES "Build the GLFW example programs" ON)
 option(GLFW_BUILD_TESTS "Build the GLFW test programs" ON)
 option(GLFW_BUILD_DOCS "Build the GLFW documentation" ON)
-option(GLFW_INSTALL "Generate installation target" ON)
 option(GLFW_VULKAN_STATIC "Use the Vulkan loader statically linked into application" OFF)
 
+#--------------------------------------------------------------------
+# Options for controlling installation behavior
+#--------------------------------------------------------------------
+option(GLFW_INSTALL "Generate installation target" ON)
+option(GLFW_UNINSTALL "Generate uninstall target if not already defined" ON)
 include(GNUInstallDirs)
 
+# pkg-config file needs absolute paths for install and include directories.
+# This macro helps reset variables populated by GNUInstallDirs when a user
+# specifies a custom include / lib install directory.
+#
+# destvar: variable to make replacement in / save value to
+# original: default value GNUInstallDirs set
+# custom: value of custom directory specified by user
+macro(glfw_replace_absolute destvar original custom)
+    if (IS_ABSOLUTE "${${custom}}")
+        set(${destvar} "${${custom}}")
+    else()
+        string(REGEX REPLACE
+               "${${original}}$" # Replace original path suffix
+               "${${custom}}"    # with custom suffix.
+               ${destvar}        # Save into destvar
+               "${${destvar}}")  # Input to replace is current value of destvar
+    endif()
+endmacro()
+
+# Allow parent projects to define where to install the headers
+if (NOT DEFINED GLFW_INSTALL_INCLUDEDIR)
+    set(GLFW_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
+else()
+    glfw_replace_absolute(CMAKE_INSTALL_FULL_INCLUDEDIR
+                          CMAKE_INSTALL_INCLUDEDIR
+                          GLFW_INSTALL_INCLUDEDIR)
+endif()
+
+# Allow parent projects to define where to install the library.  Value affects
+# where to install:
+# - GLFW_INSTALL_CONFIGDIR: defaults to GLFW_INSTALL_LIBDIR/cmake/glfw3
+# - GLFW_INSTALL_PKGCONFDIR: defaults to GLFW_INSTALL_LIBDIR/pkgconfig
+# Parent projects seeking different install locations must also override these.
+if (NOT DEFINED GLFW_INSTALL_LIBDIR)
+    set(GLFW_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
+else()
+    glfw_replace_absolute(CMAKE_INSTALL_FULL_LIBDIR
+                          CMAKE_INSTALL_LIBDIR
+                          GLFW_INSTALL_LIBDIR)
+endif()
+
+# Allow parent projects to define where to install cmake config / targets.
+if (NOT DEFINED GLFW_INSTALL_CONFIGDIR)
+    set(GLFW_INSTALL_CONFIGDIR "${GLFW_INSTALL_LIBDIR}/cmake/glfw3")
+endif()
+
+# Allow parent projects to define where to install pkg-config files.
+if (NOT DEFINED GLFW_INSTALL_PKGCONFDIR)
+    set(GLFW_INSTALL_PKGCONFDIR "${GLFW_INSTALL_LIBDIR}/pkgconfig")
+endif()
+
+#--------------------------------------------------------------------
+# Platform specific project options
+#--------------------------------------------------------------------
 if (UNIX)
     option(GLFW_USE_OSMESA "Use OSMesa for offscreen context creation" OFF)
 endif()
@@ -42,6 +107,9 @@ if (MSVC)
     option(USE_MSVC_RUNTIME_LIBRARY_DLL "Use MSVC runtime library DLL" ON)
 endif()
 
+#--------------------------------------------------------------------
+# Initial project setup
+#--------------------------------------------------------------------
 if (BUILD_SHARED_LIBS)
     set(_GLFW_BUILD_DLL 1)
 endif()
@@ -321,11 +389,9 @@ endforeach()
 #--------------------------------------------------------------------
 include(CMakePackageConfigHelpers)
 
-set(GLFW_CONFIG_PATH "${CMAKE_INSTALL_LIBDIR}/cmake/glfw3")
-
 configure_package_config_file(src/glfw3Config.cmake.in
                               src/glfw3Config.cmake
-                              INSTALL_DESTINATION "${GLFW_CONFIG_PATH}"
+                              INSTALL_DESTINATION "${GLFW_INSTALL_CONFIGDIR}"
                               NO_CHECK_REQUIRED_COMPONENTS_MACRO)
 
 write_basic_package_version_file(src/glfw3ConfigVersion.cmake
@@ -358,21 +424,21 @@ endif()
 # The library is installed by src/CMakeLists.txt
 #--------------------------------------------------------------------
 if (GLFW_INSTALL)
-    install(DIRECTORY include/GLFW DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    install(DIRECTORY include/GLFW DESTINATION "${GLFW_INSTALL_INCLUDEDIR}"
             FILES_MATCHING PATTERN glfw3.h PATTERN glfw3native.h)
 
     install(FILES "${GLFW_BINARY_DIR}/src/glfw3Config.cmake"
                   "${GLFW_BINARY_DIR}/src/glfw3ConfigVersion.cmake"
-            DESTINATION "${GLFW_CONFIG_PATH}")
+            DESTINATION "${GLFW_INSTALL_CONFIGDIR}")
 
     install(EXPORT glfwTargets FILE glfw3Targets.cmake
             EXPORT_LINK_INTERFACE_LIBRARIES
-            DESTINATION "${GLFW_CONFIG_PATH}")
+            DESTINATION "${GLFW_INSTALL_CONFIGDIR}")
     install(FILES "${GLFW_BINARY_DIR}/src/glfw3.pc"
-            DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+            DESTINATION "${GLFW_INSTALL_PKGCONFDIR}")
 
     # Only generate this target if no higher-level project already has
-    if (NOT TARGET uninstall)
+    if (GLFW_UNINSTALL AND NOT TARGET uninstall)
         configure_file(cmake_uninstall.cmake.in
                        cmake_uninstall.cmake IMMEDIATE @ONLY)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,7 +103,7 @@ set_target_properties(glfw PROPERTIES
 target_compile_definitions(glfw PRIVATE _GLFW_USE_CONFIG_H)
 target_include_directories(glfw PUBLIC
                            "$<BUILD_INTERFACE:${GLFW_SOURCE_DIR}/include>"
-                           "$<INSTALL_INTERFACE:${CMAKE_INSTALL_FULL_INCLUDEDIR}>")
+                           "$<INSTALL_INTERFACE:${GLFW_INSTALL_INCLUDEDIR}>")
 target_include_directories(glfw PRIVATE
                            "${GLFW_SOURCE_DIR}/src"
                            "${GLFW_BINARY_DIR}/src"
@@ -139,7 +139,7 @@ if (BUILD_SHARED_LIBS)
         target_compile_options(glfw PRIVATE "-fno-common")
 
         set_target_properties(glfw PROPERTIES
-                              INSTALL_NAME_DIR "${CMAKE_INSTALL_LIBDIR}")
+                              INSTALL_NAME_DIR "${GLFW_INSTALL_LIBDIR}")
     elseif (UNIX)
         # Hide symbols not explicitly tagged for export from the shared library
         target_compile_options(glfw PRIVATE "-fvisibility=hidden")
@@ -159,7 +159,7 @@ if (GLFW_INSTALL)
     install(TARGETS glfw
             EXPORT glfwTargets
             RUNTIME DESTINATION "bin"
-            ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-            LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+            ARCHIVE DESTINATION "${GLFW_INSTALL_LIBDIR}"
+            LIBRARY DESTINATION "${GLFW_INSTALL_LIBDIR}")
 endif()
 


### PR DESCRIPTION
Introduces configuration variables that can control the install location(s) for headers, libraries, cmake, and pkg-config.

- Existing installation procedures are unchanged (if user does not use these variables, remains as is).
- These variables are extremely helpful for parent packages that may need to control where things go.  This could also potentially be quite useful for packagers if their platform needs values other than what `GNUInstallDirs` defines.
- Adds `GLFW_UNINSTALL` option, parent projects that do not define an `uninstall` target likely do not want the GLFW uninstall (only).
- Includes CMP0077 policy update, this means that in a parent project I can `set(GLFW_UNINSTALL OFF)` in parent project, rather than `set(GLFW_UNINSTALL OFF CACHE BOOL "" FORCE)`.
    - I just noticed #1416 has this, I can remove it if you'd rather keep this more isolated.

For reference this tactic is inspired by the [vtk-m project](https://gitlab.kitware.com/vtk/vtk-m), it's a simple but very useful way to enable parent projects to control things :slightly_smiling_face:

### Results

To help with review I've included some sample output.  The manipulations introduced by `glfw_replace_absolute` macro are most relevant for `pkg-config` file, so that's why I'm including those.  Hopefully this is more helpful than distracting...

#### `master` branch

```
$ cmake .. -DCMAKE_INSTALL_PREFIX=/tmp/glfw_master && make -j install
-- Install configuration: ""
-- Installing: /tmp/glfw_master/include/GLFW
-- Installing: /tmp/glfw_master/include/GLFW/glfw3.h
-- Installing: /tmp/glfw_master/include/GLFW/glfw3native.h
-- Installing: /tmp/glfw_master/lib64/cmake/glfw3/glfw3Config.cmake
-- Installing: /tmp/glfw_master/lib64/cmake/glfw3/glfw3ConfigVersion.cmake
-- Installing: /tmp/glfw_master/lib64/cmake/glfw3/glfw3Targets.cmake
-- Installing: /tmp/glfw_master/lib64/cmake/glfw3/glfw3Targets-noconfig.cmake
-- Installing: /tmp/glfw_master/lib64/pkgconfig/glfw3.pc
-- Installing: /tmp/glfw_master/lib64/libglfw3.a
```

```console
$ cat /tmp/glfw_master/lib64/pkgconfig/glfw3.pc
prefix=/tmp/glfw_master
exec_prefix=${prefix}
includedir=/tmp/glfw_master/include
libdir=/tmp/glfw_master/lib64

Name: GLFW
Description: A multi-platform library for OpenGL, window and input
Version: 3.3.0
URL: https://www.glfw.org/
Requires.private:  x11
Libs: -L${libdir} -lglfw3
Libs.private:  -lrt -lm -ldl
Cflags: -I${includedir}
```

#### this branch (no changes)

```console
$ cmake .. -DCMAKE_INSTALL_PREFIX=/tmp/glfw_defaults && make -j install
-- Install configuration: ""
-- Installing: /tmp/glfw_defaults/include/GLFW
-- Installing: /tmp/glfw_defaults/include/GLFW/glfw3.h
-- Installing: /tmp/glfw_defaults/include/GLFW/glfw3native.h
-- Installing: /tmp/glfw_defaults/lib64/cmake/glfw3/glfw3Config.cmake
-- Installing: /tmp/glfw_defaults/lib64/cmake/glfw3/glfw3ConfigVersion.cmake
-- Installing: /tmp/glfw_defaults/lib64/cmake/glfw3/glfw3Targets.cmake
-- Installing: /tmp/glfw_defaults/lib64/cmake/glfw3/glfw3Targets-noconfig.cmake
-- Installing: /tmp/glfw_defaults/lib64/pkgconfig/glfw3.pc
-- Installing: /tmp/glfw_defaults/lib64/libglfw3.a
```

```console
$ cat /tmp/glfw_defaults/lib64/pkgconfig/glfw3.pc
prefix=/tmp/glfw_defaults
exec_prefix=${prefix}
includedir=/tmp/glfw_defaults/include
libdir=/tmp/glfw_defaults/lib64

Name: GLFW
Description: A multi-platform library for OpenGL, window and input
Version: 3.3.0
URL: https://www.glfw.org/
Requires.private:  x11
Libs: -L${libdir} -lglfw3
Libs.private:  -lrt -lm -ldl
Cflags: -I${includedir}
```

#### example change `lib64` to `lib`

```console
$ cmake .. -DCMAKE_INSTALL_PREFIX=/tmp/glfw_lib -DGLFW_INSTALL_LIBDIR=lib
-- Install configuration: ""
-- Installing: /tmp/glfw_lib/include/GLFW
-- Installing: /tmp/glfw_lib/include/GLFW/glfw3.h
-- Installing: /tmp/glfw_lib/include/GLFW/glfw3native.h
-- Installing: /tmp/glfw_lib/lib/cmake/glfw3/glfw3Config.cmake
-- Installing: /tmp/glfw_lib/lib/cmake/glfw3/glfw3ConfigVersion.cmake
-- Installing: /tmp/glfw_lib/lib/cmake/glfw3/glfw3Targets.cmake
-- Installing: /tmp/glfw_lib/lib/cmake/glfw3/glfw3Targets-noconfig.cmake
-- Installing: /tmp/glfw_lib/lib/pkgconfig/glfw3.pc
-- Installing: /tmp/glfw_lib/lib/libglfw3.a
```

```console
$ cat /tmp/glfw_lib/lib/pkgconfig/glfw3.pc
prefix=/tmp/glfw_lib
exec_prefix=${prefix}
includedir=/tmp/glfw_lib/include
libdir=/tmp/glfw_lib/lib

Name: GLFW
Description: A multi-platform library for OpenGL, window and input
Version: 3.3.0
URL: https://www.glfw.org/
Requires.private:  x11
Libs: -L${libdir} -lglfw3
Libs.private:  -lrt -lm -ldl
Cflags: -I${includedir}
```

#### example absolute path of include (test for `glfw_replace_absolute` macro)

```console
$ cmake .. -DCMAKE_INSTALL_PREFIX=/tmp/glfw_incl -DGLFW_INSTALL_INCLUDEDIR=/tmp/another_dir
-- Install configuration: ""
-- Installing: /tmp/another_dir/GLFW
-- Installing: /tmp/another_dir/GLFW/glfw3.h
-- Installing: /tmp/another_dir/GLFW/glfw3native.h
-- Installing: /tmp/glfw_incl/lib64/cmake/glfw3/glfw3Config.cmake
-- Installing: /tmp/glfw_incl/lib64/cmake/glfw3/glfw3ConfigVersion.cmake
-- Installing: /tmp/glfw_incl/lib64/cmake/glfw3/glfw3Targets.cmake
-- Installing: /tmp/glfw_incl/lib64/cmake/glfw3/glfw3Targets-noconfig.cmake
-- Installing: /tmp/glfw_incl/lib64/pkgconfig/glfw3.pc
-- Installing: /tmp/glfw_incl/lib64/libglfw3.a
```

```console
$ cat /tmp/glfw_incl/lib64/pkgconfig/glfw3.pc
prefix=/tmp/glfw_incl
exec_prefix=${prefix}
includedir=/tmp/another_dir
libdir=/tmp/glfw_incl/lib64

Name: GLFW
Description: A multi-platform library for OpenGL, window and input
Version: 3.3.0
URL: https://www.glfw.org/
Requires.private:  x11
Libs: -L${libdir} -lglfw3
Libs.private:  -lrt -lm -ldl
Cflags: -I${includedir}
```

`glfw3Targets.cmake` snippet

```cmake
set_target_properties(glfw PROPERTIES
  INTERFACE_INCLUDE_DIRECTORIES "/tmp/another_dir"
  INTERFACE_LINK_LIBRARIES "/usr/lib64/librt.so;/usr/lib64/libm.so;dl;/usr/lib64/libX11.so;-lpthread"                                                        
)
```