### PR TITLE
Use the correct type in a for loop

### DIFF
--- a/src/x11_init.c
+++ b/src/x11_init.c
@@ -497,7 +497,7 @@ static Atom getAtomIfSupported(Atom* supportedAtoms,
 {
     const Atom atom = XInternAtom(_glfw.x11.display, atomName, False);
 
-    for (unsigned int i = 0;  i < atomCount;  i++)
+    for (unsigned long i = 0;  i < atomCount;  i++)
     {
         if (supportedAtoms[i] == atom)
             return atom;


### PR DESCRIPTION
The `atomCount` variable has the type `unsigned long`, so the `for` loop iterating over it should use the same type.

Closes #1701.