### PR TITLE
Added dumb fix for disabled cursor snapping to center

### DIFF
--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -1452,7 +1452,11 @@ static void processEvent(XEvent *event)
                 updateCursorImage(window);
 
             _glfwInputCursorEnter(window, GLFW_TRUE);
-            _glfwInputCursorPos(window, x, y);
+
+            // Don't call the cursor callback when GLFW_CURSOR_DISABLED for
+            // this event, it snaps the cursor back to the center
+            if (window->cursorMode != GLFW_CURSOR_DISABLED)
+              _glfwInputCursorPos(window, x, y);
 
             window->x11.lastCursorPosX = x;
             window->x11.lastCursorPosY = y;


### PR DESCRIPTION
This is a fix for https://github.com/glfw/glfw/issues/1790

The cursor callback was being called, snapping the cursor back to the center of the window, when the cursor was disabled.

This PR disables calling the cursor callback for 'EnterNotify' X11 events, which seemed to be the root of the snapping. This seems to fix all the issues I was having.

Unsure whether this is the correct solution, since I don't understand the purpose of the GLFW cursor warping - with this change, the virtual cursor position will grow and grow to quite absurd sizes. This might not be the correct fix!