### PR TITLE
Add glfwGetOpenedFilenames() to glfw3native.h

### DIFF
--- a/include/GLFW/glfw3native.h
+++ b/include/GLFW/glfw3native.h
@@ -215,6 +215,20 @@ GLFWAPI CGDirectDisplayID glfwGetCocoaMonitor(GLFWmonitor* monitor);
  *  @ingroup native
  */
 GLFWAPI id glfwGetCocoaWindow(GLFWwindow* window);
+
+/*! @brief Returns the list of filenames that opened the application,
+ *  such as by dragging files to the app bundle or through file associations.
+ *
+ *  @return A list of strings, null terminated.
+ *
+ *  @thread_safety This function may be called from any thread.  Access is not
+ *  synchronized.
+ *
+ *  @since Added in version 3.4.
+ *
+ *  @ingroup native
+ */
+const char* const* glfwGetCocoaOpenedFilenames(void);
 #endif
 
 #if defined(GLFW_EXPOSE_NATIVE_NSGL)

--- a/include/GLFW/glfw3native.h
+++ b/include/GLFW/glfw3native.h
@@ -228,7 +228,7 @@ GLFWAPI id glfwGetCocoaWindow(GLFWwindow* window);
  *
  *  @ingroup native
  */
-const char* const* glfwGetCocoaOpenedFilenames(void);
+const char* const* glfwGetOpenedFilenames(void);
 #endif
 
 #if defined(GLFW_EXPOSE_NATIVE_NSGL)

--- a/src/cocoa_init.m
+++ b/src/cocoa_init.m
@@ -623,7 +623,7 @@ const char* _glfwPlatformGetVersionString(void)
 //////                        GLFW native API                       //////
 //////////////////////////////////////////////////////////////////////////
 
-const char* const* glfwGetCocoaOpenedFilenames(void)
+const char* const* glfwGetOpenedFilenames(void)
 {
     return (const char* const*) _glfw.ns.openedFilenames;
 }

--- a/src/cocoa_init.m
+++ b/src/cocoa_init.m
@@ -625,5 +625,5 @@ const char* _glfwPlatformGetVersionString(void)
 
 const char* const* glfwGetCocoaOpenedFilenames(void)
 {
-    return _glfw.ns.openedFilenames;
+    return (const char* const*) _glfw.ns.openedFilenames;
 }

--- a/src/cocoa_platform.h
+++ b/src/cocoa_platform.h
@@ -148,6 +148,7 @@ typedef struct _GLFWlibraryNS
     double              restoreCursorPosX, restoreCursorPosY;
     // The window whose disabled cursor mode is active
     _GLFWwindow*        disabledCursorWindow;
+    char**              openedFilenames;
 
     struct {
         CFBundleRef     bundle;


### PR DESCRIPTION
This solves https://github.com/glfw/glfw/issues/1024 and https://github.com/glfw/glfw/issues/1458 (which are nearly duplicates) in the least invasive way I could think of. A handful of people need this feature, and accessing `application:openFiles:` is impossible without access to the NSApplication class, so I believe a new native GLFW function is unavoidable.