### PR TITLE
Videomode crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ information on what to include when reporting a bug.
    (#1462,#1528)
  - [X11] Bugfix: Decorations could not be enabled after window creation (#1566)
  - [X11] Bugfix: Content scale fallback value could be inconsistent (#1578)
+ - [X11] Bugfix: Fix crash when querying video mode/position of disconnected monitor
  - [Wayland] Bugfix: The `GLFW_HAND_CURSOR` shape used the wrong image (#1432)
  - [NSGL] Removed enforcement of forward-compatible flag for core contexts
 

--- a/src/x11_monitor.c
+++ b/src/x11_monitor.c
@@ -322,12 +322,14 @@ void _glfwPlatformGetMonitorPos(_GLFWmonitor* monitor, int* xpos, int* ypos)
             XRRGetScreenResourcesCurrent(_glfw.x11.display, _glfw.x11.root);
         XRRCrtcInfo* ci = XRRGetCrtcInfo(_glfw.x11.display, sr, monitor->x11.crtc);
 
-        if (xpos)
-            *xpos = ci->x;
-        if (ypos)
-            *ypos = ci->y;
+        if (ci) {
+            if (xpos)
+                *xpos = ci->x;
+            if (ypos)
+                *ypos = ci->y;
 
-        XRRFreeCrtcInfo(ci);
+            XRRFreeCrtcInfo(ci);
+        }
         XRRFreeScreenResources(sr);
     }
 }
@@ -493,9 +495,12 @@ void _glfwPlatformGetVideoMode(_GLFWmonitor* monitor, GLFWvidmode* mode)
             XRRGetScreenResourcesCurrent(_glfw.x11.display, _glfw.x11.root);
         XRRCrtcInfo* ci = XRRGetCrtcInfo(_glfw.x11.display, sr, monitor->x11.crtc);
 
-        *mode = vidmodeFromModeInfo(getModeInfo(sr, ci->mode), ci);
-
-        XRRFreeCrtcInfo(ci);
+        if (ci) {
+            const XRRModeInfo* mi = getModeInfo(sr, ci->mode);
+            if (mi) // mi can be NULL if the monitor has been disconnected
+                *mode = vidmodeFromModeInfo(mi, ci);
+            XRRFreeCrtcInfo(ci);
+        }
         XRRFreeScreenResources(sr);
     }
     else


### PR DESCRIPTION
Fixing a bug where querying the position or video mode of a disconnected monitor would cause GLFW to segfault.

All credits to [kovidgoyal](https://github.com/kovidgoyal) for originally pushing this fix in his own fork of GLFW. (Original pull request: https://github.com/kovidgoyal/glfw/commit/c5a1269b2a661b86ed54934836796599526669b3?diff=split) 