### PR TITLE
Desktop Environment freezes when GLFW Window width or height is >32767

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ information on what to include when reporting a bug.
    combinaitons (#1598)
  - [X11] Bugfix: Keys pressed simultaneously with others were not always
    reported (#1112,#1415,#1472,#1616)
+ - [X11] Bugfix: Desktop Environment freezes when window width or height is
+   over 32767
  - [Wayland] Removed support for `wl_shell` (#1443)
  - [Wayland] Bugfix: The `GLFW_HAND_CURSOR` shape used the wrong image (#1432)
  - [Wayland] Bugfix: `CLOCK_MONOTONIC` was not correctly enabled

--- a/src/window.c
+++ b/src/window.c
@@ -162,10 +162,12 @@ GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height,
     assert(title != NULL);
     assert(width >= 0);
     assert(height >= 0);
+    assert(width <= 32767);
+    assert(height <= 32767);
 
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
 
-    if (width <= 0 || height <= 0)
+    if (width <= 0 || height <= 0 || width > 32767 || height > 32767)
     {
         _glfwInputError(GLFW_INVALID_VALUE,
                         "Invalid window size %ix%i",
@@ -941,10 +943,12 @@ GLFWAPI void glfwSetWindowMonitor(GLFWwindow* wh,
     assert(window != NULL);
     assert(width >= 0);
     assert(height >= 0);
+    assert(width <= 32767);
+    assert(height <= 32767);
 
     _GLFW_REQUIRE_INIT();
 
-    if (width <= 0 || height <= 0)
+    if (width <= 0 || height <= 0 || width > 32767 || height > 32767)
     {
         _glfwInputError(GLFW_INVALID_VALUE,
                         "Invalid window size %ix%i",


### PR DESCRIPTION
I found this bug while working with the GLFW library with Open3D. 

Basically, if you set the width or height to 32768 in the `boing.c` example, the entire desktop would freeze. While stepping through the code, the program would freeze at `XCheckTypedWindowEvent` in [x11_window.c:114](https://github.com/glfw/glfw/blob/96f9f5c4b970140ab5380fb9886ba787c8698937/src/x11_window.c#L114).

I thought it made sense to add the `assert` statements to check for `width > 32767` and `height > 32767` because if you remove the asserts that are already present in the function, and the if statement to check if `width or height <= 0`, then the desktop environment will freeze in a similar way when you set the `width or height > 32767`.

OS: `Linux 5.4.0-47-generic #51~18.04.1-Ubuntu SMP Sat Sep 5 14:35:50 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux`
xserver-xorg-core version: `1.20.8-2ubuntu2.2~18.04.3`
Release or commit: 96f9f5c4b970140ab5380fb9886ba787c8698937 (latest commit)
Error messages: None because the system needs to be restarted.