### PR TITLE
Use the correct type in a for loop

### DIFF
--- a/src/cocoa_joystick.m
+++ b/src/cocoa_joystick.m
@@ -331,7 +331,7 @@ void _glfwInitJoysticksNS(void)
         return;
     }
 
-    for (int i = 0;  i < sizeof(usages) / sizeof(long);  i++)
+    for (size_t i = 0;  i < sizeof(usages) / sizeof(long);  i++)
     {
         const long page = kHIDPage_GenericDesktop;
 


### PR DESCRIPTION
The `sizeof()` operator has the type `size_t`, so the `for` loop iterating over it should use the same type.

Closes #1614.