### PR TITLE
Gamepad rumble effects

### DIFF
--- a/deps/mingw/xinput.h
+++ b/deps/mingw/xinput.h
@@ -182,8 +182,8 @@ typedef struct _XINPUT_STATE {
  */
 
 typedef struct _XINPUT_VIBRATION {
-    WORD wLeftMotorIntensity;
-    WORD wRightMotorIntensity;
+    WORD wLeftMotorSpeed;
+    WORD wRightMotorSpeed;
 } XINPUT_VIBRATION, *PXINPUT_VIBRATION;
 
 /*

--- a/deps/mingw/xinput.h
+++ b/deps/mingw/xinput.h
@@ -182,8 +182,8 @@ typedef struct _XINPUT_STATE {
  */
 
 typedef struct _XINPUT_VIBRATION {
-    WORD wLeftMotorSpeed;
-    WORD wRightMotorSpeed;
+    WORD wLeftMotorIntensity;
+    WORD wRightMotorIntensity;
 } XINPUT_VIBRATION, *PXINPUT_VIBRATION;
 
 /*

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -5348,16 +5348,18 @@ GLFWAPI const char* glfwGetGamepadName(int jid);
  */
 GLFWAPI int glfwGetGamepadState(int jid, GLFWgamepadstate* state);
 
-/*! @brief Sets the specified gamepad's vibration effect intensity.
+/*! @brief Sets the intensity of an Xbox-like gamepad's rumble effect.
  *  
- *  This function sends vibration data to the specified Xbox-like gamepad. 
+ *  This function sends vibration data to gamepads that implement haptic
+ *  feedback effects using two vibration motors: a low-frequency motor, and
+ *  a high-frequency motor.
  *  
  *  Vibration intensity is a value between 0.0 and 1.0 inclusive, where 0.0 is no 
  *  vibration, and 1.0 is maximum vibration. It is set separately for the 
  *  gamepad's low frequency and high frequency rumble motors.
  * 
  *  If the specified gamepad is not present or does not support the rumble 
- *  effect, this function will return `GLFW_FALSE` but will not generate an 
+ *  effect, this function will return `GLFW_FALSE` but will not generate an
  *  error. 
  *
  *  @param[in] jid The [joystick](@ref joysticks) to vibrate.
@@ -5377,7 +5379,7 @@ GLFWAPI int glfwGetGamepadState(int jid, GLFWgamepadstate* state);
  *
  *  @ingroup input
  */
-GLFWAPI int glfwSetGamepadRumble(int jid, float slowMotorSpeed, float fastMotorSpeed);
+GLFWAPI int glfwSetJoystickRumble(int jid, float slowMotorSpeed, float fastMotorSpeed);
 
 /*! @brief Sets the clipboard to the specified string.
  *

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -5363,8 +5363,8 @@ GLFWAPI int glfwGetGamepadState(int jid, GLFWgamepadstate* state);
  *  error. 
  *
  *  @param[in] jid The [joystick](@ref joysticks) to vibrate.
- *  @param[in] slowMotorSpeed The low frequency rumble intensity.
- *  @param[in] fastMotorSpeed The high frequency rumble intensity.
+ *  @param[in] slowMotorIntensity The low frequency rumble intensity.
+ *  @param[in] fastMotorIntensity The high frequency rumble intensity.
  *  @return `GLFW_TRUE` if successful, or `GLFW_FALSE` if no joystick is
  *  connected, or the joystick does not support the rumble effect.
  * 
@@ -5373,13 +5373,16 @@ GLFWAPI int glfwGetGamepadState(int jid, GLFWgamepadstate* state);
  *
  *  @thread_safety This function must only be called from the main thread.
  *
+ *  @note @win32 This function is only implemented for XInput devices.
+ *  @note @macos This function is not implemented.
+ *
  *  @sa @ref gamepad
  *  @sa @ref glfwUpdateGamepadMappings
  *  @sa @ref glfwJoystickIsGamepad
  *
  *  @ingroup input
  */
-GLFWAPI int glfwSetJoystickRumble(int jid, float slowMotorSpeed, float fastMotorSpeed);
+GLFWAPI int glfwSetJoystickRumble(int jid, float slowMotorIntensity, float fastMotorIntensity);
 
 /*! @brief Sets the clipboard to the specified string.
  *

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -5348,25 +5348,24 @@ GLFWAPI const char* glfwGetGamepadName(int jid);
  */
 GLFWAPI int glfwGetGamepadState(int jid, GLFWgamepadstate* state);
 
-/*! @brief Sets the intensity of an Xbox-like gamepad's rumble effect.
+/*! @brief Sets the intensity of a joystick's rumble effect.
  *  
- *  This function sends vibration data to gamepads that implement haptic
- *  feedback effects using two vibration motors: a low-frequency motor, and
- *  a high-frequency motor.
+ *  This function sends vibration data to joysticks that implement haptic feedback
+ *  effects using two vibration motors: a low-frequency motor, and a
+ *  high-frequency motor.
  *  
  *  Vibration intensity is a value between 0.0 and 1.0 inclusive, where 0.0 is no 
- *  vibration, and 1.0 is maximum vibration. It is set separately for the 
- *  gamepad's low frequency and high frequency rumble motors.
+ *  vibration, and 1.0 is maximum vibration. It is set separately for the
+ *  joystick's low frequency and high frequency rumble motors.
  * 
- *  If the specified gamepad is not present or does not support the rumble 
- *  effect, this function will return `GLFW_FALSE` but will not generate an
- *  error. 
+ *  If the specified joystick is not present or does not support the rumble effect,
+ *  this function will return `GLFW_FALSE` but will not generate an error.
  *
  *  @param[in] jid The [joystick](@ref joysticks) to vibrate.
  *  @param[in] slowMotorIntensity The low frequency vibration intensity.
  *  @param[in] fastMotorIntensity The high frequency vibration intensity.
- *  @return `GLFW_TRUE` if successful, or `GLFW_FALSE` if no joystick is
- *  connected, or the joystick does not support the rumble effect.
+ *  @return `GLFW_TRUE` if successful, or `GLFW_FALSE` if no joystick is connected,
+ *  or the joystick does not support the rumble effect.
  * 
  *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
  *  GLFW_INVALID_ENUM.
@@ -5375,10 +5374,6 @@ GLFWAPI int glfwGetGamepadState(int jid, GLFWgamepadstate* state);
  *
  *  @note @win32 This function is only implemented for XInput devices.
  *  @note @macos This function is not implemented.
- *
- *  @sa @ref gamepad
- *  @sa @ref glfwUpdateGamepadMappings
- *  @sa @ref glfwJoystickIsGamepad
  *
  *  @ingroup input
  */

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -5363,8 +5363,8 @@ GLFWAPI int glfwGetGamepadState(int jid, GLFWgamepadstate* state);
  *  error. 
  *
  *  @param[in] jid The [joystick](@ref joysticks) to vibrate.
- *  @param[in] slowMotorIntensity The low frequency rumble intensity.
- *  @param[in] fastMotorIntensity The high frequency rumble intensity.
+ *  @param[in] slowMotorIntensity The low frequency vibration intensity.
+ *  @param[in] fastMotorIntensity The high frequency vibration intensity.
  *  @return `GLFW_TRUE` if successful, or `GLFW_FALSE` if no joystick is
  *  connected, or the joystick does not support the rumble effect.
  * 

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -5348,6 +5348,37 @@ GLFWAPI const char* glfwGetGamepadName(int jid);
  */
 GLFWAPI int glfwGetGamepadState(int jid, GLFWgamepadstate* state);
 
+/*! @brief Sets the specified gamepad's vibration effect intensity.
+ *  
+ *  This function sends vibration data to the specified Xbox-like gamepad. 
+ *  
+ *  Vibration intensity is a value between 0.0 and 1.0 inclusive, where 0.0 is no 
+ *  vibration, and 1.0 is maximum vibration. It is set separately for the 
+ *  gamepad's low frequency and high frequency rumble motors.
+ * 
+ *  If the specified gamepad is not present or does not support the rumble 
+ *  effect, this function will return `GLFW_FALSE` but will not generate an 
+ *  error. 
+ *
+ *  @param[in] jid The [joystick](@ref joysticks) to vibrate.
+ *  @param[in] slowMotorSpeed The low frequency rumble intensity.
+ *  @param[in] fastMotorSpeed The high frequency rumble intensity.
+ *  @return `GLFW_TRUE` if successful, or `GLFW_FALSE` if no joystick is
+ *  connected, or the joystick does not support the rumble effect.
+ * 
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_INVALID_ENUM.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref gamepad
+ *  @sa @ref glfwUpdateGamepadMappings
+ *  @sa @ref glfwJoystickIsGamepad
+ *
+ *  @ingroup input
+ */
+GLFWAPI int glfwSetGamepadRumble(int jid, float slowMotorSpeed, float fastMotorSpeed);
+
 /*! @brief Sets the clipboard to the specified string.
  *
  *  This function sets the system clipboard to the specified, UTF-8 encoded

--- a/src/cocoa_joystick.m
+++ b/src/cocoa_joystick.m
@@ -485,3 +485,8 @@ void _glfwPlatformUpdateGamepadGUID(char* guid)
     }
 }
 
+int _glfwPlatformSetJoystickRumble(_GLFWjoystick* js, float slowMotorSpeed, float fastMotorSpeed)
+{
+    return GLFW_FALSE;
+}
+

--- a/src/cocoa_joystick.m
+++ b/src/cocoa_joystick.m
@@ -485,7 +485,7 @@ void _glfwPlatformUpdateGamepadGUID(char* guid)
     }
 }
 
-int _glfwPlatformSetJoystickRumble(_GLFWjoystick* js, float slowMotorSpeed, float fastMotorSpeed)
+int _glfwPlatformSetJoystickRumble(_GLFWjoystick* js, float slowMotorIntensity, float fastMotorIntensity)
 {
     return GLFW_FALSE;
 }

--- a/src/input.c
+++ b/src/input.c
@@ -1312,6 +1312,34 @@ GLFWAPI int glfwGetGamepadState(int jid, GLFWgamepadstate* state)
     return GLFW_TRUE;
 }
 
+GLFWAPI int glfwSetGamepadRumble(int jid, float slowMotorSpeed, float fastMotorSpeed)
+{
+    _GLFWjoystick* js;
+
+    assert(jid >= GLFW_JOYSTICK_1);
+    assert(jid <= GLFW_JOYSTICK_LAST);
+
+    _GLFW_REQUIRE_INIT_OR_RETURN(GLFW_FALSE);
+
+    if (jid < 0 || jid > GLFW_JOYSTICK_LAST)
+    {
+        _glfwInputError(GLFW_INVALID_ENUM, "Invalid joystick ID %i", jid);
+        return GLFW_FALSE;
+    }
+
+    js = _glfw.joysticks + jid;
+    if (!js->present)
+        return GLFW_FALSE;
+
+    slowMotorSpeed = slowMotorSpeed < 0.0f ? 0.0f : slowMotorSpeed;
+    slowMotorSpeed = slowMotorSpeed > 1.0f ? 1.0f : slowMotorSpeed;
+
+    fastMotorSpeed = fastMotorSpeed < 0.0f ? 0.0f : fastMotorSpeed;
+    fastMotorSpeed = fastMotorSpeed > 1.0f ? 1.0f : fastMotorSpeed;
+
+    return _glfwPlatformSetGamepadRumble(js, slowMotorSpeed, fastMotorSpeed);
+}
+
 GLFWAPI void glfwSetClipboardString(GLFWwindow* handle, const char* string)
 {
     assert(string != NULL);

--- a/src/input.c
+++ b/src/input.c
@@ -1312,7 +1312,7 @@ GLFWAPI int glfwGetGamepadState(int jid, GLFWgamepadstate* state)
     return GLFW_TRUE;
 }
 
-GLFWAPI int glfwSetJoystickRumble(int jid, float slowMotorSpeed, float fastMotorSpeed)
+GLFWAPI int glfwSetJoystickRumble(int jid, float slowMotorIntensity, float fastMotorIntensity)
 {
     _GLFWjoystick* js;
 
@@ -1331,13 +1331,13 @@ GLFWAPI int glfwSetJoystickRumble(int jid, float slowMotorSpeed, float fastMotor
     if (!js->present)
         return GLFW_FALSE;
 
-    slowMotorSpeed = slowMotorSpeed < 0.0f ? 0.0f : slowMotorSpeed;
-    slowMotorSpeed = slowMotorSpeed > 1.0f ? 1.0f : slowMotorSpeed;
+    slowMotorIntensity = slowMotorIntensity < 0.0f ? 0.0f : slowMotorIntensity;
+    slowMotorIntensity = slowMotorIntensity > 1.0f ? 1.0f : slowMotorIntensity;
 
-    fastMotorSpeed = fastMotorSpeed < 0.0f ? 0.0f : fastMotorSpeed;
-    fastMotorSpeed = fastMotorSpeed > 1.0f ? 1.0f : fastMotorSpeed;
+    fastMotorIntensity = fastMotorIntensity < 0.0f ? 0.0f : fastMotorIntensity;
+    fastMotorIntensity = fastMotorIntensity > 1.0f ? 1.0f : fastMotorIntensity;
 
-    return _glfwPlatformSetJoystickRumble(js, slowMotorSpeed, fastMotorSpeed);
+    return _glfwPlatformSetJoystickRumble(js, slowMotorIntensity, fastMotorIntensity);
 }
 
 GLFWAPI void glfwSetClipboardString(GLFWwindow* handle, const char* string)

--- a/src/input.c
+++ b/src/input.c
@@ -1312,7 +1312,7 @@ GLFWAPI int glfwGetGamepadState(int jid, GLFWgamepadstate* state)
     return GLFW_TRUE;
 }
 
-GLFWAPI int glfwSetGamepadRumble(int jid, float slowMotorSpeed, float fastMotorSpeed)
+GLFWAPI int glfwSetJoystickRumble(int jid, float slowMotorSpeed, float fastMotorSpeed)
 {
     _GLFWjoystick* js;
 
@@ -1337,7 +1337,7 @@ GLFWAPI int glfwSetGamepadRumble(int jid, float slowMotorSpeed, float fastMotorS
     fastMotorSpeed = fastMotorSpeed < 0.0f ? 0.0f : fastMotorSpeed;
     fastMotorSpeed = fastMotorSpeed > 1.0f ? 1.0f : fastMotorSpeed;
 
-    return _glfwPlatformSetGamepadRumble(js, slowMotorSpeed, fastMotorSpeed);
+    return _glfwPlatformSetJoystickRumble(js, slowMotorSpeed, fastMotorSpeed);
 }
 
 GLFWAPI void glfwSetClipboardString(GLFWwindow* handle, const char* string)

--- a/src/internal.h
+++ b/src/internal.h
@@ -628,7 +628,7 @@ const char* _glfwPlatformGetClipboardString(void);
 
 int _glfwPlatformPollJoystick(_GLFWjoystick* js, int mode);
 void _glfwPlatformUpdateGamepadGUID(char* guid);
-int _glfwPlatformSetGamepadRumble(_GLFWjoystick* js, float slowMotorSpeed, float fastMotorSpeed);
+int _glfwPlatformSetJoystickRumble(_GLFWjoystick* js, float slowMotorSpeed, float fastMotorSpeed);
 
 uint64_t _glfwPlatformGetTimerValue(void);
 uint64_t _glfwPlatformGetTimerFrequency(void);

--- a/src/internal.h
+++ b/src/internal.h
@@ -628,6 +628,7 @@ const char* _glfwPlatformGetClipboardString(void);
 
 int _glfwPlatformPollJoystick(_GLFWjoystick* js, int mode);
 void _glfwPlatformUpdateGamepadGUID(char* guid);
+int _glfwPlatformSetGamepadRumble(_GLFWjoystick* js, float slowMotorSpeed, float fastMotorSpeed);
 
 uint64_t _glfwPlatformGetTimerValue(void);
 uint64_t _glfwPlatformGetTimerFrequency(void);

--- a/src/internal.h
+++ b/src/internal.h
@@ -628,7 +628,7 @@ const char* _glfwPlatformGetClipboardString(void);
 
 int _glfwPlatformPollJoystick(_GLFWjoystick* js, int mode);
 void _glfwPlatformUpdateGamepadGUID(char* guid);
-int _glfwPlatformSetJoystickRumble(_GLFWjoystick* js, float slowMotorSpeed, float fastMotorSpeed);
+int _glfwPlatformSetJoystickRumble(_GLFWjoystick* js, float slowMotorIntensity, float fastMotorIntensity);
 
 uint64_t _glfwPlatformGetTimerValue(void);
 uint64_t _glfwPlatformGetTimerFrequency(void);

--- a/src/linux_joystick.c
+++ b/src/linux_joystick.c
@@ -479,7 +479,7 @@ void _glfwPlatformUpdateGamepadGUID(char* guid)
 }
 
 
-int _glfwPlatformSetGamepadRumble(_GLFWjoystick* js, float slowMotorSpeed, float fastMotorSpeed)
+int _glfwPlatformSetJoystickRumble(_GLFWjoystick* js, float slowMotorSpeed, float fastMotorSpeed)
 {
     _GLFWjoystickLinux *linjs = &js->linjs;
 

--- a/src/linux_joystick.c
+++ b/src/linux_joystick.c
@@ -122,6 +122,49 @@ static void pollAbsState(_GLFWjoystick* js)
 
 #define isBitSet(bit, arr) (arr[(bit) / 8] & (1 << ((bit) % 8)))
 
+static void checkForceFeedback(_GLFWjoystickLinux *linjs)
+{
+    linjs->rumble = NULL;
+    struct ff_effect* effect = NULL;
+
+    char ffBits[(FF_CNT + 7) / 8] = {0};
+    if (ioctl(linjs->fd, EVIOCGBIT(EV_FF, sizeof(ffBits)), ffBits) < 0)
+    {
+        return;
+    }
+
+    if (isBitSet(FF_RUMBLE, ffBits))
+    {
+        effect = malloc(sizeof(struct ff_effect));
+        *effect = (struct ff_effect)
+        {
+            .type      = FF_RUMBLE,
+            .id        = -1,
+            .direction = 0,
+            .trigger   = {
+                .button   = 0,
+                .interval = 0
+            },
+            .replay = {
+                .length = 2000,  // xinput rumble lasts ~2 seconds
+                .delay  = 0
+            },
+            .u.rumble = {
+                .strong_magnitude = 0,
+                .weak_magnitude   = 0
+            }
+        };
+
+        if (ioctl(linjs->fd, EVIOCSFF, effect) < 0)
+        {
+            free(effect);
+            return;
+        } else {
+            linjs->rumble = effect;
+        }
+    }
+}
+
 // Attempt to open the specified joystick device
 //
 static GLFWbool openJoystickDevice(const char* path)
@@ -135,7 +178,7 @@ static GLFWbool openJoystickDevice(const char* path)
     }
 
     _GLFWjoystickLinux linjs = {0};
-    linjs.fd = open(path, O_RDONLY | O_NONBLOCK);
+    linjs.fd = open(path, O_RDWR | O_NONBLOCK);
     if (linjs.fd == -1)
         return GLFW_FALSE;
 
@@ -222,6 +265,8 @@ static GLFWbool openJoystickDevice(const char* path)
         }
     }
 
+    checkForceFeedback(&linjs);
+
     _GLFWjoystick* js =
         _glfwAllocJoystick(name, guid, axisCount, buttonCount, hatCount);
     if (!js)
@@ -246,6 +291,8 @@ static GLFWbool openJoystickDevice(const char* path)
 static void closeJoystick(_GLFWjoystick* js)
 {
     close(js->linjs.fd);
+    if (js->linjs.rumble)
+        free(js->linjs.rumble);
     _glfwFreeJoystick(js);
     _glfwInputJoystick(js, GLFW_DISCONNECTED);
 }
@@ -431,3 +478,32 @@ void _glfwPlatformUpdateGamepadGUID(char* guid)
 {
 }
 
+
+int _glfwPlatformSetGamepadRumble(_GLFWjoystick* js, float slowMotorSpeed, float fastMotorSpeed)
+{
+    _GLFWjoystickLinux *linjs = &js->linjs;
+
+    if (!js->linjs.rumble)
+        return GLFW_FALSE;
+
+    js->linjs.rumble->u.rumble = (struct ff_rumble_effect)
+    {
+        .strong_magnitude = 65535 * slowMotorSpeed,
+        .weak_magnitude   = 65535 * fastMotorSpeed
+    };
+
+    struct input_event play =
+    {
+        .type  = EV_FF,
+        .code  = linjs->rumble->id,
+        .value = 1
+    };
+
+    if (ioctl(linjs->fd, EVIOCSFF, linjs->rumble) < 0 ||
+        write(linjs->fd, (const void*) &play, sizeof(play)) < 0)
+    {
+        return GLFW_FALSE;
+    }
+
+    return GLFW_TRUE;
+}

--- a/src/linux_joystick.c
+++ b/src/linux_joystick.c
@@ -122,7 +122,7 @@ static void pollAbsState(_GLFWjoystick* js)
 
 #define isBitSet(bit, arr) (arr[(bit) / 8] & (1 << ((bit) % 8)))
 
-static void checkForceFeedback(_GLFWjoystickLinux *linjs)
+static void initJoystickForceFeedback(_GLFWjoystickLinux *linjs)
 {
     linjs->rumble = NULL;
     struct ff_effect* effect = NULL;
@@ -265,7 +265,7 @@ static GLFWbool openJoystickDevice(const char* path)
         }
     }
 
-    checkForceFeedback(&linjs);
+    initJoystickForceFeedback(&linjs);
 
     _GLFWjoystick* js =
         _glfwAllocJoystick(name, guid, axisCount, buttonCount, hatCount);

--- a/src/linux_joystick.c
+++ b/src/linux_joystick.c
@@ -478,7 +478,7 @@ void _glfwPlatformUpdateGamepadGUID(char* guid)
 }
 
 
-int _glfwPlatformSetJoystickRumble(_GLFWjoystick* js, float slowMotorSpeed, float fastMotorSpeed)
+int _glfwPlatformSetJoystickRumble(_GLFWjoystick* js, float slowMotorIntensity, float fastMotorIntensity)
 {
     _GLFWjoystickLinux *linjs = &js->linjs;
 
@@ -487,8 +487,8 @@ int _glfwPlatformSetJoystickRumble(_GLFWjoystick* js, float slowMotorSpeed, floa
 
     js->linjs.rumble->u.rumble = (struct ff_rumble_effect)
     {
-        .strong_magnitude = 65535 * slowMotorSpeed,
-        .weak_magnitude   = 65535 * fastMotorSpeed
+        .strong_magnitude = 65535 * slowMotorIntensity,
+        .weak_magnitude   = 65535 * fastMotorIntensity
     };
 
     struct input_event play =

--- a/src/linux_joystick.c
+++ b/src/linux_joystick.c
@@ -158,7 +158,6 @@ static void initJoystickForceFeedback(_GLFWjoystickLinux *linjs)
         if (ioctl(linjs->fd, EVIOCSFF, effect) < 0)
         {
             free(effect);
-            return;
         } else {
             linjs->rumble = effect;
         }

--- a/src/linux_joystick.h
+++ b/src/linux_joystick.h
@@ -43,6 +43,7 @@ typedef struct _GLFWjoystickLinux
     int                     absMap[ABS_CNT];
     struct input_absinfo    absInfo[ABS_CNT];
     int                     hats[4][2];
+    struct ff_effect        *rumble;
 } _GLFWjoystickLinux;
 
 // Linux-specific joystick API data

--- a/src/null_joystick.c
+++ b/src/null_joystick.c
@@ -42,3 +42,8 @@ void _glfwPlatformUpdateGamepadGUID(char* guid)
 {
 }
 
+int _glfwPlatformSetJoystickRumble(_GLFWjoystick* js, float slowMotorSpeed, float fastMotorSpeed)
+{
+    return GLFW_FALSE;
+}
+

--- a/src/null_joystick.c
+++ b/src/null_joystick.c
@@ -42,7 +42,7 @@ void _glfwPlatformUpdateGamepadGUID(char* guid)
 {
 }
 
-int _glfwPlatformSetJoystickRumble(_GLFWjoystick* js, float slowMotorSpeed, float fastMotorSpeed)
+int _glfwPlatformSetJoystickRumble(_GLFWjoystick* js, float slowMotorIntensity, float fastMotorIntensity)
 {
     return GLFW_FALSE;
 }

--- a/src/win32_init.c
+++ b/src/win32_init.c
@@ -128,6 +128,8 @@ static GLFWbool loadLibraries(void)
                     GetProcAddress(_glfw.win32.xinput.instance, "XInputGetCapabilities");
                 _glfw.win32.xinput.GetState = (PFN_XInputGetState)
                     GetProcAddress(_glfw.win32.xinput.instance, "XInputGetState");
+                _glfw.win32.xinput.SetState = (PFN_XInputSetState)
+                    GetProcAddress(_glfw.win32.xinput.instance, "XInputSetState");
 
                 break;
             }

--- a/src/win32_joystick.c
+++ b/src/win32_joystick.c
@@ -761,8 +761,8 @@ int _glfwPlatformSetJoystickRumble(_GLFWjoystick* js, float slowMotorIntensity, 
     XINPUT_VIBRATION effect;
     ZeroMemory(&effect, sizeof(XINPUT_VIBRATION));
 
-    effect.wLeftMotorIntensity  = (WORD)(65535.0f * slowMotorIntensity);
-    effect.wRightMotorIntensity = (WORD)(65535.0f * fastMotorIntensity);
+    effect.wLeftMotorSpeed  = (WORD)(65535.0f * slowMotorIntensity);
+    effect.wRightMotorSpeed = (WORD)(65535.0f * fastMotorIntensity);
 
     return (int) (XInputSetState(js->win32.index, &effect) == ERROR_SUCCESS);
 }

--- a/src/win32_joystick.c
+++ b/src/win32_joystick.c
@@ -753,3 +753,16 @@ void _glfwPlatformUpdateGamepadGUID(char* guid)
     }
 }
 
+int _glfwPlatformSetGamepadRumble(_GLFWjoystick* js, float slowMotorSpeed, float fastMotorSpeed)
+{
+    if (js->win32.device)
+        return GLFW_FALSE;
+    
+    XINPUT_VIBRATION effect;
+    ZeroMemory(&effect, sizeof(XINPUT_VIBRATION));
+
+    effect.wLeftMotorSpeed  = (WORD)(65535.0f * slowMotorSpeed);
+    effect.wRightMotorSpeed = (WORD)(65535.0f * fastMotorSpeed);
+
+    return (int) (XInputSetState(js->win32.index, &effect) == ERROR_SUCCESS);
+}

--- a/src/win32_joystick.c
+++ b/src/win32_joystick.c
@@ -753,7 +753,7 @@ void _glfwPlatformUpdateGamepadGUID(char* guid)
     }
 }
 
-int _glfwPlatformSetJoystickRumble(_GLFWjoystick* js, float slowMotorSpeed, float fastMotorSpeed)
+int _glfwPlatformSetJoystickRumble(_GLFWjoystick* js, float slowMotorIntensity, float fastMotorIntensity)
 {
     if (js->win32.device)
         return GLFW_FALSE;
@@ -761,8 +761,8 @@ int _glfwPlatformSetJoystickRumble(_GLFWjoystick* js, float slowMotorSpeed, floa
     XINPUT_VIBRATION effect;
     ZeroMemory(&effect, sizeof(XINPUT_VIBRATION));
 
-    effect.wLeftMotorSpeed  = (WORD)(65535.0f * slowMotorSpeed);
-    effect.wRightMotorSpeed = (WORD)(65535.0f * fastMotorSpeed);
+    effect.wLeftMotorIntensity  = (WORD)(65535.0f * slowMotorIntensity);
+    effect.wRightMotorIntensity = (WORD)(65535.0f * fastMotorIntensity);
 
     return (int) (XInputSetState(js->win32.index, &effect) == ERROR_SUCCESS);
 }

--- a/src/win32_joystick.c
+++ b/src/win32_joystick.c
@@ -753,7 +753,7 @@ void _glfwPlatformUpdateGamepadGUID(char* guid)
     }
 }
 
-int _glfwPlatformSetGamepadRumble(_GLFWjoystick* js, float slowMotorSpeed, float fastMotorSpeed)
+int _glfwPlatformSetJoystickRumble(_GLFWjoystick* js, float slowMotorSpeed, float fastMotorSpeed)
 {
     if (js->win32.device)
         return GLFW_FALSE;

--- a/src/win32_platform.h
+++ b/src/win32_platform.h
@@ -222,8 +222,10 @@ typedef DWORD (WINAPI * PFN_timeGetTime)(void);
 // xinput.dll function pointer typedefs
 typedef DWORD (WINAPI * PFN_XInputGetCapabilities)(DWORD,DWORD,XINPUT_CAPABILITIES*);
 typedef DWORD (WINAPI * PFN_XInputGetState)(DWORD,XINPUT_STATE*);
+typedef DWORD (WINAPI * PFN_XInputSetState)(DWORD,XINPUT_VIBRATION*);
 #define XInputGetCapabilities _glfw.win32.xinput.GetCapabilities
 #define XInputGetState _glfw.win32.xinput.GetState
+#define XInputSetState _glfw.win32.xinput.SetState
 
 // dinput8.dll function pointer typedefs
 typedef HRESULT (WINAPI * PFN_DirectInput8Create)(HINSTANCE,DWORD,REFIID,LPVOID*,LPUNKNOWN);
@@ -357,6 +359,7 @@ typedef struct _GLFWlibraryWin32
         HINSTANCE                       instance;
         PFN_XInputGetCapabilities       GetCapabilities;
         PFN_XInputGetState              GetState;
+        PFN_XInputSetState              SetState;
     } xinput;
 
     struct {

--- a/tests/joysticks.c
+++ b/tests/joysticks.c
@@ -238,11 +238,6 @@ int main(void)
                 {
                     if (nk_button_label(nk, joystick_label(joysticks[i])))
                         nk_window_set_focus(nk, joystick_label(joysticks[i]));
-
-                    slowRumble[i] = nk_slide_float(nk, 0.0f, slowRumble[i], 1.0f, 0.05f);
-                    fastRumble[i] = nk_slide_float(nk, 0.0f, fastRumble[i], 1.0f, 0.05f);
-
-                    glfwSetJoystickRumble(joysticks[i], slowRumble[i], fastRumble[i]);
                 }
             }
             else
@@ -335,6 +330,16 @@ int main(void)
 
                     nk_layout_row_dynamic(nk, 30, 8);
                     hat_widget(nk, hat);
+
+                    nk_layout_row_dynamic(nk, 30, 2);
+                    nk_label(nk, "Slow rumble motor intensity", NK_TEXT_LEFT);
+                    nk_label(nk, "Fast rumble motor intensity", NK_TEXT_LEFT);
+                    
+                    nk_layout_row_dynamic(nk, 30, 2);
+                    slowRumble[i] = nk_slide_float(nk, 0.0f, slowRumble[i], 1.0f, 0.05f);
+                    fastRumble[i] = nk_slide_float(nk, 0.0f, fastRumble[i], 1.0f, 0.05f);
+
+                    glfwSetJoystickRumble(joysticks[i], slowRumble[i], fastRumble[i]);
                 }
                 else
                     nk_label(nk, "Joystick has no gamepad mapping", NK_TEXT_LEFT);

--- a/tests/joysticks.c
+++ b/tests/joysticks.c
@@ -242,7 +242,7 @@ int main(void)
                     slowRumble[i] = nk_slide_float(nk, 0.0f, slowRumble[i], 1.0f, 0.05f);
                     fastRumble[i] = nk_slide_float(nk, 0.0f, fastRumble[i], 1.0f, 0.05f);
 
-                    glfwSetGamepadRumble(joysticks[i], slowRumble[i], fastRumble[i]);
+                    glfwSetJoystickRumble(joysticks[i], slowRumble[i], fastRumble[i]);
                 }
             }
             else

--- a/tests/joysticks.c
+++ b/tests/joysticks.c
@@ -57,6 +57,9 @@ static GLFWwindow* window;
 static int joysticks[GLFW_JOYSTICK_LAST + 1];
 static int joystick_count = 0;
 
+static float slowRumble[GLFW_JOYSTICK_LAST + 1];
+static float fastRumble[GLFW_JOYSTICK_LAST + 1];
+
 static void error_callback(int error, const char* description)
 {
     fprintf(stderr, "Error: %s\n", description);
@@ -174,7 +177,9 @@ int main(void)
     struct nk_context* nk;
     struct nk_font_atlas* atlas;
 
-    memset(joysticks, 0, sizeof(joysticks));
+    memset(joysticks,  0, sizeof(joysticks));
+    memset(slowRumble, 0, sizeof(slowRumble));
+    memset(fastRumble, 0, sizeof(fastRumble));
 
     glfwSetErrorCallback(error_callback);
 
@@ -233,6 +238,11 @@ int main(void)
                 {
                     if (nk_button_label(nk, joystick_label(joysticks[i])))
                         nk_window_set_focus(nk, joystick_label(joysticks[i]));
+
+                    slowRumble[i] = nk_slide_float(nk, 0.0f, slowRumble[i], 1.0f, 0.05f);
+                    fastRumble[i] = nk_slide_float(nk, 0.0f, fastRumble[i], 1.0f, 0.05f);
+
+                    glfwSetGamepadRumble(joysticks[i], slowRumble[i], fastRumble[i]);
                 }
             }
             else


### PR DESCRIPTION
This adds a function to control rumble effects on xbox-like gamepads, partially addressing #57. It also adds two sliders to the joystick test app, which allow the user to set each rumble motor's intensity. Some notes:

1. There is currently no MacOS support. I intend to implement this once I get my hands on an Apple machine. Linux and Windows work fine.
2. There is no fallback for DirectInput devices. Although all of the devices available to me support vibration effects, `IDirectInputDevice8_EnumEffects` produced no effect types; consequently, I couldn't test my work. If anybody can recommend a cheap pad with vibration effects that are available through DirectInput, I'd be happy to buy one and add some code to cover older devices.
3. The sole change to the API is a new method, `int glfwSetJoystickRumble(int jid, float slowMotorIntensity, float fastMotorIntensity)`, which returns `GLFW_FALSE` if it was unable to make the gamepad rumble for any reason. @elmindreda's comment on #57 regarding a more complex haptic feedback API got no response, so I assume this is sufficient in the maintainer's/community's view. 

Right now I'm looking for some feedback on my code, since I'm not really a C person. I'll add all the missing documentation (changelog, guide, etc.) once my work is good enough to merge.