### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Release
 MinSizeRel
 RelWithDebInfo
 *.xcodeproj
+build
 
 # CMake files
 Makefile


### PR DESCRIPTION
often github projects or libraries in general are compiled inside a folder build
so would be nice to add to the .gitignore file