### PR TITLE
OS X EGL context api support with ANGLE

### DIFF
--- a/src/cocoa_platform.h
+++ b/src/cocoa_platform.h
@@ -81,7 +81,7 @@ typedef VkResult (APIENTRY *PFN_vkCreateMacOSSurfaceMVK)(VkInstance,const VkMacO
 #define _glfw_dlclose(handle) dlclose(handle)
 #define _glfw_dlsym(handle, name) dlsym(handle, name)
 
-#define _GLFW_EGL_NATIVE_WINDOW  ((EGLNativeWindowType) window->ns.view)
+#define _GLFW_EGL_NATIVE_WINDOW  ((EGLNativeWindowType) window->ns.layer)
 #define _GLFW_EGL_NATIVE_DISPLAY EGL_DEFAULT_DISPLAY
 
 #define _GLFW_PLATFORM_WINDOW_STATE         _GLFWwindowNS  ns

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -849,6 +849,8 @@ static GLFWbool createNativeWindow(_GLFWwindow* window,
         [window->ns.object setBackgroundColor:[NSColor clearColor]];
     }
 
+    [window->ns.view setWantsLayer:YES];
+    window->ns.layer = [window->ns.view layer];
     [window->ns.object setContentView:window->ns.view];
     [window->ns.object makeFirstResponder:window->ns.view];
     [window->ns.object setTitle:@(wndconfig->title)];


### PR DESCRIPTION
ANGLE'S EGL implementation expects the NativeWindowType to be a CALayer*.
https://github.com/google/angle/blob/master/src/libANGLE/renderer/gl/cgl/DisplayCGL.mm: DisplayCGL::isValidNativeWindow

Current GLFW implementation uses NSView*.
Since I couldn't find any alternative EGL implementations, I assumed that ANGLE's CALayer* choice is correct, and changed GLFW without checking the vendor.

To test I used the following code: https://gist.github.com/some00/1a5c9962e1efced46c26624e0b90d584