### PR TITLE
win32_window : Respect floating.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ tests/title
 tests/triangle-vulkan
 tests/windows
 
+/[Bb]uild*/

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -1741,8 +1741,13 @@ void _glfwPlatformSetWindowMonitor(_GLFWwindow* window,
 
         acquireMonitor(window);
 
+        HWND z_mode = HWND_TOP;
+        if (window->floating) {
+                z_mode = HWND_TOPMOST;
+        }
+
         GetMonitorInfo(window->monitor->win32.handle, &mi);
-        SetWindowPos(window->win32.handle, HWND_TOPMOST,
+        SetWindowPos(window->win32.handle, z_mode,
                      mi.rcMonitor.left,
                      mi.rcMonitor.top,
                      mi.rcMonitor.right - mi.rcMonitor.left,


### PR DESCRIPTION
From my other closed PR. Fullscreen should not be topmost unless floating is set.
This is important for borderless fullscreen windows, which are expected to behave like normal windows.

If this is too drastic of a change. A new window option should be added to control this behavior, as it makes true borderless fullscreen impossible.