### PR TITLE
Wayland: Fix windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ information on what to include when reporting a bug.
 
 ## Changelog
 
+ - [Wayland] Bugfix: Window hiding not working (#1492)
  - Added `GLFW_RESIZE_NWSE_CURSOR`, `GLFW_RESIZE_NESW_CURSOR`,
    `GLFW_RESIZE_ALL_CURSOR` and `GLFW_NOT_ALLOWED_CURSOR` cursor shapes (#427)
  - Added `GLFW_RESIZE_EW_CURSOR` alias for `GLFW_HRESIZE_CURSOR` (#427)
@@ -271,6 +272,7 @@ skills.
  - Siavash Eliasi
  - Felipe Ferreira
  - Michael Fogleman
+ - Jason Francis
  - Gerald Franz
  - Mário Freitas
  - GeO4d

--- a/src/context.c
+++ b/src/context.c
@@ -566,7 +566,7 @@ GLFWbool _glfwRefreshContextAttribs(_GLFWwindow* window,
 
     // Clearing the front buffer to black to avoid garbage pixels left over from
     // previous uses of our bit of VRAM
-    {
+    if (_glfwPlatformWindowVisible(window)) {
         PFNGLCLEARPROC glClear = (PFNGLCLEARPROC)
             window->context.getProcAddress("glClear");
         glClear(GL_COLOR_BUFFER_BIT);

--- a/src/egl_context.c
+++ b/src/egl_context.c
@@ -221,7 +221,7 @@ static void makeContextCurrentEGL(_GLFWwindow* window)
     _glfwPlatformSetTls(&_glfw.contextSlot, window);
 }
 
-static void swapBuffersEGL(_GLFWwindow* window)
+void swapBuffersEGL(_GLFWwindow* window)
 {
     if (window != _glfwPlatformGetTls(&_glfw.contextSlot))
     {


### PR DESCRIPTION
Corrects the protocol violation with attaching an `xdg_surface` to a `wl_surface` that already has a buffer. Destroying the `xdg_surface` is not necessary. Instead we just attach a null `wl_buffer`.

NOTE: this patch introduces new behavior where `glfwSwapBuffers` will always return immediately on Wayland if the window is hidden, even if there is a swap interval. This is probably better than the previous behavior where swapping a hidden window with swap interval >= 1 would cause the program to hang indefinitely in a frame callback. However, it could cause some applications to consume a lot of CPU if they keep a render loop going after hiding a window.

Fixes  #1492