### PR TITLE
Removed overloading of INSTALL_NAME_DIR with ${CMAKE_INSTALL_LIBDIR} …

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -137,9 +137,6 @@ if (BUILD_SHARED_LIBS)
     elseif (APPLE)
         # Add -fno-common to work around a bug in Apple's GCC
         target_compile_options(glfw PRIVATE "-fno-common")
-
-        set_target_properties(glfw PROPERTIES
-                              INSTALL_NAME_DIR "${CMAKE_INSTALL_LIBDIR}")
     endif()
 
     if (UNIX)


### PR DESCRIPTION
Hi. I don't quite understand why this was done in the first place, but it prevents users from specifying CMAKE_INSTALL_NAME_DIR. In particular it breaks linking against libglfw when (for exmaple) in tracy (https://bitbucket.org/wolfpld/tracy/src) when built using pkgsrc framework that relies on being able to pass CMAKE_INSTAL_NAME_DIR (see https://github.com/jsonn/pkgsrc/blob/trunk/mk/configure/cmake.mk, line 46).

Removing those lines make everything work as expected.