### PR TITLE
Win32: Invoke cursor enter callback before cursor position callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ information on what to include when reporting a bug.
  - Disabled tests and examples by default when built as a CMake subdirectory
  - Bugfix: The CMake config-file package used an absolute path and was not
    relocatable (#1470)
+ - [Win32] Bugfix: Invoke cursor enter callback before cursor position callback
  - [X11] Bugfix: The CMake files did not check for the XInput headers (#1480)
  - [NSGL] Removed enforcement of forward-compatible flag for core contexts
 
@@ -223,6 +224,7 @@ skills.
  - Glenn Lewis
  - Shane Liesegang
  - Anders Lindqvist
+ - Leon Linhart
  - Eyal Lotem
  - Aaron Loucks
  - Tristam MacDonald

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -828,6 +828,19 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
             const int x = GET_X_LPARAM(lParam);
             const int y = GET_Y_LPARAM(lParam);
 
+            if (!window->win32.cursorTracked)
+            {
+                TRACKMOUSEEVENT tme;
+                ZeroMemory(&tme, sizeof(tme));
+                tme.cbSize = sizeof(tme);
+                tme.dwFlags = TME_LEAVE;
+                tme.hwndTrack = window->win32.handle;
+                TrackMouseEvent(&tme);
+
+                window->win32.cursorTracked = GLFW_TRUE;
+                _glfwInputCursorEnter(window, GLFW_TRUE);
+            }
+
             if (window->cursorMode == GLFW_CURSOR_DISABLED)
             {
                 const int dx = x - window->win32.lastCursorPosX;
@@ -847,19 +860,6 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
 
             window->win32.lastCursorPosX = x;
             window->win32.lastCursorPosY = y;
-
-            if (!window->win32.cursorTracked)
-            {
-                TRACKMOUSEEVENT tme;
-                ZeroMemory(&tme, sizeof(tme));
-                tme.cbSize = sizeof(tme);
-                tme.dwFlags = TME_LEAVE;
-                tme.hwndTrack = window->win32.handle;
-                TrackMouseEvent(&tme);
-
-                window->win32.cursorTracked = GLFW_TRUE;
-                _glfwInputCursorEnter(window, GLFW_TRUE);
-            }
 
             return 0;
         }


### PR DESCRIPTION
Currently, on windows, when the cursor enters a window the cursor position callback is invoked once before the cursor enter callback is invoked. This behavior is confusing, does not seem to have any purpose. Additionally (from what I can tell by looking at the code) this is not the case for other platforms.

This PR provides a simple fix by moving some logic in the related Win32 event handling code in order to guarantee that the cursor enter callback is invoked before the cursor position callback (when the cursor enters the window.) After some brief testing I could not find any regressions caused by this change.


Note: The PR is currently targeting the `master` branch and thus the `3.4` release since I was not sure whether this could go into a patch update. Other than that I followed the contribution guidelines and enabled PR edits from maintainers, but if there is anything else for me to do, please let me know!