### PR TITLE
Remove _glfwInputWindowMonitor

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -1213,7 +1213,7 @@ void _glfwPlatformSetWindowMonitor(_GLFWwindow* window,
     if (window->monitor)
         releaseMonitor(window);
 
-    _glfwInputWindowMonitor(window, monitor);
+    window->monitor = monitor;
 
     // HACK: Allow the state cached in Cocoa to catch up to reality
     // TODO: Solve this in a less terrible way

--- a/src/internal.h
+++ b/src/internal.h
@@ -710,7 +710,6 @@ void _glfwInputWindowIconify(_GLFWwindow* window, GLFWbool iconified);
 void _glfwInputWindowMaximize(_GLFWwindow* window, GLFWbool maximized);
 void _glfwInputWindowDamage(_GLFWwindow* window);
 void _glfwInputWindowCloseRequest(_GLFWwindow* window);
-void _glfwInputWindowMonitor(_GLFWwindow* window, _GLFWmonitor* monitor);
 
 void _glfwInputKey(_GLFWwindow* window,
                    int key, int scancode, int action, int mods);

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -1725,7 +1725,7 @@ void _glfwPlatformSetWindowMonitor(_GLFWwindow* window,
 
     _glfwInputWindowMonitor(window, monitor);
 
-    if (monitor)
+    if (window->monitor)
     {
         MONITORINFO mi = { sizeof(mi) };
         UINT flags = SWP_SHOWWINDOW | SWP_NOACTIVATE | SWP_NOCOPYBITS;

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -1723,7 +1723,7 @@ void _glfwPlatformSetWindowMonitor(_GLFWwindow* window,
     if (window->monitor)
         releaseMonitor(window);
 
-    _glfwInputWindowMonitor(window, monitor);
+    window->monitor = monitor;
 
     if (window->monitor)
     {

--- a/src/window.c
+++ b/src/window.c
@@ -138,13 +138,6 @@ void _glfwInputWindowCloseRequest(_GLFWwindow* window)
         window->callbacks.close((GLFWwindow*) window);
 }
 
-// Notifies shared code that a window has changed its desired monitor
-//
-void _glfwInputWindowMonitor(_GLFWwindow* window, _GLFWmonitor* monitor)
-{
-    window->monitor = monitor;
-}
-
 //////////////////////////////////////////////////////////////////////////
 //////                        GLFW public API                       //////
 //////////////////////////////////////////////////////////////////////////

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -1015,7 +1015,7 @@ void _glfwPlatformRestoreWindow(_GLFWwindow* window)
         // There is no way to unset minimized, or even to know if we are
         // minimized, so there is nothing to do in this case.
     }
-    _glfwInputWindowMonitor(window, NULL);
+    window->monitor = NULL;
     window->wl.maximized = GLFW_FALSE;
 }
 
@@ -1080,7 +1080,7 @@ void _glfwPlatformSetWindowMonitor(_GLFWwindow* window,
         if (!_glfw.wl.decorationManager)
             createDecorations(window);
     }
-    _glfwInputWindowMonitor(window, monitor);
+    window->monitor = monitor;
 }
 
 int _glfwPlatformWindowFocused(_GLFWwindow* window)

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -2421,7 +2421,7 @@ void _glfwPlatformSetWindowMonitor(_GLFWwindow* window,
     if (window->monitor)
         releaseMonitor(window);
 
-    _glfwInputWindowMonitor(window, monitor);
+    window->monitor = monitor;
     updateNormalHints(window, width, height);
 
     if (window->monitor)


### PR DESCRIPTION
`_glfwInputWindowMonitor` did nothing more than assign a member of the `window` struct, so I think the code actually becomes more readable by removing the function and doing the assignment explicitly.

Also cleaned up a pointer non-NULL check in win32_window.c that was causing a false-positive warning in MSVC 2019.