### PR TITLE
Touch input

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ skills.
  - Bailey Cosier
  - Noel Cower
  - Jason Daly
+ - Torkel Danielsson
  - Jarrod Davis
  - Olivier Delannoy
  - Paul R. Deppe
@@ -316,6 +317,7 @@ skills.
  - Yuri Kunde Schlesner
  - Rokas Kupstys
  - Konstantin Käfer
+ - Quinten Lansu
  - Eric Larson
  - Francis Lecavalier
  - Robin Leffmann

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -1736,7 +1736,7 @@ typedef void (* GLFWdropfun)(GLFWwindow*,int,const char*[]);
 
 /*! @brief The function pointer type for touch callbacks.
  *
- *  This is the function pointer type for touch callbacks. 
+ *  This is the function pointer type for touch callbacks.
  *  A touch callback function has the following signature:
  *  @code
  *  void function_name(GLFWwindow* window, int touch, int action, double xpos, double ypos)
@@ -4283,7 +4283,7 @@ GLFWAPI int glfwGetInputMode(GLFWwindow* window, int mode);
  *  attempting to set this will emit @ref GLFW_FEATURE_UNAVAILABLE.  Call @ref
  *  glfwRawMouseMotionSupported to check for support.
  *
- *  If the mode is `GLFW_TOUCH`, the value must be either `GLFW_TRUE` to enable 
+ *  If the mode is `GLFW_TOUCH`, the value must be either `GLFW_TRUE` to enable
  *  touch input, or `GLFW_FALSE` to disable it. If touch input is not supported,
  *  attempting to set this will emit @ref GLFW_FEATURE_UNAVAILABLE.  Call @ref
  *  glfwTouchInputSupported to check for support.

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -1403,6 +1403,17 @@ GLFWbool _glfwPlatformRawMouseMotionSupported(void)
     return GLFW_FALSE;
 }
 
+void _glfwPlatformSetTouchInput(_GLFWwindow *window, GLFWbool enabled)
+{
+    _glfwInputError(GLFW_FEATURE_UNIMPLEMENTED,
+                    "Cocoa: Touch input not yet implemented");
+}
+
+GLFWbool _glfwPlatformTouchInputSupported(void)
+{
+    return GLFW_FALSE;
+}
+
 void _glfwPlatformPollEvents(void)
 {
     @autoreleasepool {

--- a/src/internal.h
+++ b/src/internal.h
@@ -394,6 +394,7 @@ struct _GLFWwindow
 
     GLFWbool            stickyKeys;
     GLFWbool            stickyMouseButtons;
+    GLFWbool            touchInput;
     GLFWbool            lockKeyMods;
     int                 cursorMode;
     char                mouseButtons[GLFW_MOUSE_BUTTON_LAST + 1];
@@ -422,6 +423,7 @@ struct _GLFWwindow
         GLFWcharfun             character;
         GLFWcharmodsfun         charmods;
         GLFWdropfun             drop;
+        GLFWtouchfun            touch;
     } callbacks;
 
     // This is defined in the window API's platform.h
@@ -611,6 +613,8 @@ void _glfwPlatformSetCursorPos(_GLFWwindow* window, double xpos, double ypos);
 void _glfwPlatformSetCursorMode(_GLFWwindow* window, int mode);
 void _glfwPlatformSetRawMouseMotion(_GLFWwindow *window, GLFWbool enabled);
 GLFWbool _glfwPlatformRawMouseMotionSupported(void);
+void _glfwPlatformSetTouchInput(_GLFWwindow* window, int enabled);
+GLFWbool _glfwPlatformTouchInputSupported(void);
 int _glfwPlatformCreateCursor(_GLFWcursor* cursor,
                               const GLFWimage* image, int xhot, int yhot);
 int _glfwPlatformCreateStandardCursor(_GLFWcursor* cursor, int shape);
@@ -739,6 +743,8 @@ void _glfwInputScroll(_GLFWwindow* window, double xoffset, double yoffset);
 void _glfwInputMouseClick(_GLFWwindow* window, int button, int action, int mods);
 void _glfwInputCursorPos(_GLFWwindow* window, double xpos, double ypos);
 void _glfwInputCursorEnter(_GLFWwindow* window, GLFWbool entered);
+void _glfwInputTouch(_GLFWwindow* window, int touch, int action, double xpos, double ypos);
+
 void _glfwInputDrop(_GLFWwindow* window, int count, const char** names);
 void _glfwInputJoystick(_GLFWjoystick* js, int event);
 void _glfwInputJoystickAxis(_GLFWjoystick* js, int axis, float value);

--- a/src/null_window.c
+++ b/src/null_window.c
@@ -400,6 +400,15 @@ GLFWbool _glfwPlatformRawMouseMotionSupported(void)
     return GLFW_TRUE;
 }
 
+void _glfwPlatformSetTouchInput(_GLFWwindow *window, GLFWbool enabled)
+{
+}
+
+GLFWbool _glfwPlatformTouchInputSupported(void)
+{
+    return GLFW_TRUE;
+}
+
 void _glfwPlatformShowWindow(_GLFWwindow* window)
 {
     window->null.visible = GLFW_TRUE;

--- a/src/win32_init.c
+++ b/src/win32_init.c
@@ -107,6 +107,23 @@ static GLFWbool loadLibraries(void)
             GetProcAddress(_glfw.win32.dinput8.instance, "DirectInput8Create");
     }
 
+    _glfw.win32.user32.GetTouchInputInfo_ = (PFN_GetTouchInputInfo)
+        GetProcAddress(_glfw.win32.user32.instance, "GetTouchInputInfo");
+    _glfw.win32.user32.CloseTouchInputHandle_ = (PFN_CloseTouchInputHandle)
+        GetProcAddress(_glfw.win32.user32.instance, "CloseTouchInputHandle");
+    _glfw.win32.user32.RegisterTouchWindow_ = (PFN_RegisterTouchWindow)
+        GetProcAddress(_glfw.win32.user32.instance, "RegisterTouchWindow");
+    _glfw.win32.user32.UnregisterTouchWindow_ = (PFN_UnregisterTouchWindow)
+        GetProcAddress(_glfw.win32.user32.instance, "UnregisterTouchWindow");
+
+    if (_glfw.win32.user32.GetTouchInputInfo_ &&
+        _glfw.win32.user32.CloseTouchInputHandle_ &&
+        _glfw.win32.user32.RegisterTouchWindow_ &&
+        _glfw.win32.user32.UnregisterTouchWindow_)
+    {
+        _glfw.win32.touch.available = GLFW_TRUE;
+    }
+
     {
         int i;
         const char* names[] =

--- a/src/win32_platform.h
+++ b/src/win32_platform.h
@@ -215,6 +215,34 @@ typedef enum
  #define DIDFT_OPTIONAL 0x80000000
 #endif
 
+#if WINVER < 0x0601
+
+#define WM_TOUCH 0x0240
+
+DECLARE_HANDLE(HTOUCHINPUT);
+
+typedef struct tagTOUCHINPUT
+{
+    LONG x;
+    LONG y;
+    HANDLE hSource;
+    DWORD dwID;
+    DWORD dwFlags;
+    DWORD dwMask;
+    DWORD dwTime;
+    ULONG_PTR dwExtraInfo;
+    DWORD cxContact;
+    DWORD cyContext;
+} TOUCHINPUT, *PTOUCHINPUT;
+
+#define TOUCH_COORD_TO_PIXEL(x) ((x) / 100)
+
+#define TOUCHEVENTF_MOVE    0x0001
+#define TOUCHEVENTF_DOWN    0x0002
+#define TOUCHEVENTF_UP      0x0004
+
+#endif /*WINVER < 0x0601*/
+
 // winmm.dll function pointer typedefs
 typedef DWORD (WINAPI * PFN_timeGetTime)(void);
 #define timeGetTime _glfw.win32.winmm.GetTime
