### PR TITLE
Use CALayer instead of NSView for EGLNativeWindowType

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ information on what to include when reporting a bug.
  - [Cocoa] Bugfix: Undecorated windows could not be iconified on recent macOS
  - [Cocoa] Bugfix: Touching event queue from secondary thread before main thread
    would abort (#1649)
+ - [Cocoa] Use `CALayer` instead of `NSView` for `EGLNativeWindowType` (#1169)
  - [X11] Bugfix: The CMake files did not check for the XInput headers (#1480)
  - [X11] Bugfix: Key names were not updated when the keyboard layout changed
    (#1462,#1528)

--- a/src/cocoa_platform.h
+++ b/src/cocoa_platform.h
@@ -92,7 +92,7 @@ typedef VkResult (APIENTRY *PFN_vkCreateMetalSurfaceEXT)(VkInstance,const VkMeta
 #define _glfw_dlclose(handle) dlclose(handle)
 #define _glfw_dlsym(handle, name) dlsym(handle, name)
 
-#define _GLFW_EGL_NATIVE_WINDOW  ((EGLNativeWindowType) window->ns.view)
+#define _GLFW_EGL_NATIVE_WINDOW  ((EGLNativeWindowType) window->ns.layer)
 #define _GLFW_EGL_NATIVE_DISPLAY EGL_DEFAULT_DISPLAY
 
 #define _GLFW_PLATFORM_WINDOW_STATE         _GLFWwindowNS  ns

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -906,6 +906,11 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
         }
         else if (ctxconfig->source == GLFW_EGL_CONTEXT_API)
         {
+            // EGL implementation on macOS use CALayer* EGLNativeWindowType so we
+            // need to get the layer for EGL window surface creation.
+            [window->ns.view setWantsLayer:YES];
+            window->ns.layer = [window->ns.view layer];
+
             if (!_glfwInitEGL())
                 return GLFW_FALSE;
             if (!_glfwCreateContextEGL(window, ctxconfig, fbconfig))


### PR DESCRIPTION
The only two EGL implementations on macOS are Swiftshader and ANGLE.
While Swiftshader supports both `NSView` and `CALayer` as
`EGLNativeWindowType`, ANGLE supports only `CALayer`. Furthermore
Swiftshader's OpenGL ES frontend is deprecated in favor of using ANGLE
on top of Swiftshader's Vulkan frontend.

This means that on macOS `EGLNativeWindowType` should be a `CALayer` for
compatibility with ANGLE.

Fixes #1169