### PR TITLE
Fixes glfw/src/cocoa_platform.h:34:9: warning: 'GL_SILENCE_DEPRECATION' macro redefined [-Wmacro-redefined]

### DIFF
--- a/src/cocoa_platform.h
+++ b/src/cocoa_platform.h
@@ -31,7 +31,9 @@
 
 // NOTE: All of NSGL was deprecated in the 10.14 SDK
 //       This disables the pointless warnings for every symbol we use
+#ifndef GL_SILENCE_DEPRECATION
 #define GL_SILENCE_DEPRECATION
+#endif
 
 #if defined(__OBJC__)
 #import <Cocoa/Cocoa.h>


### PR DESCRIPTION
I build glfw from source, directly in my Xcode project, where I already have the GL_SILENCE_DEPRECATION macro defined.
Wrapping glfw's GL_SILENCE_DEPRECATION macro definition in an `#ifndef` removes the macro redefined warning.
Feel free to close if this is irrelevant for standard glfw usage (linking against built library), but it is useful for me.