### PR TITLE
Add statement to docs for glfwTerminate

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -1866,6 +1866,8 @@ GLFWAPI int glfwInit(void);
  *  call this function, as it is called by @ref glfwInit before it returns
  *  failure.
  *
+ *  This function has no effect if GLFW is not initialized.
+ *
  *  @errors Possible errors include @ref GLFW_PLATFORM_ERROR.
  *
  *  @remark This function may be called before @ref glfwInit.


### PR DESCRIPTION
At the moment it is safe to call `glfwTerminate` even if the library is not currently initialized (it returns instantly with no side effects), but this is not mentioned in the documentation. Unless you plan to change this behaviour in future (and I don't think you should), it would be great to make this a promise so that users don't need to add their own redundant conditional.