### PR TITLE
Make _glfwPlatformInitJoysticks() return the correct type in null_joystick

### DIFF
--- a/src/null_joystick.c
+++ b/src/null_joystick.c
@@ -33,7 +33,7 @@
 //////                       GLFW platform API                      //////
 //////////////////////////////////////////////////////////////////////////
 
-int _glfwPlatformInitJoysticks(void)
+GLFWbool _glfwPlatformInitJoysticks(void)
 {
     return GLFW_TRUE;
 }


### PR DESCRIPTION
This code was introduced in 782e6b6cefc9ac2a2b6779f9e658ab948809253b.
All the other instances of `_glfwPlatformInitJoysticks()` also return `GLFWbool`.

Closes #1745.