### PR TITLE
wl: Fix destroying CSDs in the correct order

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ information on what to include when reporting a bug.
  - [Wayland] Bugfix: Retrieving partial framebuffer size would segfault
  - [Wayland] Bugfix: Scrolling offsets were inverted compared to other platforms
    (#1463)
+ - [Wayland] Bugfix: Client-Side Decorations were destroyed in the wrong worder
  - [POSIX] Bugfix: `CLOCK_MONOTONIC` was not correctly tested for or enabled
  - [NSGL] Removed enforcement of forward-compatible flag for core contexts
  - [NSGL] Bugfix: `GLFW_COCOA_RETINA_FRAMEBUFFER` had no effect on newer
@@ -436,6 +437,7 @@ skills.
  - Santi Zupancic
  - Jonas Ådahl
  - Lasse Öörni
+ - Leonard König
  - All the unmentioned and anonymous contributors in the GLFW community, for bug
    reports, patches, feedback, testing and encouragement
 

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -246,10 +246,10 @@ static void createDecorations(_GLFWwindow* window)
 
 static void destroyDecoration(_GLFWdecorationWayland* decoration)
 {
-    if (decoration->surface)
-        wl_surface_destroy(decoration->surface);
     if (decoration->subsurface)
         wl_subsurface_destroy(decoration->subsurface);
+    if (decoration->surface)
+        wl_surface_destroy(decoration->surface);
     if (decoration->viewport)
         wp_viewport_destroy(decoration->viewport);
     decoration->surface = NULL;


### PR DESCRIPTION
On Wayland we implement Client-Side Decorations if the compositors do not
implement SSDs.  In that case, the destructors of the surfaces were called
in the wrong order, leading to a dereference of an already freed object.
We need to first destroy the subsurface before destroying the parent surface.

Related PR on kitty: https://github.com/kovidgoyal/kitty/pull/3066
Related issue on kitty: https://github.com/kovidgoyal/kitty/issues/3051