### PR TITLE
Use __typeof__() instead of void*

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -218,7 +218,7 @@ typedef void (APIENTRY * PFN_vkVoidFunction)(void);
 // Swaps the provided pointers
 #define _GLFW_SWAP_POINTERS(x, y) \
     {                             \
-        void* t;                  \
+        __typeof__(x) t;          \
         t = x;                    \
         x = y;                    \
         y = t;                    \


### PR DESCRIPTION
Preserve the real type of a pointer instead of casting to `void*`.

Closes #1703.

Can `__typeof__()` be used on all supported platforms?