@@ -236,12 +264,20 @@ typedef BOOL (WINAPI * PFN_EnableNonClientDpiScaling)(HWND);
 typedef BOOL (WINAPI * PFN_SetProcessDpiAwarenessContext)(HANDLE);
 typedef UINT (WINAPI * PFN_GetDpiForWindow)(HWND);
 typedef BOOL (WINAPI * PFN_AdjustWindowRectExForDpi)(LPRECT,DWORD,BOOL,DWORD,UINT);
+typedef BOOL (WINAPI * PFN_GetTouchInputInfo)(HTOUCHINPUT,UINT,PTOUCHINPUT,int);
+typedef BOOL (WINAPI * PFN_CloseTouchInputHandle)(HTOUCHINPUT);
+typedef BOOL (WINAPI * PFN_RegisterTouchWindow)(HWND,LONG);
+typedef BOOL (WINAPI * PFN_UnregisterTouchWindow)(HWND);
 #define SetProcessDPIAware _glfw.win32.user32.SetProcessDPIAware_
 #define ChangeWindowMessageFilterEx _glfw.win32.user32.ChangeWindowMessageFilterEx_
 #define EnableNonClientDpiScaling _glfw.win32.user32.EnableNonClientDpiScaling_
 #define SetProcessDpiAwarenessContext _glfw.win32.user32.SetProcessDpiAwarenessContext_
 #define GetDpiForWindow _glfw.win32.user32.GetDpiForWindow_
 #define AdjustWindowRectExForDpi _glfw.win32.user32.AdjustWindowRectExForDpi_
