### PR TITLE
Window setjoystickcallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,4 +82,4 @@ tests/timeout
 tests/title
 tests/triangle-vulkan
 tests/windows
-
+/[Bb]uild*/

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -1613,6 +1613,32 @@ typedef void (* GLFWmonitorfun)(GLFWmonitor*,int);
  */
 typedef void (* GLFWjoystickfun)(int,int);
 
+/*! @brief The function pointer type for window joystick configuration callbacks.
+ *
+ *  This is the function pointer type for window joystick configuration callbacks.
+ *  Even though joystick configuration callbacks are global events, you may
+ *  use this version of the callback to recieve valid window pointers in
+ *  your callback. Must be used with appropriate glfwSetJoystickCallback overload.
+ *
+ *  A joystick configuration callback function has the following signature:
+ *  @code
+ *  void function_name(GLFWwindow* window, int jid, int event)
+ *  @endcode
+ *
+ *  @param[in] window A valid window associated to the event.
+ *  @param[in] jid The joystick that was connected or disconnected.
+ *  @param[in] event One of `GLFW_CONNECTED` or `GLFW_DISCONNECTED`.  Future
+ *  releases may add more events.
+ *
+ *  @sa @ref joystick_event
+ *  @sa @ref glfwSetJoystickCallback
+ *
+ *  @since Added in version 3.4.
+ *
+ *  @ingroup input
+ */
+typedef void (* GLFWjoystickwindowfun)(GLFWwindow*,int,int);
+
 /*! @brief Video mode type.
  *
  *  This describes a single video mode.
@@ -5138,6 +5164,44 @@ GLFWAPI int glfwJoystickIsGamepad(int jid);
  *  @ingroup input
  */
 GLFWAPI GLFWjoystickfun glfwSetJoystickCallback(GLFWjoystickfun callback);
+
+/*! @brief Sets the window joystick configuration callback.
+ *
+ *  This function sets the window joystick configuration callback, or removes the
+ *  currently set callback.  This is called when a joystick is connected to or
+ *  disconnected from the system. Windows which have registered to recieve
+ *  this callback will be notified, and provided with their window pointer.
+ *
+ *  For joystick connection and disconnection events to be delivered on all
+ *  platforms, you need to call one of the [event processing](@ref events)
+ *  functions.  Joystick disconnection may also be detected and the callback
+ *  called by joystick functions.  The function will then return whatever it
+ *  returns if the joystick is not present.
+ *
+ *  @param[in] window The window whose callback to set.
+ *  @param[in] callback The new callback, or `NULL` to remove the currently set
+ *  callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or the
+ *  library had not been [initialized](@ref intro_init).
+ *
+ *  @callback_signature
+ *  @code
+ *  void function_name(GLFWwindow* window, int jid, int event)
+ *  @endcode
+ *  For more information about the callback parameters, see the
+ *  [function pointer type](@ref GLFWjoystickwindowfun).
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref joystick_event
+ *
+ *  @since Added in version 3.4.
+ *
+ *  @ingroup input
+ */
+GLFWAPI GLFWjoystickwindowfun glfwSetJoystickCallback(GLFWwindow* window, GLFWjoystickwindowfun callback);
 
 /*! @brief Adds the specified SDL_GameControllerDB gamepad mappings.
  *

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -5201,7 +5201,7 @@ GLFWAPI GLFWjoystickfun glfwSetJoystickCallback(GLFWjoystickfun callback);
  *
  *  @ingroup input
  */
