### PR TITLE
Fix issue with Windows multi-threaded applications not being able to correctly get the GLFW_FOCUSED attribute from outside the main thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ information on what to include when reporting a bug.
 
 ## Changelog
 
-User-visible changes since the last release.
+* [Win32] Bugfix: Worker threads are now able to correctly detect if the window has focus by getting the `GLFW_FOCUSED` attribute.
 
 
 ## Contact

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -1788,7 +1788,7 @@ void _glfwPlatformSetWindowMonitor(_GLFWwindow* window,
 
 int _glfwPlatformWindowFocused(_GLFWwindow* window)
 {
-    return window->win32.handle == GetActiveWindow();
+    return window->win32.handle == GetForegroundWindow();
 }
 
 int _glfwPlatformWindowIconified(_GLFWwindow* window)
@@ -1918,7 +1918,7 @@ void _glfwPlatformPollEvents(void)
         }
     }
 
-    handle = GetActiveWindow();
+    handle = GetForegroundWindow();
     if (handle)
     {
         // NOTE: Shift keys on Windows tend to "stick" when both are pressed as


### PR DESCRIPTION
Multi-threaded Windows applications that attempt to get the `GLFW_FOCUSED` attribute from one of its worker threads will always be returned 0. 

This issue is being caused by the `GetActiveWindow()` calls in `win32_window.c:1791` and `win32_window.c:1921`, which returns a `nullptr` if it is called by a worker thread, even if `glfwMakeContextCurrent()` is correctly set.

Replacing these calls with `GetForegroundWindow()` fixes this issue, because it always returns the foreground window's handle, even from worker threads.

References:
* **GetActiveWindow**: https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-getactivewindow
* **GetForegroundWindow**: https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-getforegroundwindow
* **Relevant Microsoft devblogpost**: https://devblogs.microsoft.com/oldnewthing/?p=20643