### PR TITLE
Machine shutdown callback

### DIFF
--- a/docs/window.dox
+++ b/docs/window.dox
@@ -618,8 +618,8 @@ void window_close_callback(GLFWwindow* window)
 }
 @endcode
 
-If you wish to be notified when the user attempts to shut down the machine, set a 
-machine shutdown callback.
+If you wish to be notified when the user attempts to shut down the machine, or 
+interrupt a shutdown, then set a machine shutdown callback.
 
 @code
 glfwSetMachineShutdownCallback(window, machine_shutdown_callback);
@@ -627,11 +627,16 @@ glfwSetMachineShutdownCallback(window, machine_shutdown_callback);
 
 The callback function is called when GLFW detects that the machine is shutting down.
 It can be used for example to save data to disk in order to minimize risk of data loss.
+Another use is to interrupt the shutdown (return false).
 
 @code
-void machine_shutdown_callback(GLFWwindow* window)
+int machine_shutdown_callback(GLFWwindow* window)
 {
     initiate_save_of_important_data_to_disk();
+    if (prevent_machine_shutdown())
+        return GLFW_FALSE;
+    else
+        return GLFW_TRUE;
 }
 @endcode
 

--- a/docs/window.dox
+++ b/docs/window.dox
@@ -618,6 +618,23 @@ void window_close_callback(GLFWwindow* window)
 }
 @endcode
 
+If you wish to be notified when the user attempts to shut down the machine, set a 
+machine shutdown callback.
+
+@code
+glfwSetMachineShutdownCallback(window, machine_shutdown_callback);
+@endcode
+
+The callback function is called when GLFW detects that the machine is shutting down.
+It can be used for example to save data to disk in order to minimize risk of data loss.
+
+@code
+void machine_shutdown_callback(GLFWwindow* window)
+{
+    initiate_save_of_important_data_to_disk();
+}
+@endcode
+
 
 @subsection window_size Window size
 

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -1412,6 +1412,21 @@ typedef void (* GLFWwindowsizefun)(GLFWwindow*,int,int);
  */
 typedef void (* GLFWwindowclosefun)(GLFWwindow*);
 
+/*! @brief The function pointer type for machine shutdown callbacks.
+ *
+ *  This is the function pointer type for machine shutdown callbacks.
+ *  A machine shutdown callback function has the following signature:
+ *  @code
+ *  void function_name(GLFWwindow* window)
+ *  @endcode
+ *
+ *  @sa @ref machine_shutdown
+ *  @sa @ref glfwSetMachineShutdownCallback
+ *
+ *  @ingroup window
+ */
+typedef void (* GLFWmachineShutdownfun)(GLFWwindow*);
+
 /*! @brief The function pointer type for window content refresh callbacks.
  *
  *  This is the function pointer type for window content refresh callbacks.
@@ -3842,6 +3857,34 @@ GLFWAPI GLFWwindowsizefun glfwSetWindowSizeCallback(GLFWwindow* window, GLFWwind
  *  @ingroup window
  */
 GLFWAPI GLFWwindowclosefun glfwSetWindowCloseCallback(GLFWwindow* window, GLFWwindowclosefun callback);
+
+/*! @brief Sets the machine shutdown callback for the specified window.
+ *
+ *  This function sets the machine shutdown callback of the specified window, which is
+ *  called when the operating system is preparing to shut down the machine.
+ *
+ *  @param[in] window The window whose callback to set.
+ *  @param[in] callback The new callback, or `NULL` to remove the currently set
+ *  callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or the
+ *  library had not been [initialized](@ref intro_init).
+ *
+ *  @callback_signature
+ *  @code
+ *  void function_name(GLFWwindow* window)
+ *  @endcode
+ *  For more information about the callback parameters, see the
+ *  [function pointer type](@ref GLFWmachineShutdownfun).
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref machine_shutdown
+ *
+ *  @ingroup window
+ */
+GLFWAPI GLFWmachineShutdownfun glfwSetMachineShutdownCallback(GLFWwindow* window, GLFWmachineShutdownfun callback);
 
 /*! @brief Sets the refresh callback for the specified window.
  *

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -1422,10 +1422,11 @@ typedef void (* GLFWwindowclosefun)(GLFWwindow*);
  *
  *  @sa @ref machine_shutdown
  *  @sa @ref glfwSetMachineShutdownCallback
+ *  @return GLFW_TRUE to accept the shutdown or GLFW_FALSE to interrupt it
  *
  *  @ingroup window
  */
