### PR TITLE
Bypass DwmIsCompositionEnabled checks on Win8+.

### DIFF
--- a/src/wgl_context.c
+++ b/src/wgl_context.c
@@ -321,10 +321,15 @@ static void swapBuffersWGL(_GLFWwindow* window)
     {
         if (IsWindowsVistaOrGreater())
         {
-            BOOL enabled;
+            BOOL enabled = FALSE;
+          
+            // DWM Composition is always enabled on Win8+
+            if (IsWindows8OrGreater())
+              enabled = TRUE;
 
             // HACK: Use DwmFlush when desktop composition is enabled
-            if (SUCCEEDED(DwmIsCompositionEnabled(&enabled)) && enabled)
+            if (enabled ||
+                (SUCCEEDED(DwmIsCompositionEnabled(&enabled)) && enabled))
             {
                 int count = abs(window->context.wgl.interval);
                 while (count--)
@@ -346,11 +351,16 @@ static void swapIntervalWGL(int interval)
     {
         if (IsWindowsVistaOrGreater())
         {
-            BOOL enabled;
+            BOOL enabled = FALSE;
+          
+            // DWM Composition is always enabled on Win8+
+            if (IsWindows8OrGreater())
+              enabled = TRUE;
 
             // HACK: Disable WGL swap interval when desktop composition is enabled to
             //       avoid interfering with DWM vsync
-            if (SUCCEEDED(DwmIsCompositionEnabled(&enabled)) && enabled)
+            if (enabled ||
+                (SUCCEEDED(DwmIsCompositionEnabled(&enabled)) && enabled))
                 interval = 0;
         }
     }

--- a/src/wgl_context.c
+++ b/src/wgl_context.c
@@ -321,11 +321,8 @@ static void swapBuffersWGL(_GLFWwindow* window)
     {
         if (IsWindowsVistaOrGreater())
         {
-            BOOL enabled = FALSE;
-
             // DWM Composition is always enabled on Win8+
-            if (IsWindows8OrGreater())
-              enabled = TRUE;
+            BOOL enabled = IsWindows8OrGreater();
 
             // HACK: Use DwmFlush when desktop composition is enabled
             if (enabled ||
@@ -351,11 +348,8 @@ static void swapIntervalWGL(int interval)
     {
         if (IsWindowsVistaOrGreater())
         {
-            BOOL enabled = FALSE;
-
             // DWM Composition is always enabled on Win8+
-            if (IsWindows8OrGreater())
-              enabled = TRUE;
+            BOOL enabled = IsWindows8OrGreater();
 
             // HACK: Disable WGL swap interval when desktop composition is enabled to
             //       avoid interfering with DWM vsync

--- a/src/wgl_context.c
+++ b/src/wgl_context.c
@@ -322,7 +322,7 @@ static void swapBuffersWGL(_GLFWwindow* window)
         if (IsWindowsVistaOrGreater())
         {
             BOOL enabled = FALSE;
-          
+
             // DWM Composition is always enabled on Win8+
             if (IsWindows8OrGreater())
               enabled = TRUE;
@@ -352,7 +352,7 @@ static void swapIntervalWGL(int interval)
         if (IsWindowsVistaOrGreater())
         {
             BOOL enabled = FALSE;
-          
+
             // DWM Composition is always enabled on Win8+
             if (IsWindows8OrGreater())
               enabled = TRUE;


### PR DESCRIPTION
DWM composition is always enabled on Win8+, so there's no need to call DwmIsCompositionEnabled on those platforms. See also https://bugs.chromium.org/p/chromium/issues/detail?id=942165.