### PR TITLE
Use switch statement instead of if-else-chain for cursor shapes

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -1635,14 +1635,21 @@ int _glfwPlatformCreateStandardCursor(_GLFWcursor* cursor, int shape)
     SEL cursorSelector = NULL;
 
     // HACK: Try to use a private message
-    if (shape == GLFW_RESIZE_EW_CURSOR)
-        cursorSelector = NSSelectorFromString(@"_windowResizeEastWestCursor");
-    else if (shape == GLFW_RESIZE_NS_CURSOR)
-        cursorSelector = NSSelectorFromString(@"_windowResizeNorthSouthCursor");
-    else if (shape == GLFW_RESIZE_NWSE_CURSOR)
-        cursorSelector = NSSelectorFromString(@"_windowResizeNorthWestSouthEastCursor");
-    else if (shape == GLFW_RESIZE_NESW_CURSOR)
-        cursorSelector = NSSelectorFromString(@"_windowResizeNorthEastSouthWestCursor");
+    switch (shape)
+    {
+        case GLFW_RESIZE_EW_CURSOR:
+            cursorSelector = NSSelectorFromString(@"_windowResizeEastWestCursor");
+            break;
+        case GLFW_RESIZE_NS_CURSOR:
+            cursorSelector = NSSelectorFromString(@"_windowResizeNorthSouthCursor");
+            break;
+        case GLFW_RESIZE_NWSE_CURSOR:
+            cursorSelector = NSSelectorFromString(@"_windowResizeNorthWestSouthEastCursor");
+            break;
+        case GLFW_RESIZE_NESW_CURSOR:
+            cursorSelector = NSSelectorFromString(@"_windowResizeNorthEastSouthWestCursor");
+            break;
+    }
 
     if (cursorSelector && [NSCursor respondsToSelector:cursorSelector])
     {
@@ -1653,22 +1660,33 @@ int _glfwPlatformCreateStandardCursor(_GLFWcursor* cursor, int shape)
 
     if (!cursor->ns.object)
     {
-        if (shape == GLFW_ARROW_CURSOR)
-            cursor->ns.object = [NSCursor arrowCursor];
-        else if (shape == GLFW_IBEAM_CURSOR)
-            cursor->ns.object = [NSCursor IBeamCursor];
-        else if (shape == GLFW_CROSSHAIR_CURSOR)
-            cursor->ns.object = [NSCursor crosshairCursor];
-        else if (shape == GLFW_POINTING_HAND_CURSOR)
-            cursor->ns.object = [NSCursor pointingHandCursor];
-        else if (shape == GLFW_RESIZE_EW_CURSOR)
-            cursor->ns.object = [NSCursor resizeLeftRightCursor];
-        else if (shape == GLFW_RESIZE_NS_CURSOR)
-            cursor->ns.object = [NSCursor resizeUpDownCursor];
-        else if (shape == GLFW_RESIZE_ALL_CURSOR)
-            cursor->ns.object = [NSCursor closedHandCursor];
-        else if (shape == GLFW_NOT_ALLOWED_CURSOR)
-            cursor->ns.object = [NSCursor operationNotAllowedCursor];
+        switch (shape)
+        {
+            case GLFW_ARROW_CURSOR:
+                cursor->ns.object = [NSCursor arrowCursor];
+                break;
+            case GLFW_IBEAM_CURSOR:
+                cursor->ns.object = [NSCursor IBeamCursor];
+                break;
+            case GLFW_CROSSHAIR_CURSOR:
+                cursor->ns.object = [NSCursor crosshairCursor];
+                break;
+            case GLFW_POINTING_HAND_CURSOR:
+                cursor->ns.object = [NSCursor pointingHandCursor];
+                break;
+            case GLFW_RESIZE_EW_CURSOR:
+                cursor->ns.object = [NSCursor resizeLeftRightCursor];
+                break;
+            case GLFW_RESIZE_NS_CURSOR:
+                cursor->ns.object = [NSCursor resizeUpDownCursor];
+                break;
+            case GLFW_RESIZE_ALL_CURSOR:
+                cursor->ns.object = [NSCursor closedHandCursor];
+                break;
+            case GLFW_NOT_ALLOWED_CURSOR:
+                cursor->ns.object = [NSCursor operationNotAllowedCursor];
+                break;
+        }
     }
 
     if (!cursor->ns.object)

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -2117,30 +2117,41 @@ int _glfwPlatformCreateStandardCursor(_GLFWcursor* cursor, int shape)
 {
     int id = 0;
 
-    if (shape == GLFW_ARROW_CURSOR)
-        id = OCR_NORMAL;
-    else if (shape == GLFW_IBEAM_CURSOR)
-        id = OCR_IBEAM;
-    else if (shape == GLFW_CROSSHAIR_CURSOR)
-        id = OCR_CROSS;
-    else if (shape == GLFW_POINTING_HAND_CURSOR)
-        id = OCR_HAND;
-    else if (shape == GLFW_RESIZE_EW_CURSOR)
-        id = OCR_SIZEWE;
-    else if (shape == GLFW_RESIZE_NS_CURSOR)
-        id = OCR_SIZENS;
-    else if (shape == GLFW_RESIZE_NWSE_CURSOR)
-        id = OCR_SIZENWSE;
-    else if (shape == GLFW_RESIZE_NESW_CURSOR)
-        id = OCR_SIZENESW;
-    else if (shape == GLFW_RESIZE_ALL_CURSOR)
-        id = OCR_SIZEALL;
-    else if (shape == GLFW_NOT_ALLOWED_CURSOR)
-        id = OCR_NO;
-    else
+    switch (shape)
     {
-        _glfwInputError(GLFW_PLATFORM_ERROR, "Win32: Unknown standard cursor");
-        return GLFW_FALSE;
+        case GLFW_ARROW_CURSOR:
+            id = OCR_NORMAL;
+            break;
+        case GLFW_IBEAM_CURSOR:
+            id = OCR_IBEAM;
+            break;
+        case GLFW_CROSSHAIR_CURSOR:
+            id = OCR_CROSS;
+            break;
+        case GLFW_POINTING_HAND_CURSOR:
+            id = OCR_HAND;
+            break;
+        case GLFW_RESIZE_EW_CURSOR:
+            id = OCR_SIZEWE;
+            break;
+        case GLFW_RESIZE_NS_CURSOR:
+            id = OCR_SIZENS;
+            break;
+        case GLFW_RESIZE_NWSE_CURSOR:
+            id = OCR_SIZENWSE;
+            break;
+        case GLFW_RESIZE_NESW_CURSOR:
+            id = OCR_SIZENESW;
+            break;
+        case GLFW_RESIZE_ALL_CURSOR:
+            id = OCR_SIZEALL;
+            break;
+        case GLFW_NOT_ALLOWED_CURSOR:
+            id = OCR_NO;
+            break;
+        default:
+            _glfwInputError(GLFW_PLATFORM_ERROR, "Win32: Unknown standard cursor");
+            return GLFW_FALSE;
     }
 
     cursor->win32.handle = LoadImageW(NULL,

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -1242,26 +1242,39 @@ int _glfwPlatformCreateStandardCursor(_GLFWcursor* cursor, int shape)
     const char* name = NULL;
 
     // Try the XDG names first
-    if (shape == GLFW_ARROW_CURSOR)
-        name = "default";
-    else if (shape == GLFW_IBEAM_CURSOR)
-        name = "text";
-    else if (shape == GLFW_CROSSHAIR_CURSOR)
-        name = "crosshair";
-    else if (shape == GLFW_POINTING_HAND_CURSOR)
-        name = "pointer";
-    else if (shape == GLFW_RESIZE_EW_CURSOR)
-        name = "ew-resize";
-    else if (shape == GLFW_RESIZE_NS_CURSOR)
-        name = "ns-resize";
-    else if (shape == GLFW_RESIZE_NWSE_CURSOR)
-        name = "nwse-resize";
-    else if (shape == GLFW_RESIZE_NESW_CURSOR)
-        name = "nesw-resize";
-    else if (shape == GLFW_RESIZE_ALL_CURSOR)
-        name = "all-scroll";
-    else if (shape == GLFW_NOT_ALLOWED_CURSOR)
-        name = "not-allowed";
+    switch (shape)
+    {
+        case GLFW_ARROW_CURSOR:
+            name = "default";
+            break;
+        case GLFW_IBEAM_CURSOR:
+            name = "text";
+            break;
+        case GLFW_CROSSHAIR_CURSOR:
+            name = "crosshair";
+            break;
+        case GLFW_POINTING_HAND_CURSOR:
+            name = "pointer";
+            break;
+        case GLFW_RESIZE_EW_CURSOR:
+            name = "ew-resize";
+            break;
+        case GLFW_RESIZE_NS_CURSOR:
+            name = "ns-resize";
+            break;
+        case GLFW_RESIZE_NWSE_CURSOR:
+            name = "nwse-resize";
+            break;
+        case GLFW_RESIZE_NESW_CURSOR:
+            name = "nesw-resize";
+            break;
+        case GLFW_RESIZE_ALL_CURSOR:
+            name = "all-scroll";
+            break;
+        case GLFW_NOT_ALLOWED_CURSOR:
+            name = "not-allowed";
+            break;
+    }
 
     cursor->wl.cursor = wl_cursor_theme_get_cursor(_glfw.wl.cursorTheme, name);
 
@@ -1274,25 +1287,26 @@ int _glfwPlatformCreateStandardCursor(_GLFWcursor* cursor, int shape)
     if (!cursor->wl.cursor)
     {
         // Fall back to the core X11 names
-        if (shape == GLFW_ARROW_CURSOR)
-            name = "left_ptr";
-        else if (shape == GLFW_IBEAM_CURSOR)
-            name = "xterm";
-        else if (shape == GLFW_CROSSHAIR_CURSOR)
-            name = "crosshair";
-        else if (shape == GLFW_POINTING_HAND_CURSOR)
-            name = "hand2";
-        else if (shape == GLFW_RESIZE_EW_CURSOR)
-            name = "sb_h_double_arrow";
-        else if (shape == GLFW_RESIZE_NS_CURSOR)
-            name = "sb_v_double_arrow";
-        else if (shape == GLFW_RESIZE_ALL_CURSOR)
-            name = "fleur";
-        else
+        switch (shape)
         {
-            _glfwInputError(GLFW_CURSOR_UNAVAILABLE,
-                            "Wayland: Standard cursor shape unavailable");
-            return GLFW_FALSE;
+            case GLFW_ARROW_CURSOR:
+                name = "left_ptr";
+            case GLFW_IBEAM_CURSOR:
+                name = "xterm";
+            case GLFW_CROSSHAIR_CURSOR:
+                name = "crosshair";
+            case GLFW_POINTING_HAND_CURSOR:
+                name = "hand2";
+            case GLFW_RESIZE_EW_CURSOR:
+                name = "sb_h_double_arrow";
+            case GLFW_RESIZE_NS_CURSOR:
+                name = "sb_v_double_arrow";
+            case GLFW_RESIZE_ALL_CURSOR:
+                name = "fleur";
+            default:
+                _glfwInputError(GLFW_CURSOR_UNAVAILABLE,
+                                "Wayland: Standard cursor shape unavailable");
+                return GLFW_FALSE;
         }
 
         cursor->wl.cursor = wl_cursor_theme_get_cursor(_glfw.wl.cursorTheme, name);

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -2935,26 +2935,39 @@ int _glfwPlatformCreateStandardCursor(_GLFWcursor* cursor, int shape)
             const int size = XcursorGetDefaultSize(_glfw.x11.display);
             const char* name = NULL;
 
-            if (shape == GLFW_ARROW_CURSOR)
-                name = "default";
-            else if (shape == GLFW_IBEAM_CURSOR)
-                name = "text";
-            else if (shape == GLFW_CROSSHAIR_CURSOR)
-                name = "crosshair";
-            else if (shape == GLFW_POINTING_HAND_CURSOR)
-                name = "pointer";
-            else if (shape == GLFW_RESIZE_EW_CURSOR)
-                name = "ew-resize";
-            else if (shape == GLFW_RESIZE_NS_CURSOR)
-                name = "ns-resize";
-            else if (shape == GLFW_RESIZE_NWSE_CURSOR)
-                name = "nwse-resize";
-            else if (shape == GLFW_RESIZE_NESW_CURSOR)
-                name = "nesw-resize";
-            else if (shape == GLFW_RESIZE_ALL_CURSOR)
-                name = "all-scroll";
-            else if (shape == GLFW_NOT_ALLOWED_CURSOR)
-                name = "not-allowed";
+            switch (shape)
+            {
+                case GLFW_ARROW_CURSOR:
+                    name = "default";
+                    break;
+                case GLFW_IBEAM_CURSOR:
+                    name = "text";
+                    break;
+                case GLFW_CROSSHAIR_CURSOR:
+                    name = "crosshair";
+                    break;
+                case GLFW_POINTING_HAND_CURSOR:
+                    name = "pointer";
+                    break;
+                case GLFW_RESIZE_EW_CURSOR:
+                    name = "ew-resize";
+                    break;
+                case GLFW_RESIZE_NS_CURSOR:
+                    name = "ns-resize";
+                    break;
+                case GLFW_RESIZE_NWSE_CURSOR:
+                    name = "nwse-resize";
+                    break;
+                case GLFW_RESIZE_NESW_CURSOR:
+                    name = "nesw-resize";
+                    break;
+                case GLFW_RESIZE_ALL_CURSOR:
+                    name = "all-scroll";
+                    break;
+                case GLFW_NOT_ALLOWED_CURSOR:
+                    name = "not-allowed";
+                    break;
+            }
 
             XcursorImage* image = XcursorLibraryLoadImage(name, theme, size);
             if (image)
@@ -2969,25 +2982,33 @@ int _glfwPlatformCreateStandardCursor(_GLFWcursor* cursor, int shape)
     {
         unsigned int native = 0;
 
-        if (shape == GLFW_ARROW_CURSOR)
-            native = XC_left_ptr;
-        else if (shape == GLFW_IBEAM_CURSOR)
-            native = XC_xterm;
-        else if (shape == GLFW_CROSSHAIR_CURSOR)
-            native = XC_crosshair;
-        else if (shape == GLFW_POINTING_HAND_CURSOR)
-            native = XC_hand2;
-        else if (shape == GLFW_RESIZE_EW_CURSOR)
-            native = XC_sb_h_double_arrow;
-        else if (shape == GLFW_RESIZE_NS_CURSOR)
-            native = XC_sb_v_double_arrow;
-        else if (shape == GLFW_RESIZE_ALL_CURSOR)
-            native = XC_fleur;
-        else
+        switch (shape)
         {
-            _glfwInputError(GLFW_CURSOR_UNAVAILABLE,
-                            "X11: Standard cursor shape unavailable");
-            return GLFW_FALSE;
+            case GLFW_ARROW_CURSOR:
+                native = XC_left_ptr;
+                break;
+            case GLFW_IBEAM_CURSOR:
+                native = XC_xterm;
+                break;
+            case GLFW_CROSSHAIR_CURSOR:
+                native = XC_crosshair;
+                break;
+            case GLFW_POINTING_HAND_CURSOR:
+                native = XC_hand2;
+                break;
+            case GLFW_RESIZE_EW_CURSOR:
+                native = XC_sb_h_double_arrow;
+                break;
+            case GLFW_RESIZE_NS_CURSOR:
+                native = XC_sb_v_double_arrow;
+                break;
+            case GLFW_RESIZE_ALL_CURSOR:
+                native = XC_fleur;
+                break;
+            default:
+                _glfwInputError(GLFW_CURSOR_UNAVAILABLE,
+                                "X11: Standard cursor shape unavailable");
+                return GLFW_FALSE;
         }
 
         cursor->x11.handle = XCreateFontCursor(_glfw.x11.display, native);


### PR DESCRIPTION
I propose replacing the if-else-chains for the cursor shapes with switch statements. Since the C language provides this construct for this exact purpose, I think we should use it. Is there any reason not to do that?