### PR TITLE
Wayland: Assume 96 DPI if physical size is <= 0

### DIFF
--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -1038,6 +1038,8 @@ int _glfwPlatformInit(void)
     char *cursorSizeEnd;
     long cursorSizeLong;
     int cursorSize;
+    int i;
+    _GLFWmonitor* monitor;
 
     _glfw.wl.cursor.handle = _glfw_dlopen("libwayland-cursor.so.0");
     if (!_glfw.wl.cursor.handle)
@@ -1145,6 +1147,17 @@ int _glfwPlatformInit(void)
 
     // Sync so we got all initial output events
     wl_display_roundtrip(_glfw.wl.display);
+
+    for (i = 0; i < _glfw.monitorCount; ++i)
+    {
+        monitor = _glfw.monitors[i];
+        if (monitor->widthMM <= 0 || monitor->heightMM <= 0)
+        {
+            // If Wayland does not provide a physical size, assume the default 96 DPI
+            monitor->widthMM  = (int) (monitor->modes[monitor->wl.currentMode].width * 25.4f / 96.f);
+            monitor->heightMM = (int) (monitor->modes[monitor->wl.currentMode].height * 25.4f / 96.f);
+        }
+    }
 
     _glfwInitTimerPOSIX();
 


### PR DESCRIPTION
This fallback is similar to the one performed in the "X11: Assume 96 DPI if RandR Monitor Size is zero" commit: https://github.com/glfw/glfw/commit/e96dc5d2199032d565b55c4177820ab28b1d67c9

Nicolas Caramelli