### PR TITLE
proper decorations with title and window buttons

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,12 @@ jobs:
               run: |
                   sudo apt update
                   sudo apt install wayland-protocols libwayland-dev libxkbcommon-dev
+                  sudo apt install meson libpango1.0-dev
+                  git clone --depth 1 https://gitlab.gnome.org/jadahl/libdecor.git --branch 0.1.0
+                  cd libdecor
+                  meson build --buildtype release -Ddemo=false -Ddbus=disabled
+                  ninja -C build
+                  sudo meson install -C build
 
             - name: Configure static library
               run: cmake -S . -B build-static -D GLFW_USE_WAYLAND=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,25 @@ if (GLFW_BUILD_DOCS)
     find_package(Doxygen)
 endif()
 
+if (CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} \
+        -fsanitize=address \
+        -fsanitize=bool \
+        -fsanitize=bounds \
+        -fsanitize=enum \
+        -fsanitize=float-cast-overflow \
+        -fsanitize=float-divide-by-zero \
+        -fsanitize=nonnull-attribute \
+        -fsanitize=returns-nonnull-attribute \
+        -fsanitize=signed-integer-overflow \
+        -fsanitize=undefined \
+        -fsanitize=vla-bound \
+        -fno-sanitize=alignment \
+        -fsanitize=leak \
+        -fsanitize=object-size \
+    ")
+endif()
+
 #--------------------------------------------------------------------
 # Set compiler specific flags
 #--------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,8 @@ cmake_dependent_option(GLFW_USE_WAYLAND "Use Wayland for window creation" OFF
                        "UNIX;NOT APPLE" OFF)
 cmake_dependent_option(USE_MSVC_RUNTIME_LIBRARY_DLL "Use MSVC runtime library DLL" ON
                        "MSVC" OFF)
+cmake_dependent_option(GLFW_USE_LIBDECOR "use libdecor for client-side window decorations" ON
+                       "GLFW_USE_WAYLAND" OFF)
 
 if (BUILD_SHARED_LIBS AND UNIX)
     # On Unix-like systems, shared libraries can use the soname system.
@@ -224,6 +226,14 @@ if (_GLFW_WAYLAND)
 
     list(APPEND glfw_INCLUDE_DIRS "${Wayland_INCLUDE_DIRS}")
     list(APPEND glfw_LIBRARIES "${Wayland_LINK_LIBRARIES}")
+
+    if (GLFW_USE_LIBDECOR)
+        pkg_check_modules(libdecor REQUIRED libdecor-0)
+        list(APPEND glfw_PKG_DEPS "libdecor-0")
+        list(APPEND glfw_INCLUDE_DIRS "${libdecor_INCLUDE_DIRS}")
+        list(APPEND glfw_LIBRARIES "${libdecor_LINK_LIBRARIES}")
+        add_definitions(-DWITH_DECORATION)
+    endif()
 
     include(CheckIncludeFiles)
     include(CheckFunctionExists)

--- a/src/window.c
+++ b/src/window.c
@@ -279,7 +279,7 @@ void glfwDefaultWindowHints(void)
     _glfw.hints.framebuffer.redBits      = 8;
     _glfw.hints.framebuffer.greenBits    = 8;
     _glfw.hints.framebuffer.blueBits     = 8;
-    _glfw.hints.framebuffer.alphaBits    = 8;
+    _glfw.hints.framebuffer.alphaBits    = 0;
     _glfw.hints.framebuffer.depthBits    = 24;
     _glfw.hints.framebuffer.stencilBits  = 8;
     _glfw.hints.framebuffer.doublebuffer = GLFW_TRUE;

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -56,6 +56,7 @@ static _GLFWwindow* findWindowFromDecorationSurface(struct wl_surface* surface,
     _GLFWwindow* window = _glfw.windowListHead;
     if (!which)
         which = &focus;
+#ifndef WITH_DECORATION
     while (window)
     {
         if (surface == window->wl.decorations.top.surface)
@@ -80,6 +81,7 @@ static _GLFWwindow* findWindowFromDecorationSurface(struct wl_surface* surface,
         }
         window = window->next;
     }
+#endif
     return window;
 }
 
