### PR TITLE
Update documentation for OPENGL_DEBUG_CONTEXT hint

### DIFF
--- a/docs/window.dox
+++ b/docs/window.dox
@@ -408,8 +408,7 @@ Forward-compatibility is described in detail in the
 @anchor GLFW_OPENGL_DEBUG_CONTEXT_hint
 __GLFW_OPENGL_DEBUG_CONTEXT__ specifies whether to create a debug OpenGL
 context, which may have additional error and performance issue reporting
-functionality.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  If OpenGL ES
-is requested, this hint is ignored.
+functionality.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.
 
 @anchor GLFW_OPENGL_PROFILE_hint
 __GLFW_OPENGL_PROFILE__ specifies which OpenGL profile to create the context

--- a/docs/window.dox
+++ b/docs/window.dox
@@ -406,9 +406,14 @@ Forward-compatibility is described in detail in the
 [OpenGL Reference Manual](https://www.opengl.org/registry/).
 
 @anchor GLFW_OPENGL_DEBUG_CONTEXT_hint
-__GLFW_OPENGL_DEBUG_CONTEXT__ specifies whether to create a debug OpenGL
-context, which may have additional error and performance issue reporting
+__GLFW_OPENGL_DEBUG_CONTEXT__ specifies whether the context should be created
+in debug mode, which may provide additional error and diagnostic reporting
 functionality.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.
+
+@par
+Debug contexts for OpenGL and OpenGL ES are described in detail by the
+[GL_KHR_debug](https://www.khronos.org/registry/OpenGL/extensions/KHR/KHR_debug.txt)
+extension.
 
 @anchor GLFW_OPENGL_PROFILE_hint
 __GLFW_OPENGL_PROFILE__ specifies which OpenGL profile to create the context


### PR DESCRIPTION
The documentation currently says that the GLFW_OPENGL_DEBUG_CONTEXT hint is ignored if an OpenGL ES context is requested, but I don't think that matches the implemented behaviour.