### PR TITLE
CMake: remove -DGLFW_DLL on non-Windows targets

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -134,6 +134,8 @@ if (BUILD_SHARED_LIBS)
             # Add a suffix to the import library to avoid naming conflicts
             set_target_properties(glfw PROPERTIES IMPORT_SUFFIX "dll.lib")
         endif()
+
+	target_compile_definitions(glfw INTERFACE GLFW_DLL)
     elseif (APPLE)
         # Add -fno-common to work around a bug in Apple's GCC
         target_compile_options(glfw PRIVATE "-fno-common")
@@ -145,7 +147,6 @@ if (BUILD_SHARED_LIBS)
         target_compile_options(glfw PRIVATE "-fvisibility=hidden")
     endif()
 
-    target_compile_definitions(glfw INTERFACE GLFW_DLL)
     target_link_libraries(glfw PRIVATE ${glfw_LIBRARIES})
 else()
     target_link_libraries(glfw INTERFACE ${glfw_LIBRARIES})


### PR DESCRIPTION
When using GLFW with CMake and installed GLFW binaries, `-DGLFW_DLL` is
passed on Linux, which should not happen.