### PR TITLE
Don’t let the driver guess the platform

### DIFF
--- a/src/egl_context.h
+++ b/src/egl_context.h
@@ -107,6 +107,11 @@ typedef struct wl_egl_window* EGLNativeWindowType;
 #define EGL_CONTEXT_RELEASE_BEHAVIOR_NONE_KHR 0
 #define EGL_CONTEXT_RELEASE_BEHAVIOR_FLUSH_KHR 0x2098
 
+#define EGL_PLATFORM_WAYLAND_EXT 0x31d8
+#define EGL_PLATFORM_X11_EXT 0x31d5
+
+#define EGL_PLATFORM_GBM_MESA 0x31d7
+
 typedef int EGLint;
 typedef unsigned int EGLBoolean;
 typedef unsigned int EGLenum;
@@ -132,6 +137,8 @@ typedef EGLBoolean (EGLAPIENTRY * PFN_eglSwapBuffers)(EGLDisplay,EGLSurface);
 typedef EGLBoolean (EGLAPIENTRY * PFN_eglSwapInterval)(EGLDisplay,EGLint);
 typedef const char* (EGLAPIENTRY * PFN_eglQueryString)(EGLDisplay,EGLint);
 typedef GLFWglproc (EGLAPIENTRY * PFN_eglGetProcAddress)(const char*);
+typedef EGLDisplay (EGLAPIENTRY * PFN_eglGetPlatformDisplay)(EGLenum,void*,const EGLint*);
+typedef EGLSurface (EGLAPIENTRY * PFN_eglCreatePlatformWindowSurface)(EGLDisplay,EGLConfig,void*,const EGLint*);
 #define eglGetConfigAttrib _glfw.egl.GetConfigAttrib
 #define eglGetConfigs _glfw.egl.GetConfigs
 #define eglGetDisplay _glfw.egl.GetDisplay
@@ -148,6 +155,8 @@ typedef GLFWglproc (EGLAPIENTRY * PFN_eglGetProcAddress)(const char*);
 #define eglSwapInterval _glfw.egl.SwapInterval
 #define eglQueryString _glfw.egl.QueryString
 #define eglGetProcAddress _glfw.egl.GetProcAddress
+#define eglGetPlatformDisplay _glfw.egl.GetPlatformDisplay
+#define eglCreatePlatformWindowSurface _glfw.egl.CreatePlatformWindowSurface
 
 #define _GLFW_EGL_CONTEXT_STATE            _GLFWcontextEGL egl
 #define _GLFW_EGL_LIBRARY_CONTEXT_STATE    _GLFWlibraryEGL egl
@@ -178,6 +187,7 @@ typedef struct _GLFWlibraryEGL
     GLFWbool        KHR_gl_colorspace;
     GLFWbool        KHR_get_all_proc_addresses;
     GLFWbool        KHR_context_flush_control;
+    GLFWbool        platform_supported;
 
     void*           handle;
 
@@ -197,6 +207,8 @@ typedef struct _GLFWlibraryEGL
     PFN_eglSwapInterval         SwapInterval;
     PFN_eglQueryString          QueryString;
     PFN_eglGetProcAddress       GetProcAddress;
+    PFN_eglGetPlatformDisplay   GetPlatformDisplay;
+    PFN_eglCreatePlatformWindowSurface CreatePlatformWindowSurface;
 
 } _GLFWlibraryEGL;
 

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -67,8 +67,11 @@ typedef VkBool32 (APIENTRY *PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR
 #define _glfw_dlclose(handle) dlclose(handle)
 #define _glfw_dlsym(handle, name) dlsym(handle, name)
 
-#define _GLFW_EGL_NATIVE_WINDOW         ((EGLNativeWindowType) window->wl.native)
-#define _GLFW_EGL_NATIVE_DISPLAY        ((EGLNativeDisplayType) _glfw.wl.display)
+#define _GLFW_EGL_NATIVE_WINDOW   (window->wl.native)
+#define _GLFW_EGL_NATIVE_DISPLAY  (_glfw.wl.display)
+#define _GLFW_EGL_NATIVE_PLATFORM EGL_PLATFORM_WAYLAND_EXT
+#define _GLFW_EGL_KHR_PLATFORM    "EGL_KHR_platform_wayland"
+#define _GLFW_EGL_EXT_PLATFORM    "EGL_EXT_platform_wayland"
 
 #define _GLFW_PLATFORM_WINDOW_STATE         _GLFWwindowWayland  wl
 #define _GLFW_PLATFORM_LIBRARY_WINDOW_STATE _GLFWlibraryWayland wl

--- a/src/x11_platform.h
+++ b/src/x11_platform.h
@@ -373,8 +373,11 @@ typedef VkBool32 (APIENTRY *PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR)(Vk
 #define _glfw_dlclose(handle) dlclose(handle)
 #define _glfw_dlsym(handle, name) dlsym(handle, name)
 
-#define _GLFW_EGL_NATIVE_WINDOW  ((EGLNativeWindowType) window->x11.handle)
-#define _GLFW_EGL_NATIVE_DISPLAY ((EGLNativeDisplayType) _glfw.x11.display)
+#define _GLFW_EGL_NATIVE_WINDOW   (window->x11.handle)
+#define _GLFW_EGL_NATIVE_DISPLAY  (_glfw.x11.display)
+#define _GLFW_EGL_NATIVE_PLATFORM EGL_PLATFORM_X11_EXT
+#define _GLFW_EGL_KHR_PLATFORM    "EGL_KHR_platform_x11"
+#define _GLFW_EGL_EXT_PLATFORM    "EGL_EXT_platform_x11"
 
 #define _GLFW_PLATFORM_WINDOW_STATE         _GLFWwindowX11  x11
 #define _GLFW_PLATFORM_LIBRARY_WINDOW_STATE _GLFWlibraryX11 x11


### PR DESCRIPTION
EGL_EXT_platform_base, and later EGL 1.5, introduced two new functions
which take a platform enum instead of guessing based on the shape of the
passed pointer data, which is incredibly error-prone.

This commit makes use of them when they’re exposed by the driver, and
falls back to the old insecure API when not.