-GLFWAPI GLFWjoystickwindowfun glfwSetJoystickCallback(GLFWwindow* window, GLFWjoystickwindowfun callback);
+GLFWAPI GLFWjoystickwindowfun glfwSetWindowJoystickCallback(GLFWwindow* window, GLFWjoystickwindowfun callback);
 
 /*! @brief Adds the specified SDL_GameControllerDB gamepad mappings.
  *

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -1618,7 +1618,7 @@ typedef void (* GLFWjoystickfun)(int,int);
  *  This is the function pointer type for window joystick configuration callbacks.
  *  Even though joystick configuration callbacks are global events, you may
  *  use this version of the callback to recieve valid window pointers in
- *  your callback. Must be used with appropriate glfwSetJoystickCallback overload.
+ *  your callback. Must be used with appropriate glfwSetWindowJoystickCallback overload.
  *
  *  A joystick configuration callback function has the following signature:
  *  @code
@@ -1631,7 +1631,7 @@ typedef void (* GLFWjoystickfun)(int,int);
  *  releases may add more events.
  *
  *  @sa @ref joystick_event
- *  @sa @ref glfwSetJoystickCallback
+ *  @sa @ref glfwSetWindowJoystickCallback
  *
  *  @since Added in version 3.4.
  *

--- a/src/input.c
+++ b/src/input.c
@@ -1124,7 +1124,7 @@ GLFWAPI GLFWjoystickfun glfwSetJoystickCallback(GLFWjoystickfun cbfun)
     return cbfun;
 }
 
-GLFWAPI GLFWjoystickwindowfun glfwSetJoystickCallback(GLFWwindow* handle, GLFWjoystickwindowfun cbfun)
+GLFWAPI GLFWjoystickwindowfun glfwSetWindowJoystickCallback(GLFWwindow* handle, GLFWjoystickwindowfun cbfun)
 {
     _GLFWwindow* window = (_GLFWwindow*) handle;
     assert(window != NULL);

--- a/src/input.c
+++ b/src/input.c
@@ -373,6 +373,18 @@ void _glfwInputJoystick(_GLFWjoystick* js, int event)
 
     if (_glfw.callbacks.joystick)
         _glfw.callbacks.joystick(jid, event);
+
+    // Send event to windows that want the notification.
+    {
+        _GLFWwindow* window;
+
+        for (window = _glfw.windowListHead;  window;  window = window->next) {
+            GLFWjoystickwindowfun fun = window->callbacks.joystickConnect;
+            if (fun) {
+                fun((GLFWwindow*) window, jid, event);
+            }
+        }
+    }
 }
 
 // Notifies shared code of the new value of a joystick axis
@@ -1109,6 +1121,16 @@ GLFWAPI GLFWjoystickfun glfwSetJoystickCallback(GLFWjoystickfun cbfun)
 {
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
     _GLFW_SWAP_POINTERS(_glfw.callbacks.joystick, cbfun);
+    return cbfun;
+}
+
+GLFWAPI GLFWjoystickwindowfun glfwSetJoystickCallback(GLFWwindow* handle, GLFWjoystickwindowfun cbfun)
+{
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    assert(window != NULL);
+
+    _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
+    _GLFW_SWAP_POINTERS(window->callbacks.joystickConnect, cbfun);
     return cbfun;
 }
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -412,6 +412,7 @@ struct _GLFWwindow
         GLFWcharfun             character;
         GLFWcharmodsfun         charmods;
         GLFWdropfun             drop;
+        GLFWjoystickwindowfun   joystickConnect;
     } callbacks;
 
     // This is defined in the window API's platform.h


### PR DESCRIPTION
Fixes : https://github.com/glfw/glfw/issues/1526
And also fixes this issue in a natural and expected way : https://github.com/glfw/glfw/issues/1080

The joystickcallbacks break the API contract of GLFW. Namely, that you will be provided a user window pointer in your callbacks, and receive it when being called. This idiom is important, and consistency is important as well. GLFW is natural to use because of API consistency.

Added a callback to the window callbacks struct, which can be set by the user. When executing joystick configuration callbacks, first the global one is called. We then iterate windows and call the appropriate callback if it is set, and provide the necessary window pointer to the user.

I've been writing mostly c++ in recent years, please keep your eyes open for some non-ANSI C stuff during review, ty.

You may bikeshed the name among yourselves as much as you like, just let me know what name you want. I don't care ;) 