### PR TITLE
Expose damage tracking in the API

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -5656,6 +5656,7 @@ GLFWAPI void glfwSwapBuffers(GLFWwindow* window);
  *  @sa @ref buffer_swap
  *  @sa @ref glfwSwapBuffers
  *  @sa @ref glfwSwapInterval
+ *  @sa @ref glfwGetBufferAge
  *
  *  @since Added in version 3.4.
  *
@@ -5708,6 +5709,36 @@ GLFWAPI void glfwSwapBuffersWithDamage(GLFWwindow* window, GLFWrect* rects, int 
  *  @ingroup context
  */
 GLFWAPI void glfwSwapInterval(int interval);
+
+/*! @brief Returns the buffer age of the window’s current buffer.
+ *
+ *  This function returns the age of the current buffer, in frames.  It may be
+ *  used to redraw only the parts of the buffer that have changed since this
+ *  buffer was last used, thus avoiding a clear and draw of the entire buffer.
+ *
+ *  A context must be current on the calling thread.  Calling this function
+ *  without a current context will cause a @ref GLFW_NO_CURRENT_CONTEXT error.
+ *
+ *  This function does not apply to Vulkan.  If you are rendering with Vulkan,
+ *  see the present mode of your swapchain instead.
+ *
+ *  @param[in] window The window whose buffers to swap.
+ *  @return The age of the back buffer if the extension is available, or 0
+ *  otherwise.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+ *  GLFW_NO_CURRENT_CONTEXT and @ref GLFW_PLATFORM_ERROR.
+ *
+ *  @thread_safety This function may be called from any thread.
+ *
+ *  @sa @ref buffer_swap
+ *  @sa @ref glfwSwapBuffersWithDamage
+ *
+ *  @since Added in version 3.4.
+ *
+ *  @ingroup context
+ */
+GLFWAPI int glfwGetBufferAge(GLFWwindow* window);
 
 /*! @brief Returns whether the specified extension is available.
  *

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -1780,6 +1780,33 @@ typedef struct GLFWimage
     unsigned char* pixels;
 } GLFWimage;
 
+/*! @brief Rectangle.
+ *
+ *  This describes a single 2D box.  The origin is the bottom-left point of the
+ *  window.
+ *
+ *  @sa @ref buffer_swap
+ *
+ *  @since Added in version 3.4.
+ *
+ *  @ingroup window
+ */
+typedef struct GLFWrect
+{
+    /*! The starting horizontal coordinate, in pixels, of this rect.
+     */
+    int x;
+    /*! The starting vertical coordinate, in pixels, of this rect.
+     */
+    int y;
+    /*! The width, in pixels, of this rect.
+     */
+    int width;
+    /*! The height, in pixels, of this rect.
+     */
+    int height;
+} GLFWrect;
+
 /*! @brief Gamepad input state
  *
  *  This describes the input state of a gamepad.
@@ -5584,6 +5611,7 @@ GLFWAPI GLFWwindow* glfwGetCurrentContext(void);
  *  @thread_safety This function may be called from any thread.
  *
  *  @sa @ref buffer_swap
+ *  @sa @ref glfwSwapBuffersWithDamage
  *  @sa @ref glfwSwapInterval
  *
  *  @since Added in version 1.0.
@@ -5592,6 +5620,48 @@ GLFWAPI GLFWwindow* glfwGetCurrentContext(void);
  *  @ingroup window
  */
 GLFWAPI void glfwSwapBuffers(GLFWwindow* window);
+
+/*! @brief Swaps the front and back buffers of the specified window with damage
+ *  hints.
+ *
+ *  This function swaps the front and back buffers of the specified window when
+ *  rendering with OpenGL or OpenGL ES.  If the swap interval is greater than
+ *  zero, the GPU driver waits the specified number of screen updates before
+ *  swapping the buffers.
+ *
+ *  On supported platforms, this function can damage only the specified rects
+ *  instead of the entire buffer.  This is only one possible behaviour, it is
+ *  perfectly acceptable to damage the entire buffer so you shouldn’t rely on
+ *  that and keep providing a fully up to date buffer.
+ *
+ *  The specified window must have an OpenGL or OpenGL ES context.  Specifying
+ *  a window without a context will generate a @ref GLFW_NO_WINDOW_CONTEXT
+ *  error.
+ *
+ *  This function does not apply to Vulkan.  If you are rendering with Vulkan,
+ *  see `vkQueuePresentKHR` instead.
+ *
+ *  @param[in] window The window whose buffers to swap.
+ *  @param[in] rects The rects to update.
+ *  @param[in] n_rects How many rects there are.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+ *  GLFW_NO_WINDOW_CONTEXT and @ref GLFW_PLATFORM_ERROR.
+ *
+ *  @remark __EGL:__ The context of the specified window must be current on the
+ *  calling thread.
+ *
+ *  @thread_safety This function may be called from any thread.
+ *
+ *  @sa @ref buffer_swap
+ *  @sa @ref glfwSwapBuffers
+ *  @sa @ref glfwSwapInterval
+ *
+ *  @since Added in version 3.4.
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwSwapBuffersWithDamage(GLFWwindow* window, GLFWrect* rects, int n_rects);
 
 /*! @brief Sets the swap interval for the current context.
  *

--- a/src/context.c
+++ b/src/context.c
@@ -694,6 +694,26 @@ GLFWAPI void glfwSwapInterval(int interval)
     window->context.swapInterval(interval);
 }
 
+GLFWAPI int glfwGetBufferAge(GLFWwindow* handle)
+{
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    assert(window != NULL);
+
+    _GLFW_REQUIRE_INIT_OR_RETURN(0);
+
+    if (window->context.client == GLFW_NO_API)
+    {
+        _glfwInputError(GLFW_NO_WINDOW_CONTEXT,
+                        "Cannot get buffer age of a window that has no OpenGL or OpenGL ES context");
+        return 0;
+    }
+
+    if (window->context.getBufferAge)
+        return window->context.getBufferAge(window);
+
+    return 0;
+}
+
 GLFWAPI int glfwExtensionSupported(const char* extension)
 {
     _GLFWwindow* window;

--- a/src/context.c
+++ b/src/context.c
@@ -657,6 +657,26 @@ GLFWAPI void glfwSwapBuffers(GLFWwindow* handle)
     window->context.swapBuffers(window);
 }
 
+GLFWAPI void glfwSwapBuffersWithDamage(GLFWwindow* handle, GLFWrect* rects, int n_rects)
+{
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    assert(window != NULL);
+
+    _GLFW_REQUIRE_INIT();
+
+    if (window->context.client == GLFW_NO_API)
+    {
+        _glfwInputError(GLFW_NO_WINDOW_CONTEXT,
+                        "Cannot swap buffers of a window that has no OpenGL or OpenGL ES context");
+        return;
+    }
+
+    if (window->context.swapBuffersWithDamage)
+        window->context.swapBuffersWithDamage(window, rects, n_rects);
+    else
+        window->context.swapBuffers(window);
+}
+
 GLFWAPI void glfwSwapInterval(int interval)
 {
     _GLFWwindow* window;

--- a/src/egl_context.h
+++ b/src/egl_context.h
@@ -132,6 +132,7 @@ typedef EGLBoolean (EGLAPIENTRY * PFN_eglSwapBuffers)(EGLDisplay,EGLSurface);
 typedef EGLBoolean (EGLAPIENTRY * PFN_eglSwapInterval)(EGLDisplay,EGLint);
 typedef const char* (EGLAPIENTRY * PFN_eglQueryString)(EGLDisplay,EGLint);
 typedef GLFWglproc (EGLAPIENTRY * PFN_eglGetProcAddress)(const char*);
+typedef EGLBoolean (EGLAPIENTRY * PFN_eglSwapBuffersWithDamageKHR)(EGLDisplay,EGLSurface,EGLint*,EGLint);
 #define eglGetConfigAttrib _glfw.egl.GetConfigAttrib
 #define eglGetConfigs _glfw.egl.GetConfigs
 #define eglGetDisplay _glfw.egl.GetDisplay
@@ -148,6 +149,7 @@ typedef GLFWglproc (EGLAPIENTRY * PFN_eglGetProcAddress)(const char*);
 #define eglSwapInterval _glfw.egl.SwapInterval
 #define eglQueryString _glfw.egl.QueryString
 #define eglGetProcAddress _glfw.egl.GetProcAddress
+#define eglSwapBuffersWithDamageKHR _glfw.egl.SwapBuffersWithDamageKHR
 
 #define _GLFW_EGL_CONTEXT_STATE            _GLFWcontextEGL egl
 #define _GLFW_EGL_LIBRARY_CONTEXT_STATE    _GLFWlibraryEGL egl
@@ -178,6 +180,7 @@ typedef struct _GLFWlibraryEGL
     GLFWbool        KHR_gl_colorspace;
     GLFWbool        KHR_get_all_proc_addresses;
     GLFWbool        KHR_context_flush_control;
+    GLFWbool        KHR_swap_buffers_with_damage;
 
     void*           handle;
 
@@ -197,6 +200,7 @@ typedef struct _GLFWlibraryEGL
     PFN_eglSwapInterval         SwapInterval;
     PFN_eglQueryString          QueryString;
     PFN_eglGetProcAddress       GetProcAddress;
+    PFN_eglSwapBuffersWithDamageKHR SwapBuffersWithDamageKHR;
 
 } _GLFWlibraryEGL;
 

--- a/src/egl_context.h
+++ b/src/egl_context.h
@@ -107,6 +107,8 @@ typedef struct wl_egl_window* EGLNativeWindowType;
 #define EGL_CONTEXT_RELEASE_BEHAVIOR_NONE_KHR 0
 #define EGL_CONTEXT_RELEASE_BEHAVIOR_FLUSH_KHR 0x2098
 
+#define EGL_BUFFER_AGE_EXT 0x313D
+
 typedef int EGLint;
 typedef unsigned int EGLBoolean;
 typedef unsigned int EGLenum;
@@ -131,6 +133,7 @@ typedef EGLBoolean (EGLAPIENTRY * PFN_eglMakeCurrent)(EGLDisplay,EGLSurface,EGLS
 typedef EGLBoolean (EGLAPIENTRY * PFN_eglSwapBuffers)(EGLDisplay,EGLSurface);
 typedef EGLBoolean (EGLAPIENTRY * PFN_eglSwapInterval)(EGLDisplay,EGLint);
 typedef const char* (EGLAPIENTRY * PFN_eglQueryString)(EGLDisplay,EGLint);
+typedef EGLBoolean (EGLAPIENTRY * PFN_eglQuerySurface)(EGLDisplay,EGLSurface,EGLint,EGLint*);
 typedef GLFWglproc (EGLAPIENTRY * PFN_eglGetProcAddress)(const char*);
 typedef EGLBoolean (EGLAPIENTRY * PFN_eglSwapBuffersWithDamageKHR)(EGLDisplay,EGLSurface,EGLint*,EGLint);
 #define eglGetConfigAttrib _glfw.egl.GetConfigAttrib
@@ -148,6 +151,7 @@ typedef EGLBoolean (EGLAPIENTRY * PFN_eglSwapBuffersWithDamageKHR)(EGLDisplay,EG
 #define eglSwapBuffers _glfw.egl.SwapBuffers
 #define eglSwapInterval _glfw.egl.SwapInterval
 #define eglQueryString _glfw.egl.QueryString
+#define eglQuerySurface _glfw.egl.QuerySurface
 #define eglGetProcAddress _glfw.egl.GetProcAddress
 #define eglSwapBuffersWithDamageKHR _glfw.egl.SwapBuffersWithDamageKHR
 
@@ -199,6 +203,7 @@ typedef struct _GLFWlibraryEGL
     PFN_eglSwapBuffers          SwapBuffers;
     PFN_eglSwapInterval         SwapInterval;
     PFN_eglQueryString          QueryString;
+    PFN_eglQuerySurface         QuerySurface;
     PFN_eglGetProcAddress       GetProcAddress;
     PFN_eglSwapBuffersWithDamageKHR SwapBuffersWithDamageKHR;
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -78,6 +78,7 @@ typedef struct _GLFWmutex       _GLFWmutex;
 
 typedef void (* _GLFWmakecontextcurrentfun)(_GLFWwindow*);
 typedef void (* _GLFWswapbuffersfun)(_GLFWwindow*);
+typedef void (* _GLFWswapbufferswithdamagefun)(_GLFWwindow*,GLFWrect*,int);
 typedef void (* _GLFWswapintervalfun)(int);
 typedef int (* _GLFWextensionsupportedfun)(const char*);
 typedef GLFWglproc (* _GLFWgetprocaddressfun)(const char*);
@@ -350,6 +351,7 @@ struct _GLFWcontext
 
     _GLFWmakecontextcurrentfun  makeCurrent;
     _GLFWswapbuffersfun         swapBuffers;
+    _GLFWswapbufferswithdamagefun swapBuffersWithDamage;
     _GLFWswapintervalfun        swapInterval;
     _GLFWextensionsupportedfun  extensionSupported;
     _GLFWgetprocaddressfun      getProcAddress;

--- a/src/internal.h
+++ b/src/internal.h
@@ -80,6 +80,7 @@ typedef void (* _GLFWmakecontextcurrentfun)(_GLFWwindow*);
 typedef void (* _GLFWswapbuffersfun)(_GLFWwindow*);
 typedef void (* _GLFWswapbufferswithdamagefun)(_GLFWwindow*,GLFWrect*,int);
 typedef void (* _GLFWswapintervalfun)(int);
+typedef int (* _GLFWgetbufferagefun)(_GLFWwindow*);
 typedef int (* _GLFWextensionsupportedfun)(const char*);
 typedef GLFWglproc (* _GLFWgetprocaddressfun)(const char*);
 typedef void (* _GLFWdestroycontextfun)(_GLFWwindow*);
@@ -353,6 +354,7 @@ struct _GLFWcontext
     _GLFWswapbuffersfun         swapBuffers;
     _GLFWswapbufferswithdamagefun swapBuffersWithDamage;
     _GLFWswapintervalfun        swapInterval;
+    _GLFWgetbufferagefun        getBufferAge;
     _GLFWextensionsupportedfun  extensionSupported;
     _GLFWgetprocaddressfun      getProcAddress;
     _GLFWdestroycontextfun      destroy;

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -783,7 +783,7 @@ static void registryHandleGlobal(void* data,
 {
     if (strcmp(interface, "wl_compositor") == 0)
     {
-        _glfw.wl.compositorVersion = min(3, version);
+        _glfw.wl.compositorVersion = min(4, version);
         _glfw.wl.compositor =
             wl_registry_bind(registry, name, &wl_compositor_interface,
                              _glfw.wl.compositorVersion);

--- a/tests/msaa.c
+++ b/tests/msaa.c
@@ -102,6 +102,19 @@ int main(int argc, char** argv)
     GLuint vertex_buffer, vertex_shader, fragment_shader, program;
     GLint mvp_location, vpos_location;
 
+    // Minimum static damage for both squares.
+    GLFWrect rects[8] =
+       {{ 25,  25, 350,  90},
+        { 25, 285, 350,  90},
+        { 25, 115,  90, 170},
+        {285, 115,  90, 170},
+
+        {425,  25, 350,  90},
+        {425, 285, 350,  90},
+        {425, 115,  90, 170},
+        {685, 115,  90, 170},
+       };
+
     while ((ch = getopt(argc, argv, "hs:")) != -1)
     {
         switch (ch)
@@ -178,11 +191,13 @@ int main(int argc, char** argv)
     while (!glfwWindowShouldClose(window))
     {
         float ratio;
+        int buffer_age;
         int width, height;
         mat4x4 m, p, mvp;
         const double angle = glfwGetTime() * M_PI / 180.0;
 
         glfwGetFramebufferSize(window, &width, &height);
+        buffer_age = glfwGetBufferAge(window);
         ratio = width / (float) height;
 
         glViewport(0, 0, width, height);
@@ -208,7 +223,12 @@ int main(int argc, char** argv)
         glEnable(GL_MULTISAMPLE);
         glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
 
-        glfwSwapBuffers(window);
+        // If buffer_age is 0, we can’t assume anything about the previous buffer
+        // so swap the entire buffer.
+        if (buffer_age > 0)
+            glfwSwapBuffersWithDamage(window, rects, 8);
+        else
+            glfwSwapBuffers(window);
         glfwPollEvents();
     }
 


### PR DESCRIPTION
This adds two new functions to the public API, `glfwGetBufferAge()` and `glfwSwapBuffersWithDamage()`, mirroring the EGL extensions EGL_EXT_buffer_age and EGL_KHR_swap_buffers_with_damage, as well as a new `GLFWrect` struct used by the latter.

These two functions can help efficiency tremendously, especially due to a lower memory bandwidth usage, especially on embedded GPUs:
- `glfwGetBufferAge()` lets the application know when the current buffer was last written to, so that it can avoid a clear and redraw of areas which haven’t changed.
- `glfwSwapBuffersWithDamage()` lets the compositor know which areas it should redraw, so that it can avoid compositing areas which haven’t changed, if it itself tracks the buffer age of its buffers.

Here is a video of [PyTouhou](https://pytouhou.linkmauve.fr) [patched](https://linkmauve.fr/files/pytouhou-damage-tracking.patch) to use this new API: [touhou-damage](https://linkmauve.fr/files/touhou-damage.webm)

I also modified `tests/msaa.c` to use damage to swap buffers, so that you can test this feature.