### PR TITLE
check available Wayland protocols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,7 +233,7 @@ if (_GLFW_WAYLAND)
 
     find_package(Wayland REQUIRED Client Cursor Egl)
     find_package(WaylandScanner REQUIRED)
-    find_package(WaylandProtocols 1.15 REQUIRED)
+    find_package(WaylandProtocols 1.12 REQUIRED)
 
     list(APPEND glfw_PKG_DEPS "wayland-client")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,30 +45,37 @@ if (_GLFW_X11 OR _GLFW_WAYLAND)
 endif()
 
 if (_GLFW_WAYLAND)
-    ecm_add_wayland_client_protocol(GLFW_WAYLAND_PROTOCOL_SOURCES
-        PROTOCOL
+    set(PROTO_DEF
         "${WAYLAND_PROTOCOLS_PKGDATADIR}/stable/xdg-shell/xdg-shell.xml"
-        BASENAME xdg-shell)
-    ecm_add_wayland_client_protocol(GLFW_WAYLAND_PROTOCOL_SOURCES
-        PROTOCOL
         "${WAYLAND_PROTOCOLS_PKGDATADIR}/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml"
-        BASENAME xdg-decoration)
-    ecm_add_wayland_client_protocol(GLFW_WAYLAND_PROTOCOL_SOURCES
-        PROTOCOL
         "${WAYLAND_PROTOCOLS_PKGDATADIR}/stable/viewporter/viewporter.xml"
-        BASENAME viewporter)
-    ecm_add_wayland_client_protocol(GLFW_WAYLAND_PROTOCOL_SOURCES
-        PROTOCOL
         "${WAYLAND_PROTOCOLS_PKGDATADIR}/unstable/relative-pointer/relative-pointer-unstable-v1.xml"
-        BASENAME relative-pointer-unstable-v1)
-    ecm_add_wayland_client_protocol(GLFW_WAYLAND_PROTOCOL_SOURCES
-        PROTOCOL
         "${WAYLAND_PROTOCOLS_PKGDATADIR}/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml"
-        BASENAME pointer-constraints-unstable-v1)
-    ecm_add_wayland_client_protocol(GLFW_WAYLAND_PROTOCOL_SOURCES
-        PROTOCOL
         "${WAYLAND_PROTOCOLS_PKGDATADIR}/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml"
-        BASENAME idle-inhibit-unstable-v1)
+    )
+    set(PROTO_NAME
+        xdg-shell
+        xdg-decoration
+        viewporter
+        relative-pointer-unstable-v1
+        pointer-constraints-unstable-v1
+        idle-inhibit-unstable-v1
+    )
+
+    list(LENGTH PROTO_NAME count)
+    math(EXPR count "${count}-1")
+    foreach(i RANGE ${count})
+      list(GET PROTO_DEF ${i} def)
+      list(GET PROTO_NAME ${i} name)
+      if(EXISTS ${def})
+          ecm_add_wayland_client_protocol(GLFW_WAYLAND_PROTOCOL_SOURCES
+              PROTOCOL ${def} BASENAME ${name})
+          string(REPLACE "-" "_" nameR ${name})
+          add_definitions(-DHAS_PROTO_${nameR})
+      else()
+          message(WARNING "protocol definition ${def} not available")
+      endif()
+    endforeach()
     target_sources(glfw PRIVATE ${GLFW_WAYLAND_PROTOCOL_SOURCES})
 endif()
 

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -833,6 +833,7 @@ static void registryHandleGlobal(void* data,
             wl_registry_bind(registry, name, &xdg_wm_base_interface, 1);
         xdg_wm_base_add_listener(_glfw.wl.wmBase, &wmBaseListener, NULL);
     }
+#ifdef HAS_PROTO_xdg_decoration
     else if (strcmp(interface, "zxdg_decoration_manager_v1") == 0)
     {
         _glfw.wl.decorationManager =
@@ -840,6 +841,7 @@ static void registryHandleGlobal(void* data,
                              &zxdg_decoration_manager_v1_interface,
                              1);
     }
