### PR TITLE
Mac/Apple Silicon: Fix crash-on-launch by using modern API to get display name

### DIFF
--- a/src/cocoa_monitor.m
+++ b/src/cocoa_monitor.m
@@ -41,6 +41,22 @@
 //
 static char* getDisplayName(CGDirectDisplayID displayID)
 {
+    // IOKit doesn't work on Apple Silicon anymore. Luckilly, 10.15 introduced -[NSScreen localizedName].
+    // Use it if available, and fall back to IOKit otherwise.
+    if ([NSScreen instancesRespondToSelector:@selector(localizedName)])
+    {
+        for(NSScreen *screen in [NSScreen screens])
+        {
+            if ([[[screen deviceDescription] objectForKey:@"NSScreenNumber"] intValue] == displayID)
+            {
+                NSString *name = [screen localizedName];
+                if (name)
+                {
+                    return _glfw_strdup([name UTF8String]);
+                }
+            }
+        }
+    }
     io_iterator_t it;
     io_service_t service;
     CFDictionaryRef info;

--- a/src/cocoa_monitor.m
+++ b/src/cocoa_monitor.m
@@ -49,7 +49,7 @@ static char* getDisplayName(CGDirectDisplayID displayID)
         {
             if ([[[screen deviceDescription] objectForKey:@"NSScreenNumber"] intValue] == displayID)
             {
-                NSString *name = [screen localizedName];
+                NSString *name = [screen valueForKey:@"localizedName"];
                 if (name)
                 {
                     return _glfw_strdup([name UTF8String]);


### PR DESCRIPTION
On Apple Silicon, IOKit is deprecated and there will be no
matching io_service that we can query for name. Luckilly,
NSScreen got an API to fetch the display name in 10.15.

This is a blocker to get glfw running on Apple Silicon.
Fixes https://github.com/glfw/glfw/issues/1809