### PR TITLE
remove ECM dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,10 +52,6 @@ src/glfw_config.h
 src/glfw3.pc
 src/glfw3Config.cmake
 src/glfw3ConfigVersion.cmake
-src/wayland-pointer-constraints-unstable-v1-client-protocol.h
-src/wayland-pointer-constraints-unstable-v1-protocol.c
-src/wayland-relative-pointer-unstable-v1-client-protocol.h
-src/wayland-relative-pointer-unstable-v1-protocol.c
 
 # Compiled binaries
 src/libglfw.so

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,20 +191,18 @@ endif()
 # Use Wayland for window creation
 #--------------------------------------------------------------------
 if (_GLFW_WAYLAND)
-    find_package(ECM REQUIRED NO_MODULE)
-    list(APPEND CMAKE_MODULE_PATH "${ECM_MODULE_PATH}")
 
-    find_package(Wayland REQUIRED Client Cursor Egl)
-    find_package(WaylandScanner REQUIRED)
-    find_package(WaylandProtocols 1.15 REQUIRED)
+    include(FindPkgConfig)
+    pkg_check_modules(Wayland REQUIRED
+        wayland-client>=0.2.7
+        wayland-cursor>=0.2.7
+        wayland-egl>=0.2.7
+        xkbcommon)
 
     list(APPEND glfw_PKG_DEPS "wayland-client")
 
     list(APPEND glfw_INCLUDE_DIRS "${Wayland_INCLUDE_DIRS}")
-    list(APPEND glfw_LIBRARIES "${Wayland_LIBRARIES}")
-
-    find_package(XKBCommon REQUIRED)
-    list(APPEND glfw_INCLUDE_DIRS "${XKBCOMMON_INCLUDE_DIRS}")
+    list(APPEND glfw_LIBRARIES "${Wayland_LINK_LIBRARIES}")
 
     include(CheckIncludeFiles)
     include(CheckFunctionExists)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,30 +45,44 @@ if (_GLFW_X11 OR _GLFW_WAYLAND)
 endif()
 
 if (_GLFW_WAYLAND)
-    ecm_add_wayland_client_protocol(GLFW_WAYLAND_PROTOCOL_SOURCES
-        PROTOCOL
-        "${WAYLAND_PROTOCOLS_PKGDATADIR}/stable/xdg-shell/xdg-shell.xml"
-        BASENAME xdg-shell)
-    ecm_add_wayland_client_protocol(GLFW_WAYLAND_PROTOCOL_SOURCES
-        PROTOCOL
-        "${WAYLAND_PROTOCOLS_PKGDATADIR}/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml"
-        BASENAME xdg-decoration)
-    ecm_add_wayland_client_protocol(GLFW_WAYLAND_PROTOCOL_SOURCES
-        PROTOCOL
-        "${WAYLAND_PROTOCOLS_PKGDATADIR}/stable/viewporter/viewporter.xml"
-        BASENAME viewporter)
-    ecm_add_wayland_client_protocol(GLFW_WAYLAND_PROTOCOL_SOURCES
-        PROTOCOL
-        "${WAYLAND_PROTOCOLS_PKGDATADIR}/unstable/relative-pointer/relative-pointer-unstable-v1.xml"
-        BASENAME relative-pointer-unstable-v1)
-    ecm_add_wayland_client_protocol(GLFW_WAYLAND_PROTOCOL_SOURCES
-        PROTOCOL
-        "${WAYLAND_PROTOCOLS_PKGDATADIR}/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml"
-        BASENAME pointer-constraints-unstable-v1)
-    ecm_add_wayland_client_protocol(GLFW_WAYLAND_PROTOCOL_SOURCES
-        PROTOCOL
-        "${WAYLAND_PROTOCOLS_PKGDATADIR}/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml"
-        BASENAME idle-inhibit-unstable-v1)
+    find_program(WAYLAND_SCANNER_EXECUTABLE NAMES wayland-scanner)
+    pkg_check_modules(WAYLAND_PROTOCOLS REQUIRED wayland-protocols>=1.15)
+    pkg_get_variable(WAYLAND_PROTOCOLS_BASE wayland-protocols pkgdatadir)
+
+    macro(wayland_generate protocol_file output_file)
+          add_custom_command(OUTPUT ${output_file}.h
+              COMMAND ${WAYLAND_SCANNER_EXECUTABLE} client-header
+              < ${protocol_file} > ${output_file}.h
+              DEPENDS ${protocol_file})
+          list(APPEND GLFW_WAYLAND_PROTOCOL_SOURCES ${output_file}.h)
+
+          add_custom_command(OUTPUT ${output_file}.c 
+              COMMAND ${WAYLAND_SCANNER_EXECUTABLE} private-code
+              < ${protocol_file} > ${output_file}.c
+              DEPENDS ${protocol_file})
+          list(APPEND GLFW_WAYLAND_PROTOCOL_SOURCES ${output_file}.c)
+    endmacro()
+
+    set(GLFW_WAYLAND_PROTOCOL_SOURCES)
+    wayland_generate(
+        ${WAYLAND_PROTOCOLS_BASE}/stable/xdg-shell/xdg-shell.xml
+        ${CMAKE_BINARY_DIR}/src/wayland-xdg-shell-client-protocol)
+    wayland_generate(
+        ${WAYLAND_PROTOCOLS_BASE}/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml
+        ${CMAKE_BINARY_DIR}/src/wayland-xdg-decoration-client-protocol)
+    wayland_generate(
+        ${WAYLAND_PROTOCOLS_BASE}/stable/viewporter/viewporter.xml
+        ${CMAKE_BINARY_DIR}/src/wayland-viewporter-client-protocol)
+    wayland_generate(
+        ${WAYLAND_PROTOCOLS_BASE}/unstable/relative-pointer/relative-pointer-unstable-v1.xml
+        ${CMAKE_BINARY_DIR}/src/wayland-relative-pointer-unstable-v1-client-protocol)
+    wayland_generate(
+        ${WAYLAND_PROTOCOLS_BASE}/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml
+        ${CMAKE_BINARY_DIR}/src/wayland-pointer-constraints-unstable-v1-client-protocol)
+    wayland_generate(
+        ${WAYLAND_PROTOCOLS_BASE}/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml
+        ${CMAKE_BINARY_DIR}/src/wayland-idle-inhibit-unstable-v1-client-protocol)
+
     target_sources(glfw PRIVATE ${GLFW_WAYLAND_PROTOCOL_SOURCES})
 endif()
 


### PR DESCRIPTION
This PR removes the ECM build dependency for Wayland.

This PR was built and tested on Ubuntu 18.04.5 LTS and Yocto Dunfell.