### PR TITLE
create missing directory and use proper binary folder

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,38 +50,38 @@ if (_GLFW_WAYLAND)
     pkg_get_variable(WAYLAND_PROTOCOLS_BASE wayland-protocols pkgdatadir)
 
     macro(wayland_generate protocol_file output_file)
-          add_custom_command(OUTPUT ${output_file}.h
-              COMMAND ${WAYLAND_SCANNER_EXECUTABLE} client-header
-              < ${protocol_file} > ${output_file}.h
-              DEPENDS ${protocol_file})
-          list(APPEND GLFW_WAYLAND_PROTOCOL_SOURCES ${output_file}.h)
+        add_custom_command(OUTPUT ${output_file}.h
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${GLFW_BINARY_DIR}/src
+            COMMAND ${WAYLAND_SCANNER_EXECUTABLE} client-header < ${protocol_file} > ${output_file}.h
+            DEPENDS ${protocol_file})
+        list(APPEND GLFW_WAYLAND_PROTOCOL_SOURCES ${output_file}.h)
 
-          add_custom_command(OUTPUT ${output_file}.c
-              COMMAND ${WAYLAND_SCANNER_EXECUTABLE} private-code
-              < ${protocol_file} > ${output_file}.c
-              DEPENDS ${protocol_file})
-          list(APPEND GLFW_WAYLAND_PROTOCOL_SOURCES ${output_file}.c)
+        add_custom_command(OUTPUT ${output_file}.c
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${GLFW_BINARY_DIR}/src
+            COMMAND ${WAYLAND_SCANNER_EXECUTABLE} private-code < ${protocol_file} > ${output_file}.c
+            DEPENDS ${protocol_file})
+        list(APPEND GLFW_WAYLAND_PROTOCOL_SOURCES ${output_file}.c)
     endmacro()
 
     set(GLFW_WAYLAND_PROTOCOL_SOURCES)
     wayland_generate(
         ${WAYLAND_PROTOCOLS_BASE}/stable/xdg-shell/xdg-shell.xml
-        ${CMAKE_BINARY_DIR}/src/wayland-xdg-shell-client-protocol)
+        ${GLFW_BINARY_DIR}/src/wayland-xdg-shell-client-protocol)
     wayland_generate(
         ${WAYLAND_PROTOCOLS_BASE}/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml
-        ${CMAKE_BINARY_DIR}/src/wayland-xdg-decoration-client-protocol)
+        ${GLFW_BINARY_DIR}/src/wayland-xdg-decoration-client-protocol)
     wayland_generate(
         ${WAYLAND_PROTOCOLS_BASE}/stable/viewporter/viewporter.xml
-        ${CMAKE_BINARY_DIR}/src/wayland-viewporter-client-protocol)
+        ${GLFW_BINARY_DIR}/src/wayland-viewporter-client-protocol)
     wayland_generate(
         ${WAYLAND_PROTOCOLS_BASE}/unstable/relative-pointer/relative-pointer-unstable-v1.xml
-        ${CMAKE_BINARY_DIR}/src/wayland-relative-pointer-unstable-v1-client-protocol)
+        ${GLFW_BINARY_DIR}/src/wayland-relative-pointer-unstable-v1-client-protocol)
     wayland_generate(
         ${WAYLAND_PROTOCOLS_BASE}/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml
-        ${CMAKE_BINARY_DIR}/src/wayland-pointer-constraints-unstable-v1-client-protocol)
+        ${GLFW_BINARY_DIR}/src/wayland-pointer-constraints-unstable-v1-client-protocol)
     wayland_generate(
         ${WAYLAND_PROTOCOLS_BASE}/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml
-        ${CMAKE_BINARY_DIR}/src/wayland-idle-inhibit-unstable-v1-client-protocol)
+        ${GLFW_BINARY_DIR}/src/wayland-idle-inhibit-unstable-v1-client-protocol)
 
     target_sources(glfw PRIVATE ${GLFW_WAYLAND_PROTOCOL_SOURCES})
 endif()


### PR DESCRIPTION
Fixes item misses in last PR.
- If ran on clean tree, it would fail as nothing was creating the src directory.
- If using add_directory scheme, build fails as source files were going to incorrect folder.

