### PR TITLE
CMakeLists.txt: Add support for cmake < v3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,6 @@ information on what to include when reporting a bug.
  - [X11] Bugfix: Key names were not updated when the keyboard layout changed
    (#1462,#1528)
  - [NSGL] Removed enforcement of forward-compatible flag for core contexts
- - Bugfix: Add CMake < v3.7 compatibility (#1584)
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ information on what to include when reporting a bug.
  - [X11] Bugfix: Key names were not updated when the keyboard layout changed
    (#1462,#1528)
  - [NSGL] Removed enforcement of forward-compatible flag for core contexts
-
+ - Bugfix: Add CMake < v3.7 compatibility (#1584)
 
 ## Contact
 
@@ -338,6 +338,7 @@ skills.
  - Santi Zupancic
  - Jonas Ådahl
  - Lasse Öörni
+ - Pablo Prietz
  - All the unmentioned and anonymous contributors in the GLFW community, for bug
    reports, patches, feedback, testing and encouragement
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -100,7 +100,10 @@ set_target_properties(glfw PROPERTIES
                       POSITION_INDEPENDENT_CODE ON
                       FOLDER "GLFW3")
 
-if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.1.0")
+if (
+    ${CMAKE_VERSION} VERSION_EQUAL "3.1.0" OR
+    ${CMAKE_VERSION} VERSION_GREATER "3.1.0"
+)
     set_target_properties(glfw PROPERTIES C_STANDARD 99)
 else()
     # Remove this fallback when removing support for CMake version less than 3.1


### PR DESCRIPTION
Fixes #1584

Replaces `VERSION_GREATER_EQUAL` with `VERSION_EQUAL OR VERSION_GREATER`