### PR TITLE
Use the correct type for a struct member

### DIFF
--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -330,7 +330,7 @@ typedef struct _GLFWlibraryWayland
 typedef struct _GLFWmonitorWayland
 {
     struct wl_output*           output;
-    int                         name;
+    uint32_t                    name;
     int                         currentMode;
 
     int                         x;


### PR DESCRIPTION
The `name` member in the `_GLFWmonitorWayland` struct is used in two places. It is assigned the value from a variable of type `uint32_t` and is compared to another variable of type `uint32_t`, so `name` should also have the same type.