### PR TITLE
Fix comparison of video modes (#1555)

### DIFF
--- a/src/monitor.c
+++ b/src/monitor.c
@@ -56,6 +56,10 @@ static int compareVideoModes(const void* fp, const void* sp)
     if (farea != sarea)
         return farea - sarea;
 
+    // Then sort on width
+    if (fm->width != sm->width)
+        return fm->width - sm->width;
+
     // Lastly sort on refresh rate
     return fm->refreshRate - sm->refreshRate;
 }


### PR DESCRIPTION
This fixes the video mode comparator function which is also used to filter-out assumed duplicate video modes (#1555) when returning 0.