### PR TITLE
CMake: Fix use absolute path in INSTALL_INTERFACE

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,7 +103,7 @@ set_target_properties(glfw PROPERTIES
 target_compile_definitions(glfw PRIVATE _GLFW_USE_CONFIG_H)
 target_include_directories(glfw PUBLIC
                            "$<BUILD_INTERFACE:${GLFW_SOURCE_DIR}/include>"
-                           "$<INSTALL_INTERFACE:${CMAKE_INSTALL_FULL_INCLUDEDIR}>")
+                           "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 target_include_directories(glfw PRIVATE
                            "${GLFW_SOURCE_DIR}/src"
                            "${GLFW_BINARY_DIR}/src"


### PR DESCRIPTION
Unfortunately, the long-awaited release 3.3 breaks the projects of some users. The problem arises from the use of the absolute path where it was not worth it.
There changes fix possible preprocessor error `GLFW/glfw3.h: No such file or directory` or error at CMake configuration time.