### PR TITLE
CMake : remove the setting of INSTALL_NAME_DIR property on Mac 

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -137,9 +137,6 @@ if (BUILD_SHARED_LIBS)
     elseif (APPLE)
         # Add -fno-common to work around a bug in Apple's GCC
         target_compile_options(glfw PRIVATE "-fno-common")
-
-        set_target_properties(glfw PROPERTIES
-                              INSTALL_NAME_DIR "${CMAKE_INSTALL_LIBDIR}")
     elseif (UNIX)
         # Hide symbols not explicitly tagged for export from the shared library
         target_compile_options(glfw PRIVATE "-fvisibility=hidden")


### PR DESCRIPTION
That gets in the way of proper RPATH handling as far as I can tell.

A small reproducer is below.

```
git clone https://github.com/aphecetche/glfw-open-window
mkdir build
cd build
cmake -DCMAKE_INSTALL_PREFIX=../install ../glfw-open-window -DGLFW_ROOT=[install path of glfw]
make install
```

That creates a  trivial main executable that just opens a window. 

w/o this PR launching the executable I get : 

```
~/alice/cmake/standalone/install-glfw-open-window/bin$ ./main
dyld: Library not loaded: lib/libglfw.3.dylib
  Referenced from: /Users/laurent/alice/cmake/standalone/install-glfw-open-window/bin/./main
  Reason: image not found
zsh: abort      ./main
```

And I guess it's due to the setting of the INSTALL_NAME_DIR which makes the executable try to fetch the lib from lib/ (=${CMAKE_INSTALL_LIBDIR})...

> otool -L main
main:
        lib/libglfw.3.dylib (compatibility version 3.0.0, current version 3.3.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)

while with this PR the executable just works, as the lib reference is now to @rpath as expected : 

otool -L main
main:
        @rpath/libglfw.3.dylib (compatibility version 3.0.0, current version 3.4.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)