+#define GetTouchInputInfo _glfw.win32.user32.GetTouchInputInfo_
+#define CloseTouchInputHandle _glfw.win32.user32.CloseTouchInputHandle_
+#define RegisterTouchWindow _glfw.win32.user32.RegisterTouchWindow_
+#define UnregisterTouchWindow _glfw.win32.user32.UnregisterTouchWindow_
 
 // dwmapi.dll function pointer typedefs
 typedef HRESULT (WINAPI * PFN_DwmIsCompositionEnabled)(BOOL*);
@@ -366,7 +402,15 @@ typedef struct _GLFWlibraryWin32
         PFN_SetProcessDpiAwarenessContext SetProcessDpiAwarenessContext_;
         PFN_GetDpiForWindow             GetDpiForWindow_;
         PFN_AdjustWindowRectExForDpi    AdjustWindowRectExForDpi_;
+        PFN_GetTouchInputInfo           GetTouchInputInfo_;
+        PFN_CloseTouchInputHandle       CloseTouchInputHandle_;
+        PFN_RegisterTouchWindow         RegisterTouchWindow_;
+        PFN_UnregisterTouchWindow       UnregisterTouchWindow_;
     } user32;
+
+    struct {
+        GLFWbool                        available;
+    } touch;
 
     struct {
         HINSTANCE                       instance;

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -773,6 +773,13 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
         {
             int i, button, action;
 
+            if (window->touchInput)
+            {
+                // Skip emulated button events when touch input is enabled
+                if ((GetMessageExtraInfo() & 0xffffff00) == 0xff515700)
+                    break;
+            }
+
             if (uMsg == WM_LBUTTONDOWN || uMsg == WM_LBUTTONUP)
                 button = GLFW_MOUSE_BUTTON_LEFT;
             else if (uMsg == WM_RBUTTONDOWN || uMsg == WM_RBUTTONUP)
@@ -856,7 +863,9 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
             window->win32.lastCursorPosX = x;
             window->win32.lastCursorPosY = y;
 
-            return 0;
+            // NOTE: WM_MOUSEMOVE messages must be passed on to DefWindowProc
+            //       for WM_TOUCH messages to be emitted
+            break;
         }
 
         case WM_INPUT:
@@ -1065,6 +1074,60 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
             }
 
             return 0;