-typedef void (* GLFWmachineShutdownfun)(GLFWwindow*);
+typedef int (* GLFWmachineShutdownfun)(GLFWwindow*);
 
 /*! @brief The function pointer type for window content refresh callbacks.
  *

--- a/src/internal.h
+++ b/src/internal.h
@@ -730,7 +730,7 @@ void _glfwInputWindowIconify(_GLFWwindow* window, GLFWbool iconified);
 void _glfwInputWindowMaximize(_GLFWwindow* window, GLFWbool maximized);
 void _glfwInputWindowDamage(_GLFWwindow* window);
 void _glfwInputWindowCloseRequest(_GLFWwindow* window);
-void _glfwInputMachineShutdown(_GLFWwindow* window);
+GLFWbool _glfwInputMachineShutdown(_GLFWwindow* window);
 void _glfwInputWindowMonitor(_GLFWwindow* window, _GLFWmonitor* monitor);
 
 void _glfwInputKey(_GLFWwindow* window,

--- a/src/internal.h
+++ b/src/internal.h
@@ -408,6 +408,7 @@ struct _GLFWwindow
         GLFWwindowposfun        pos;
         GLFWwindowsizefun       size;
         GLFWwindowclosefun      close;
+        GLFWmachineShutdownfun  shutdown;
         GLFWwindowrefreshfun    refresh;
         GLFWwindowfocusfun      focus;
         GLFWwindowiconifyfun    iconify;
@@ -729,6 +730,7 @@ void _glfwInputWindowIconify(_GLFWwindow* window, GLFWbool iconified);
 void _glfwInputWindowMaximize(_GLFWwindow* window, GLFWbool maximized);
 void _glfwInputWindowDamage(_GLFWwindow* window);
 void _glfwInputWindowCloseRequest(_GLFWwindow* window);
+void _glfwInputMachineShutdown(_GLFWwindow* window);
 void _glfwInputWindowMonitor(_GLFWwindow* window, _GLFWmonitor* monitor);
 
 void _glfwInputKey(_GLFWwindow* window,

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -627,6 +627,11 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
             return 0;
         }
 
+        case WM_QUERYENDSESSION:
+        {
+            return _glfwInputMachineShutdown(window);
+        }
+
         case WM_INPUTLANGCHANGE:
         {
             _glfwUpdateKeyNamesWin32();
@@ -1197,13 +1202,6 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
             free(paths);
 
             DragFinish(drop);
-            return 0;
-        }
-
-        case WM_QUERYENDSESSION:
-        case WM_ENDSESSION:
-        {
-            _glfwInputMachineShutdown(window);
             return 0;
         }
     }

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -1199,6 +1199,13 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
             DragFinish(drop);
             return 0;
         }
+
+        case WM_QUERYENDSESSION:
+        case WM_ENDSESSION:
+        {
+            _glfwInputMachineShutdown(window);
+            return 0;
+        }
     }
 
     return DefWindowProcW(hWnd, uMsg, wParam, lParam);

--- a/src/window.c
+++ b/src/window.c
@@ -138,6 +138,14 @@ void _glfwInputWindowCloseRequest(_GLFWwindow* window)
         window->callbacks.close((GLFWwindow*) window);
 }
 
+// Notifies shared code that the machine is shuting down
+//
+void _glfwInputMachineShutdown(_GLFWwindow *window)
+{
+    if (window->callbacks.shutdown)
+        window->callbacks.shutdown((GLFWwindow*) window);
+}
+
 // Notifies shared code that a window has changed its desired monitor
 //
 void _glfwInputWindowMonitor(_GLFWwindow* window, _GLFWmonitor* monitor)
@@ -1017,6 +1025,17 @@ GLFWAPI GLFWwindowclosefun glfwSetWindowCloseCallback(GLFWwindow* handle,
 
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
     _GLFW_SWAP_POINTERS(window->callbacks.close, cbfun);
+    return cbfun;
+}
+
+GLFWAPI GLFWmachineShutdownfun glfwSetMachineShutdownCallback(GLFWwindow* handle,
+                                                              GLFWmachineShutdownfun cbfun)
+{
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    assert(window != NULL);
+
+    _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
+    _GLFW_SWAP_POINTERS(window->callbacks.shutdown, cbfun);
     return cbfun;
 }
 

--- a/src/window.c
+++ b/src/window.c
@@ -140,10 +140,12 @@ void _glfwInputWindowCloseRequest(_GLFWwindow* window)
 
 // Notifies shared code that the machine is shuting down
 //
-void _glfwInputMachineShutdown(_GLFWwindow *window)
+GLFWbool _glfwInputMachineShutdown(_GLFWwindow *window)
 {
-    if (window->callbacks.shutdown)
-        window->callbacks.shutdown((GLFWwindow*) window);
+    if (window->callbacks.shutdown) {
+        return window->callbacks.shutdown((GLFWwindow*) window);
+    }
+    return GLFW_TRUE;
 }
 
 // Notifies shared code that a window has changed its desired monitor

--- a/tests/events.c
+++ b/tests/events.c
@@ -329,11 +329,12 @@ static void window_close_callback(GLFWwindow* window)
     glfwSetWindowShouldClose(window, slot->closeable);
 }
 
-static void window_machine_shutdown_callback(GLFWwindow* window)
+static int window_machine_shutdown_callback(GLFWwindow* window)
 {
     printf("%08x at %0.3f: Machine shutdown detected\n",
            counter++,
            glfwGetTime());
+    return GLFW_TRUE;
 }
 
 static void window_refresh_callback(GLFWwindow* window)

--- a/tests/events.c
+++ b/tests/events.c
@@ -329,6 +329,13 @@ static void window_close_callback(GLFWwindow* window)
     glfwSetWindowShouldClose(window, slot->closeable);
 }
 
+static void window_machine_shutdown_callback(GLFWwindow* window)
+{
+    printf("%08x at %0.3f: Machine shutdown detected\n",
+           counter++,
+           glfwGetTime());
+}
+
 static void window_refresh_callback(GLFWwindow* window)
 {
     Slot* slot = glfwGetWindowUserPointer(window);
@@ -627,6 +634,7 @@ int main(int argc, char** argv)
         glfwSetFramebufferSizeCallback(slots[i].window, framebuffer_size_callback);
         glfwSetWindowContentScaleCallback(slots[i].window, window_content_scale_callback);
         glfwSetWindowCloseCallback(slots[i].window, window_close_callback);
+        glfwSetMachineShutdownCallback(slots[i].window, window_machine_shutdown_callback);
         glfwSetWindowRefreshCallback(slots[i].window, window_refresh_callback);
         glfwSetWindowFocusCallback(slots[i].window, window_focus_callback);
         glfwSetWindowIconifyCallback(slots[i].window, window_iconify_callback);


### PR DESCRIPTION
Adds a machine shutdown callback. Windows only at the moment. (Anyone know if the API for this on linux is easy? Haven't looked into adding it on linux at all, sorry...)

It was added to our (voysys.com) fork of glfw due to a customer request. I thought I would drop a PR here in the upstream, maybe this is functionality that someone else can find useful?

From the included addition to the documentation:
```
If you wish to be notified when the user attempts to shut down the machine, or 
interrupt a shutdown, then set a machine shutdown callback.

@code
glfwSetMachineShutdownCallback(window, machine_shutdown_callback);
@endcode

The callback function is called when GLFW detects that the machine is shutting down.
It can be used for example to save data to disk in order to minimize risk of data loss.
Another use is to interrupt the shutdown (return false).

@code
int machine_shutdown_callback(GLFWwindow* window)
{
    initiate_save_of_important_data_to_disk();
    if (prevent_machine_shutdown())
        return GLFW_FALSE;
    else
        return GLFW_TRUE;
}
@endcode
```