### PR TITLE
Replace %m conversion specifier with %s and strerror()

### DIFF
--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -142,8 +142,8 @@ static struct wl_buffer* createShmBuffer(const GLFWimage* image)
     if (fd < 0)
     {
         _glfwInputError(GLFW_PLATFORM_ERROR,
-                        "Wayland: Creating a buffer file for %d B failed: %m",
-                        length);
+                        "Wayland: Creating a buffer file for %d B failed: %s",
+                        length, strerror(errno));
         return NULL;
     }
 
@@ -151,7 +151,7 @@ static struct wl_buffer* createShmBuffer(const GLFWimage* image)
     if (data == MAP_FAILED)
     {
         _glfwInputError(GLFW_PLATFORM_ERROR,
-                        "Wayland: mmap failed: %m");
+                        "Wayland: mmap failed: %s", strerror(errno));
         close(fd);
         return NULL;
     }


### PR DESCRIPTION
When compiling with `-Wall` and `-pedantic-errors`, gcc complains with
```
warning: ISO C does not support the '%m' gnu_printf format [-Wformat=]
```
because the `%m` conversion specifier is a GNU extension.

Closes #1702.

I'm not sure if this is actually a problem for most people. This was a problem for kitty but since it has its own fork of GLFW, it isn't a big deal.