+        }
+
+        case WM_TOUCH:
+        {
+            TOUCHINPUT* inputs;
+            UINT count = LOWORD(wParam);
+
+            if (!_glfw.win32.touch.available)
+                return 0;
+
+            inputs = (TOUCHINPUT*) malloc(sizeof(TOUCHINPUT) * count);
+
+            if (GetTouchInputInfo((HTOUCHINPUT) lParam,
+                                        count, inputs, sizeof(TOUCHINPUT)))
+            {
+                UINT i;
+                int width, height, xpos, ypos;
+
+                _glfwPlatformGetWindowSize(window, &width, &height);
+                _glfwPlatformGetWindowPos(window, &xpos, &ypos);
+
+                for (i = 0;  i < count;  i++)
+                {
+                    int action;
+                    POINT pos;
+
+                    pos.x = TOUCH_COORD_TO_PIXEL(inputs[i].x) - xpos;
+                    pos.y = TOUCH_COORD_TO_PIXEL(inputs[i].y) - ypos;
+
+                    // Discard any points that lie outside of the client area
+                    if (pos.x < 0 || pos.x >= width ||
+                        pos.y < 0 || pos.y >= height)
+                    {
+                        continue;
+                    }
+
+                    if (inputs[i].dwFlags & TOUCHEVENTF_DOWN)
+                        action = GLFW_PRESS;
+                    else if (inputs[i].dwFlags & TOUCHEVENTF_UP)
+                        action = GLFW_RELEASE;
+                    else
+                        action = GLFW_MOVE;
+
+                    _glfwInputTouch(window,
+                                    (int) inputs[i].dwID, action,
+                                    inputs[i].x / 100.0 - xpos,
+                                    inputs[i].y / 100.0 - ypos);
+                }
+
+                CloseTouchInputHandle((HTOUCHINPUT) lParam);
+            }
+
+            free(inputs);
+            break;
         }
 
         case WM_PAINT:
@@ -1938,6 +2001,22 @@ void _glfwPlatformSetRawMouseMotion(_GLFWwindow *window, GLFWbool enabled)
 GLFWbool _glfwPlatformRawMouseMotionSupported(void)
 {
     return GLFW_TRUE;
+}
+
+void _glfwPlatformSetTouchInput(_GLFWwindow* window, int enabled)
+{
+    if (!_glfw.win32.touch.available)
+        return;
+
+    if (enabled)
+        RegisterTouchWindow(window->win32.handle, 0);
+    else
+        UnregisterTouchWindow(window->win32.handle);
+}
+
+GLFWbool _glfwPlatformTouchInputSupported(void)
+{
+    return _glfw.win32.touch.available;
 }
 
 void _glfwPlatformPollEvents(void)

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -1163,6 +1163,17 @@ GLFWbool _glfwPlatformRawMouseMotionSupported(void)
     return GLFW_TRUE;
 }
 
+void _glfwPlatformSetTouchInput(_GLFWwindow *window, GLFWbool enabled)
+{
+    _glfwInputError(GLFW_FEATURE_UNIMPLEMENTED,
+                    "Wayland: Touch input not yet implemented");
+}
+
+GLFWbool _glfwPlatformTouchInputSupported(void)
+{
+    return GLFW_FALSE;
+}
+
 void _glfwPlatformPollEvents(void)
 {
     handleEvents(0);

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -2771,6 +2771,17 @@ GLFWbool _glfwPlatformRawMouseMotionSupported(void)
     return _glfw.x11.xi.available;
 }
 
+void _glfwPlatformSetTouchInput(_GLFWwindow *window, GLFWbool enabled)
+{
+    _glfwInputError(GLFW_FEATURE_UNIMPLEMENTED,
+                    "Cocoa: Touch input not yet implemented");
+}
+
+GLFWbool _glfwPlatformTouchInputSupported(void)
+{
+    return GLFW_FALSE;
+}
+
 void _glfwPlatformPollEvents(void)
 {
     _GLFWwindow* window;

--- a/tests/events.c
+++ b/tests/events.c
@@ -51,6 +51,7 @@ typedef struct
     GLFWwindow* window;
     int number;
     int closeable;
+    int touch;
 } Slot;
 
 static void usage(void)
@@ -204,6 +205,8 @@ static const char* get_action_name(int action)
             return "released";
         case GLFW_REPEAT:
             return "repeated";
+        case GLFW_MOVE:
+            return "moved";
     }
 
     return "caused unknown action";
