### PR TITLE
Win32 update monitor handles when monitors are added or removed

### DIFF
--- a/src/win32_monitor.c
+++ b/src/win32_monitor.c
@@ -185,6 +185,8 @@ void _glfwPollMonitorsWin32(void)
                            display.DeviceName) == 0)
                 {
                     disconnected[i] = NULL;
+                    // handle may have changed, update
+                    EnumDisplayMonitors(NULL, NULL, monitorCallback, (LPARAM) _glfw.monitors[i]);
                     break;
                 }
             }


### PR DESCRIPTION
On Windows, when a monitor is added or removed (or in some cases just a display setting change is made), the monitor display handle can change.

Currently GLFW does not update handles for monitors whose names remain the same after a monitor change, which results in calls to some functions which need the monitor handle, such as ```glfwGetMonitorWorkArea``` to fail.

This PR has the minimal change needed to fix this by updating the monitor handle. A larger code change could be made which would minimize the computation, but as monitor changes are infrequent and also take some time this is a decent enough and minimal solution.

This should fix issue #1676