### PR TITLE
removed unnecessary initialization of values with zero

### DIFF
--- a/src/monitor.c
+++ b/src/monitor.c
@@ -326,11 +326,6 @@ GLFWAPI void glfwGetMonitorPos(GLFWmonitor* handle, int* xpos, int* ypos)
     _GLFWmonitor* monitor = (_GLFWmonitor*) handle;
     assert(monitor != NULL);
 
-    if (xpos)
-        *xpos = 0;
-    if (ypos)
-        *ypos = 0;
-
     _GLFW_REQUIRE_INIT();
 
     _glfwPlatformGetMonitorPos(monitor, xpos, ypos);


### PR DESCRIPTION
xpos and ypos are assigned with a value inside _glfwPlatformGetMonitorPos