### PR TITLE
Fixed: GLFW_INCLUDE_GLU is not working related to issue #1695.

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -193,6 +193,22 @@ extern "C" {
 
  #endif /*__APPLE__*/
 
+#elif defined(GLFW_INCLUDE_GLU)
+
+ #if defined(__APPLE__)
+
+  #if defined(GLFW_INCLUDE_GLU)
+   #include <OpenGL/glu.h>
+  #endif
+
+ #else /*__APPLE__*/
+
+  #if defined(GLFW_INCLUDE_GLU)
+   #include <GL/glu.h>
+  #endif
+
+ #endif /*__APPLE__*/
+
 #elif !defined(GLFW_INCLUDE_NONE) && \
       !defined(__gl_h_) && \
       !defined(__gles1_gl_h_) && \
@@ -216,18 +232,12 @@ extern "C" {
    #define GL_GLEXT_LEGACY
   #endif
   #include <OpenGL/gl.h>
-  #if defined(GLFW_INCLUDE_GLU)
-   #include <OpenGL/glu.h>
-  #endif
 
  #else /*__APPLE__*/
 
   #include <GL/gl.h>
   #if defined(GLFW_INCLUDE_GLEXT)
    #include <GL/glext.h>
-  #endif
-  #if defined(GLFW_INCLUDE_GLU)
-   #include <GL/glu.h>
   #endif
 
  #endif /*__APPLE__*/


### PR DESCRIPTION
I found that the fix proposed in issue #1695 prevents `glu.h` from being included even when `GLFW_INCLUDE_GLU` is specified.

In this PR, I separated the section for `glu.h` from the section where the standard GL.h is included.