### PR TITLE
Use the correct type in a for loop

### DIFF
--- a/src/cocoa_monitor.m
+++ b/src/cocoa_monitor.m
@@ -252,7 +252,7 @@ void _glfwPollMonitorsNS(void)
     CGDirectDisplayID* displays = calloc(displayCount, sizeof(CGDirectDisplayID));
     CGGetOnlineDisplayList(displayCount, displays, &displayCount);
 
-    for (uint32_t i = 0;  i < _glfw.monitorCount;  i++)
+    for (int i = 0;  i < _glfw.monitorCount;  i++)
         _glfw.monitors[i]->ns.screen = nil;
 
     _GLFWmonitor** disconnected = NULL;


### PR DESCRIPTION
The `monitorCount` member in the `_GLFWlibrary` struct is of type `int`, so the `for` loop iterating over it should also use the type `int`.

Closes #1572.