### PR TITLE
Should pass hdc when invoke eglGetDisplay at win32

### DIFF
--- a/src/egl_context.c
+++ b/src/egl_context.c
@@ -396,9 +396,7 @@ GLFWbool _glfwInitEGL(void)
     }
 
 #if defined(_WIN32)
-    _GLFWwindow* mainWindow = _glfw.windowListHead;
-    HDC dc = GetDC(mainWindow->win32.handle);
-    _glfw.egl.display = eglGetDisplay(dc);
+    _glfw.egl.display = eglGetDisplay(GetDC(_glfw.windowListHead->win32.handle));
 #else
     _glfw.egl.display = eglGetDisplay(_GLFW_EGL_NATIVE_DISPLAY);
 #endif

--- a/src/egl_context.c
+++ b/src/egl_context.c
@@ -395,7 +395,13 @@ GLFWbool _glfwInitEGL(void)
         return GLFW_FALSE;
     }
 
+#if defined(_WIN32)
+    _GLFWwindow* mainWindow = _glfw.windowListHead;
+    HDC dc = GetDC(mainWindow->win32.handle);
+    _glfw.egl.display = eglGetDisplay(dc);
+#else
     _glfw.egl.display = eglGetDisplay(_GLFW_EGL_NATIVE_DISPLAY);
+#endif
     if (_glfw.egl.display == EGL_NO_DISPLAY)
     {
         _glfwInputError(GLFW_API_UNAVAILABLE,


### PR DESCRIPTION
Such as EGL provide by google AngleProject, see https://github.com/google/angle/blob/master/src/libANGLE/renderer/d3d/d3d11/Renderer11.cpp function ```Renderer11::initialize```