### PR TITLE
Fix documentation install when Doxygen is not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,7 +351,7 @@ if (GLFW_INSTALL)
     install(FILES "${GLFW_BINARY_DIR}/src/glfw3.pc"
             DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
-    if (GLFW_BUILD_DOCS)
+    if (DOXYGEN_FOUND AND GLFW_BUILD_DOCS)
         install(DIRECTORY "${GLFW_BINARY_DIR}/docs/html"
                 DESTINATION "${CMAKE_INSTALL_DOCDIR}")
     endif()


### PR DESCRIPTION
If Doxygen is not installed then the install target will fail as the documentation was not built. This simply updates the check to only include the docs directory if Doxygen was found.