@@ -424,6 +427,15 @@ static void key_callback(GLFWwindow* window, int key, int scancode, int action, 
 
     switch (key)
     {
+        case GLFW_KEY_T:
+        {
+            slot->touch = !slot->touch;
+            glfwSetInputMode(window, GLFW_TOUCH, slot->touch);
+
+            printf("(( touch %s ))\n", slot->touch ? "enabled" : "disabled");
+            break;
+        }
+
         case GLFW_KEY_C:
         {
             slot->closeable = !slot->closeable;
@@ -490,6 +502,16 @@ static void monitor_callback(GLFWmonitor* monitor, int event)
                glfwGetTime(),
                glfwGetMonitorName(monitor));
     }
+}
+
+static void touch_callback(GLFWwindow* window, int touch, int action, double x, double y)
+{
+    printf("%08x at %0.3f: Touch %i %s at position %0.3f %0.3f\n",
+           counter++,
+           glfwGetTime(),
+           touch,
+           get_action_name(action),
+           x, y);
 }
 
 static void joystick_callback(int jid, int event)
@@ -594,6 +616,7 @@ int main(int argc, char** argv)
         char title[128];
 
         slots[i].closeable = GLFW_TRUE;
+        slots[i].touch = GLFW_FALSE;
         slots[i].number = i + 1;
 
         snprintf(title, sizeof(title), "Event Linter (Window %i)", slots[i].number);
@@ -638,6 +661,7 @@ int main(int argc, char** argv)
         glfwSetKeyCallback(slots[i].window, key_callback);
         glfwSetCharCallback(slots[i].window, char_callback);
         glfwSetDropCallback(slots[i].window, drop_callback);
+        glfwSetTouchCallback(slots[i].window, touch_callback);
 
         glfwMakeContextCurrent(slots[i].window);
         gladLoadGL(glfwGetProcAddress);


### PR DESCRIPTION
This PR proposes to add the generic API from the touch branch for receiving touch input.

There exists at least the following efforts, since at least 2013 (!), to add touch to GLFW:
- #42 The related touch branch was created by Quinten Lansu with additions (bananas!) from Camilla Löwy.
- #532 An effort was made in 2015 to get touch working on Wayland by linkmauve.
- #952 In 2017 Erik Sunden made a PR which (besides rebasing) proposed bundling touches before passing to callbacks.
- Related: #90 (trackpads, but #42 is mentioned in the discussions)

Now, I have a customer who needs touch to work in our application (voysys.se) so I need touch to work (which it does) at least in a fork for us. Platform for my project is Windows. I added a few hours to the work package to be able to make this PR with these changes to the upstream. (If it is merged is of course an open question for the maintainers/community.)

After reading through the previous efforts on touch, above, I came to the conclusion that I like the callback api in the touch branch. It is based on WM_TOUCH, which is available from windows 7. The effort in PR #532 to add Wayland support indicates that the approach will work for other platforms too. Raw touch points with id, state (press/move/release), and position are passed in. It is up to the user to add inertia, gestures, whatever. I think this is a clean, sane low level api for touch and that it is the right approach. Because who knows what people want to do with the touches.

What I have done:
- Rebased the touch branch on the latest upstream/master
- Updated comments, defines, styling, etc to be in line with what the current standards seems to be (hope I got it right?)
- Added a "glfwTouchInputSupported" to check for touch support (I'm open for removing this one - I took inspiration from the raw mouse support test function but that actually works slightly differently in that it is a per platform true/false thing. Touch is a platform, OS-version and also "does the user actually have a touch screen" question. Right now this function answers the platform and OS-version questions, but it doesn't know if the user has a touch screen.)
- Used this to build a simple pan+zoom touch interface in our application
- (I squashed the individual commits, because rebasing was easier this way and they did not build individually anyway)

I have tested this now on my laptop which has a touchscreen (surface book 2) and starting next week I will run tests on the target displays which are external multitouch monitors.

[2020-11-02] Update: this is running and working well on customer's site for a few months. Touch is the only input used, on two external touch monitors per pc. No issues has been reported.