+#endif
     else if (strcmp(interface, "wp_viewporter") == 0)
     {
         _glfw.wl.viewporter =
@@ -1259,8 +1261,10 @@ void _glfwPlatformTerminate(void)
         wl_shm_destroy(_glfw.wl.shm);
     if (_glfw.wl.viewporter)
         wp_viewporter_destroy(_glfw.wl.viewporter);
+#ifdef HAS_PROTO_xdg_decoration
     if (_glfw.wl.decorationManager)
         zxdg_decoration_manager_v1_destroy(_glfw.wl.decorationManager);
+#endif
     if (_glfw.wl.wmBase)
         xdg_wm_base_destroy(_glfw.wl.wmBase);
     if (_glfw.wl.dataSource)

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -57,7 +57,9 @@ typedef VkBool32 (APIENTRY *PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR
 #include "osmesa_context.h"
 
 #include "wayland-xdg-shell-client-protocol.h"
+#ifdef HAS_PROTO_xdg_decoration
 #include "wayland-xdg-decoration-client-protocol.h"
+#endif
 #include "wayland-viewporter-client-protocol.h"
 #include "wayland-relative-pointer-unstable-v1-client-protocol.h"
 #include "wayland-pointer-constraints-unstable-v1-client-protocol.h"
@@ -185,7 +187,9 @@ typedef struct _GLFWwindowWayland
     struct {
         struct xdg_surface*     surface;
         struct xdg_toplevel*    toplevel;
+#ifdef HAS_PROTO_xdg_decoration
         struct zxdg_toplevel_decoration_v1* decoration;
+#endif
     } xdg;
 
     _GLFWcursor*                currentCursor;
@@ -235,7 +239,9 @@ typedef struct _GLFWlibraryWayland
     struct wl_data_offer*       dataOffer;
     struct wl_data_source*      dataSource;
     struct xdg_wm_base*         wmBase;
+#ifdef HAS_PROTO_xdg_decoration
     struct zxdg_decoration_manager_v1*      decorationManager;
+#endif
     struct wp_viewporter*       viewporter;
     struct zwp_relative_pointer_manager_v1* relativePointerManager;
     struct zwp_pointer_constraints_v1*      pointerConstraints;

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -265,6 +265,7 @@ static void destroyDecorations(_GLFWwindow* window)
     destroyDecoration(&window->wl.decorations.bottom);
 }
 
+#ifdef HAS_PROTO_xdg_decoration
 static void xdgDecorationHandleConfigure(void* data,
                                          struct zxdg_toplevel_decoration_v1* decoration,
                                          uint32_t mode)
@@ -280,6 +281,7 @@ static void xdgDecorationHandleConfigure(void* data,
 static const struct zxdg_toplevel_decoration_v1_listener xdgDecorationListener = {
     xdgDecorationHandleConfigure,
 };
+#endif
 
 // Makes the surface considered as XRGB instead of ARGB.
 static void setOpaqueRegion(_GLFWwindow* window)
@@ -560,6 +562,7 @@ static const struct xdg_surface_listener xdgSurfaceListener = {
 
 static void setXdgDecorations(_GLFWwindow* window)
 {
+#ifdef HAS_PROTO_xdg_decoration
     if (_glfw.wl.decorationManager)
     {
         window->wl.xdg.decoration =
@@ -573,6 +576,7 @@ static void setXdgDecorations(_GLFWwindow* window)
             ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE);
     }
     else
+#endif
     {
         window->wl.decorations.serverSide = GLFW_FALSE;
         createDecorations(window);
@@ -849,8 +853,10 @@ void _glfwPlatformDestroyWindow(_GLFWwindow* window)
         window->context.destroy(window);
 
     destroyDecorations(window);
+#ifdef HAS_PROTO_xdg_decoration
     if (window->wl.xdg.decoration)
         zxdg_toplevel_decoration_v1_destroy(window->wl.xdg.decoration);
+#endif
 
     if (window->wl.decorations.buffer)
         wl_buffer_destroy(window->wl.decorations.buffer);
@@ -1055,8 +1061,10 @@ void _glfwPlatformSetWindowMonitor(_GLFWwindow* window,
         if (window->wl.xdg.toplevel)
             xdg_toplevel_unset_fullscreen(window->wl.xdg.toplevel);
         setIdleInhibitor(window, GLFW_FALSE);
+#ifdef HAS_PROTO_xdg_decoration
         if (!_glfw.wl.decorationManager)
             createDecorations(window);
+#endif
     }
     _glfwInputWindowMonitor(window, monitor);
 }


### PR DESCRIPTION
Check the available protocol definitions when generating bindings and set `HAS_PROTO_<name>` for a compile-time check.