### PR TITLE
Init hint to pick VK_KHR_xlib_surface instead of VK_KHR_xcb_surface

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -1250,6 +1250,11 @@ extern "C" {
  *  macOS specific [init hint](@ref GLFW_COCOA_MENUBAR_hint).
  */
 #define GLFW_COCOA_MENUBAR          0x00051002
+/*! @brief X11 specific init hint.
+ *
+ *  X11 specific [init hint](@ref GLFW_X11_XCB_hint).
+ */
+#define GLFW_X11_XCB                0x00051003
 /*! @} */
 
 #define GLFW_DONT_CARE              -1

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -1252,9 +1252,9 @@ extern "C" {
 #define GLFW_COCOA_MENUBAR          0x00051002
 /*! @brief X11 specific init hint.
  *
- *  X11 specific [init hint](@ref GLFW_X11_XCB_hint).
+ *  X11 specific [init hint](@ref GLFW_X11_XCB_VULKAN_SURFACE_hint).
  */
-#define GLFW_X11_XCB                0x00051003
+#define GLFW_X11_XCB_VULKAN_SURFACE 0x00052001
 /*! @} */
 
 #define GLFW_DONT_CARE              -1

--- a/src/init.c
+++ b/src/init.c
@@ -57,7 +57,8 @@ static _GLFWinitconfig _glfwInitHints =
     {
         GLFW_TRUE,  // macOS menu bar
         GLFW_TRUE   // macOS bundle chdir
-    }
+    },
+    GLFW_TRUE,      // X11 XCB
 };
 
 // Terminate the library
@@ -297,6 +298,9 @@ GLFWAPI void glfwInitHint(int hint, int value)
             return;
         case GLFW_COCOA_MENUBAR:
             _glfwInitHints.ns.menubar = value;
+            return;
+        case GLFW_X11_XCB:
+            _glfwInitHints.x11_xcb = value;
             return;
     }
 

--- a/src/init.c
+++ b/src/init.c
@@ -58,7 +58,9 @@ static _GLFWinitconfig _glfwInitHints =
         GLFW_TRUE,  // macOS menu bar
         GLFW_TRUE   // macOS bundle chdir
     },
-    GLFW_TRUE,      // X11 XCB
+    {
+        GLFW_TRUE,  // X11 XCB Vulkan surface
+    },
 };
 
 // Terminate the library
@@ -299,8 +301,8 @@ GLFWAPI void glfwInitHint(int hint, int value)
         case GLFW_COCOA_MENUBAR:
             _glfwInitHints.ns.menubar = value;
             return;
-        case GLFW_X11_XCB:
-            _glfwInitHints.x11_xcb = value;
+        case GLFW_X11_XCB_VULKAN_SURFACE:
+            _glfwInitHints.x11.xcbVulkanSurface = value;
             return;
     }
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -248,7 +248,9 @@ struct _GLFWinitconfig
         GLFWbool  menubar;
         GLFWbool  chdir;
     } ns;
-    GLFWbool      x11_xcb;
+    struct {
+        GLFWbool  xcbVulkanSurface;
+    } x11;
 };
 
 // Window configuration

--- a/src/internal.h
+++ b/src/internal.h
@@ -248,6 +248,7 @@ struct _GLFWinitconfig
         GLFWbool  menubar;
         GLFWbool  chdir;
     } ns;
+    GLFWbool      x11_xcb;
 };
 
 // Window configuration

--- a/src/x11_init.c
+++ b/src/x11_init.c
@@ -813,11 +813,15 @@ static GLFWbool initExtensions(void)
                               XkbGroupStateMask, XkbGroupStateMask);
     }
 
+    if (!getenv("GLFW_NO_XCB"))
+    {
 #if defined(__CYGWIN__)
-    _glfw.x11.x11xcb.handle = _glfw_dlopen("libX11-xcb-1.so");
+        _glfw.x11.x11xcb.handle = _glfw_dlopen("libX11-xcb-1.so");
 #else
-    _glfw.x11.x11xcb.handle = _glfw_dlopen("libX11-xcb.so.1");
+        _glfw.x11.x11xcb.handle = _glfw_dlopen("libX11-xcb.so.1");
 #endif
+    }
+
     if (_glfw.x11.x11xcb.handle)
     {
         _glfw.x11.x11xcb.GetXCBConnection = (PFN_XGetXCBConnection)

--- a/src/x11_init.c
+++ b/src/x11_init.c
@@ -813,7 +813,7 @@ static GLFWbool initExtensions(void)
                               XkbGroupStateMask, XkbGroupStateMask);
     }
 
-    if (_glfw.hints.init.x11_xcb)
+    if (_glfw.hints.init.x11.xcbVulkanSurface)
     {
 #if defined(__CYGWIN__)
         _glfw.x11.x11xcb.handle = _glfw_dlopen("libX11-xcb-1.so");

--- a/src/x11_init.c
+++ b/src/x11_init.c
@@ -813,7 +813,7 @@ static GLFWbool initExtensions(void)
                               XkbGroupStateMask, XkbGroupStateMask);
     }
 
-    if (!getenv("GLFW_NO_XCB"))
+    if (_glfw.hints.init.x11_xcb)
     {
 #if defined(__CYGWIN__)
         _glfw.x11.x11xcb.handle = _glfw_dlopen("libX11-xcb-1.so");


### PR DESCRIPTION
If libX11-xcb.so is available on the system, the VK_KHR_xcb_surface extension is used and there is no way to force the use of the VK_KHR_xlib_surface extension.
This change adds the GLFW_NO_XCB environment variable to do this, but a better workaround might exist.

Nicolas Caramelli