@@ -103,7 +105,10 @@ static void pointerHandleEnter(void* data,
             return;
     }
 
+#ifndef WITH_DECORATION
     window->wl.decorations.focus = focus;
+#endif
+
     _glfw.wl.serial = serial;
     _glfw.wl.pointerFocus = window;
 
@@ -194,6 +199,7 @@ static void pointerHandleMotion(void* data,
     x = wl_fixed_to_double(sx);
     y = wl_fixed_to_double(sy);
 
+#ifndef WITH_DECORATION
     switch (window->wl.decorations.focus)
     {
         case mainWindow:
@@ -231,6 +237,7 @@ static void pointerHandleMotion(void* data,
         default:
             assert(0);
     }
+#endif
     if (_glfw.wl.cursorPreviousName != cursorName)
         setCursor(window, cursorName);
 }
@@ -248,6 +255,7 @@ static void pointerHandleButton(void* data,
 
     if (!window)
         return;
+#ifndef WITH_DECORATION
     if (button == BTN_LEFT)
     {
         switch (window->wl.decorations.focus)
@@ -306,6 +314,7 @@ static void pointerHandleButton(void* data,
     // Don’t pass the button to the user if it was related to a decoration.
     if (window->wl.decorations.focus != mainWindow)
         return;
+#endif
 
     _glfw.wl.serial = serial;
 
@@ -840,11 +849,13 @@ static void registryHandleGlobal(void* data,
                              &zxdg_decoration_manager_v1_interface,
                              1);
     }
+#ifndef WITH_DECORATION
     else if (strcmp(interface, "wp_viewporter") == 0)
     {
         _glfw.wl.viewporter =
             wl_registry_bind(registry, name, &wp_viewporter_interface, 1);
     }
+#endif
     else if (strcmp(interface, "zwp_relative_pointer_manager_v1") == 0)
     {
         _glfw.wl.relativePointerManager =
@@ -1249,8 +1260,10 @@ void _glfwPlatformTerminate(void)
         wl_compositor_destroy(_glfw.wl.compositor);
     if (_glfw.wl.shm)
         wl_shm_destroy(_glfw.wl.shm);
+#ifndef WITH_DECORATION
     if (_glfw.wl.viewporter)
         wp_viewporter_destroy(_glfw.wl.viewporter);
+#endif
     if (_glfw.wl.decorationManager)
         zxdg_decoration_manager_v1_destroy(_glfw.wl.decorationManager);
     if (_glfw.wl.wmBase)

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -44,11 +44,14 @@
 #include <wayland-client.h>
 
 
+const char *proxy_tag = "glfw-proxy";
+
 static inline int min(int n1, int n2)
 {
     return n1 < n2 ? n1 : n2;
 }
 
+#ifndef WITH_DECORATION
 static _GLFWwindow* findWindowFromDecorationSurface(struct wl_surface* surface,
                                                     int* which)
 {
@@ -56,7 +59,6 @@ static _GLFWwindow* findWindowFromDecorationSurface(struct wl_surface* surface,
     _GLFWwindow* window = _glfw.windowListHead;
     if (!which)
         which = &focus;
-#ifndef WITH_DECORATION
     while (window)
     {
         if (surface == window->wl.decorations.top.surface)
@@ -81,9 +83,22 @@ static _GLFWwindow* findWindowFromDecorationSurface(struct wl_surface* surface,
         }
         window = window->next;
     }
-#endif
     return window;
 }
+#endif
+
+#ifdef WITH_DECORATION
+void decoration_error(struct libdecor *context,
+                      enum libdecor_error error,
+                      const char *message)
+{
+    _glfwInputError(GLFW_PLATFORM_ERROR, "Wayland: Caught error (%d): %s\n", error, message);
+}
+
+static struct libdecor_interface decoration_interface = {
+    decoration_error,
+};
+#endif
 
 static void pointerHandleEnter(void* data,
                                struct wl_pointer* pointer,
@@ -96,8 +111,16 @@ static void pointerHandleEnter(void* data,
     if (!surface)
         return;
 
-    int focus = 0;
+    if (wl_proxy_get_tag((struct wl_proxy *) surface) != &proxy_tag)
+        return;
+
     _GLFWwindow* window = wl_surface_get_user_data(surface);
+
+#ifdef WITH_DECORATION
+    if (surface != window->wl.surface)
+        return;
+#else
+    int focus = 0;
     if (!window)
     {
         window = findWindowFromDecorationSurface(surface, &focus);
@@ -105,7 +128,6 @@ static void pointerHandleEnter(void* data,
             return;
     }
 
-#ifndef WITH_DECORATION
     window->wl.decorations.focus = focus;
 #endif
 
@@ -196,10 +218,16 @@ static void pointerHandleMotion(void* data,
 
     if (window->cursorMode == GLFW_CURSOR_DISABLED)
         return;
+
     x = wl_fixed_to_double(sx);
     y = wl_fixed_to_double(sy);
 
-#ifndef WITH_DECORATION
+#ifdef WITH_DECORATION
+    window->wl.cursorPosX = x;
+    window->wl.cursorPosY = y;
+    _glfwInputCursorPos(window, x, y);
+    _glfw.wl.cursorPreviousName = NULL;
+#else
     switch (window->wl.decorations.focus)
     {
         case mainWindow:
@@ -251,11 +279,11 @@ static void pointerHandleButton(void* data,
 {
     _GLFWwindow* window = _glfw.wl.pointerFocus;
     int glfwButton;
-    uint32_t edges = XDG_TOPLEVEL_RESIZE_EDGE_NONE;
 
     if (!window)
         return;
 #ifndef WITH_DECORATION
+    uint32_t edges = XDG_TOPLEVEL_RESIZE_EDGE_NONE;
     if (button == BTN_LEFT)
     {
         switch (window->wl.decorations.focus)
@@ -477,13 +505,21 @@ static void keyboardHandleEnter(void* data,
     if (!surface)
         return;
 
+    if (wl_proxy_get_tag((struct wl_proxy *) surface) != &proxy_tag)
+        return;
+
     _GLFWwindow* window = wl_surface_get_user_data(surface);
+#ifdef WITH_DECORATION
+    if (surface != window->wl.surface)
+        return;
+#else
     if (!window)
     {
         window = findWindowFromDecorationSurface(surface, NULL);
         if (!window)
             return;
     }
+#endif
 
     _glfw.wl.serial = serial;
     _glfw.wl.keyboardFocus = window;
@@ -778,6 +814,7 @@ static const struct wl_data_device_listener dataDeviceListener = {
     dataDeviceHandleSelection,
 };
 
+#ifndef WITH_DECORATION
 static void wmBaseHandlePing(void* data,
                              struct xdg_wm_base* wmBase,
                              uint32_t serial)
@@ -788,6 +825,7 @@ static void wmBaseHandlePing(void* data,
 static const struct xdg_wm_base_listener wmBaseListener = {
     wmBaseHandlePing
 };
+#endif
 
 static void registryHandleGlobal(void* data,
                                  struct wl_registry* registry,
@@ -836,6 +874,7 @@ static void registryHandleGlobal(void* data,
                                  &wl_data_device_manager_interface, 1);
         }
     }
+#ifndef WITH_DECORATION
     else if (strcmp(interface, "xdg_wm_base") == 0)
     {
         _glfw.wl.wmBase =
@@ -849,7 +888,6 @@ static void registryHandleGlobal(void* data,
                              &zxdg_decoration_manager_v1_interface,
                              1);
     }
-#ifndef WITH_DECORATION
     else if (strcmp(interface, "wp_viewporter") == 0)
     {
         _glfw.wl.viewporter =
@@ -1163,12 +1201,14 @@ int _glfwPlatformInit(void)
     if (_glfw.wl.seatVersion >= 4)
         _glfw.wl.timerfd = timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC);
 
+#ifndef WITH_DECORATION
     if (!_glfw.wl.wmBase)
     {
         _glfwInputError(GLFW_PLATFORM_ERROR,
                         "Wayland: Failed to find xdg-shell in your compositor");
         return GLFW_FALSE;
     }
+#endif
 
     if (_glfw.wl.pointer && _glfw.wl.shm)
     {
@@ -1213,6 +1253,10 @@ int _glfwPlatformInit(void)
         }
         _glfw.wl.clipboardSize = 4096;
     }
+
+#ifdef WITH_DECORATION
+    _glfw.wl.csd_context = libdecor_new(_glfw.wl.display, &decoration_interface);
+#endif
 
     return GLFW_TRUE;
 }
@@ -1260,14 +1304,16 @@ void _glfwPlatformTerminate(void)
         wl_compositor_destroy(_glfw.wl.compositor);
     if (_glfw.wl.shm)
         wl_shm_destroy(_glfw.wl.shm);
-#ifndef WITH_DECORATION
+#ifdef WITH_DECORATION
+    libdecor_unref(_glfw.wl.csd_context);
+#else
     if (_glfw.wl.viewporter)
         wp_viewporter_destroy(_glfw.wl.viewporter);
-#endif
     if (_glfw.wl.decorationManager)
         zxdg_decoration_manager_v1_destroy(_glfw.wl.decorationManager);
     if (_glfw.wl.wmBase)
         xdg_wm_base_destroy(_glfw.wl.wmBase);
+#endif
     if (_glfw.wl.dataSource)
         wl_data_source_destroy(_glfw.wl.dataSource);
     if (_glfw.wl.dataDevice)

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -54,14 +54,17 @@ typedef VkBool32 (APIENTRY *PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR
 #endif
 #include "xkb_unicode.h"
 
-#include "wayland-xdg-shell-client-protocol.h"
-#include "wayland-xdg-decoration-client-protocol.h"
-#ifndef WITH_DECORATION
-#include "wayland-viewporter-client-protocol.h"
-#endif
 #include "wayland-relative-pointer-unstable-v1-client-protocol.h"
 #include "wayland-pointer-constraints-unstable-v1-client-protocol.h"
 #include "wayland-idle-inhibit-unstable-v1-client-protocol.h"
+
+#ifdef WITH_DECORATION
+#include <libdecor.h>
+#else
+#include "wayland-xdg-shell-client-protocol.h"
+#include "wayland-xdg-decoration-client-protocol.h"
+#include "wayland-viewporter-client-protocol.h"
+#endif
 
 #define _glfw_dlopen(name) dlopen(name, RTLD_LAZY | RTLD_LOCAL)
 #define _glfw_dlclose(handle) dlclose(handle)
@@ -181,11 +184,13 @@ typedef struct _GLFWwindowWayland
     struct wl_egl_window*       native;
     struct wl_callback*         callback;
 
+#ifndef WITH_DECORATION
     struct {
         struct xdg_surface*     surface;
         struct xdg_toplevel*    toplevel;
         struct zxdg_toplevel_decoration_v1* decoration;
     } xdg;
+#endif
 
     _GLFWcursor*                currentCursor;
     double                      cursorPosX, cursorPosY;
@@ -216,7 +221,7 @@ typedef struct _GLFWwindowWayland
         int                                focus;
     } decorations;
 #else
-    GLFWbool                                ssd;
+    struct libdecor_frame                   *decoration_frame;
 #endif
 
 } _GLFWwindowWayland;
@@ -237,9 +242,11 @@ typedef struct _GLFWlibraryWayland
     struct wl_data_device*      dataDevice;
     struct wl_data_offer*       dataOffer;
     struct wl_data_source*      dataSource;
+#ifdef WITH_DECORATION
+    struct libdecor             *csd_context;
+#else
     struct xdg_wm_base*         wmBase;
     struct zxdg_decoration_manager_v1*      decorationManager;
-#ifndef WITH_DECORATION
     struct wp_viewporter*       viewporter;
 #endif
     struct zwp_relative_pointer_manager_v1* relativePointerManager;

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -56,7 +56,9 @@ typedef VkBool32 (APIENTRY *PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR
 
 #include "wayland-xdg-shell-client-protocol.h"
 #include "wayland-xdg-decoration-client-protocol.h"
+#ifndef WITH_DECORATION
 #include "wayland-viewporter-client-protocol.h"
+#endif
 #include "wayland-relative-pointer-unstable-v1-client-protocol.h"
 #include "wayland-pointer-constraints-unstable-v1-client-protocol.h"
 #include "wayland-idle-inhibit-unstable-v1-client-protocol.h"
@@ -146,6 +148,7 @@ typedef xkb_keysym_t (* PFN_xkb_compose_state_get_one_sym)(struct xkb_compose_st
 #define _GLFW_DECORATION_VERTICAL (_GLFW_DECORATION_TOP + _GLFW_DECORATION_WIDTH)
 #define _GLFW_DECORATION_HORIZONTAL (2 * _GLFW_DECORATION_WIDTH)
 
+#ifndef WITH_DECORATION
 typedef enum _GLFWdecorationSideWayland
 {
     mainWindow,
@@ -163,6 +166,7 @@ typedef struct _GLFWdecorationWayland
     struct wp_viewport*         viewport;
 
 } _GLFWdecorationWayland;
+#endif
 
 // Wayland-specific per-window data
 //
@@ -204,12 +208,16 @@ typedef struct _GLFWwindowWayland
 
     GLFWbool                    wasFullscreen;
 
+#ifndef WITH_DECORATION
     struct {
         GLFWbool                           serverSide;
         struct wl_buffer*                  buffer;
         _GLFWdecorationWayland             top, left, right, bottom;
         int                                focus;
     } decorations;
+#else
+    GLFWbool                                ssd;
+#endif
 
 } _GLFWwindowWayland;
 
@@ -231,7 +239,9 @@ typedef struct _GLFWlibraryWayland
     struct wl_data_source*      dataSource;
     struct xdg_wm_base*         wmBase;
     struct zxdg_decoration_manager_v1*      decorationManager;
+#ifndef WITH_DECORATION
     struct wp_viewporter*       viewporter;
+#endif
     struct zwp_relative_pointer_manager_v1* relativePointerManager;
     struct zwp_pointer_constraints_v1*      pointerConstraints;
     struct zwp_idle_inhibit_manager_v1*     idleInhibitManager;

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -826,6 +826,9 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
         window->wl.visible = GLFW_FALSE;
     }
 
+    if (window->monitor)
+        setFullscreen(window, window->monitor, window->videoMode.refreshRate);
+
     window->wl.currentCursor = NULL;
 
     window->wl.monitors = calloc(1, sizeof(_GLFWmonitor*));

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -292,7 +292,6 @@ static void setOpaqueRegion(_GLFWwindow* window)
 
     wl_region_add(region, 0, 0, window->wl.width, window->wl.height);
     wl_surface_set_opaque_region(window->wl.surface, region);
-    wl_surface_commit(window->wl.surface);
     wl_region_destroy(region);
 }
 


### PR DESCRIPTION
This adds [`libdecor`](https://gitlab.gnome.org/jadahl/libdecor) for proper client-side window decoration support:
![glfw_decorations](https://user-images.githubusercontent.com/8573621/81483971-ddc9c300-9239-11ea-9893-cbad56af6561.png)

(cc @jadahl)

~~This PR currently checks out a development branch that contains some PRs that haven't been merged upstream yet.~~

For now, I am mainly interested to get some feedback on the decoration requirements in GLFW and see if `libdecor` fits your needs. Once the remaining PRs have been merged upstream, I would appreciate if GLFW could gain proper decoration support by merging this.

I also included some minor changes to remove glitches during resizing.

Fixes #1639 .