### PR TITLE
Added 2 entries to the gitignores file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ examples/splitview
 examples/sharing
 examples/triangle-opengl
 examples/wave
+examples/windows
 tests/*.app
 tests/*.exe
 tests/clipboard
@@ -87,6 +88,7 @@ tests/gamma
 tests/glfwinfo
 tests/icon
 tests/iconify
+tests/inputlag
 tests/joysticks
 tests/monitors
 tests/msaa


### PR DESCRIPTION
I downloaded and built from sources as as submodule for a personal
exploration that I'm working on and discovered that the glfw submodule shows
changed files after a build.

Adding these 2 entries fixes the issue.

FWIW - I didn't update README or CREDITS because I don't really need any credit for such a small change, and I'm not convinced that consumers of the README would be interested in this change either.