### PR TITLE
Fix for #1648: menubar not clickable on macOS Catalina

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ information on what to include when reporting a bug.
    (#1635)
  - [Cocoa] Bugfix: Failing to retrieve the refresh rate of built-in displays
    could leak memory
+ - [Cocoa] Bugfix: Menubar was not clickable on macOS 10.15+ until it lost and
+   regained focus (#1648)
  - [X11] Bugfix: The CMake files did not check for the XInput headers (#1480)
  - [X11] Bugfix: Key names were not updated when the keyboard layout changed
    (#1462,#1528)
@@ -428,6 +430,7 @@ skills.
  - Waris
  - Jay Weisskopf
  - Frank Wille
+ - Richard A. Wilkes
  - Tatsuya Yatagawa
  - Ryogo Yoshimura
  - Lukas Zanner

--- a/src/cocoa_init.m
+++ b/src/cocoa_init.m
@@ -428,9 +428,6 @@ static GLFWbool initializeTIS(void)
 {
     if (_glfw.hints.init.ns.menubar)
     {
-        // In case we are unbundled, make us a proper UI application
-        [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
-
         // Menu bar setup must go between sharedApplication and finishLaunching
         // in order to properly emulate the behavior of NSApplicationMain
 
@@ -442,6 +439,13 @@ static GLFWbool initializeTIS(void)
         }
         else
             createMenuBar();
+
+        // Fix for issue #1648: menubar not clickable on macOS Catalina until
+        // it lost and regained focus
+        dispatch_async(dispatch_get_main_queue(), ^{
+            // In case we are unbundled, make us a proper UI application
+            [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+        });
     }
 }
 


### PR DESCRIPTION
NSApp setActivationPolicy was being called too soon when the app was not
bundled and launched from the command line.