### PR TITLE
Cache mappings on disk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ matrix:
                       - libwayland-dev
                       - libxkbcommon-dev
                       - libegl1-mesa-dev
+                      - libxxhash-dev
           env:
               - USE_WAYLAND=ON
               - BUILD_SHARED_LIBS=ON
@@ -59,6 +60,7 @@ matrix:
                       - libwayland-dev
                       - libxkbcommon-dev
                       - libegl1-mesa-dev
+                      - libxxhash-dev
           env:
               - USE_WAYLAND=ON
               - BUILD_SHARED_LIBS=OFF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,6 +218,16 @@ if (_GLFW_WAYLAND)
     endif()
 endif()
 
+# TODO: Move that elsewhere, as other platforms would equally benefit from it.
+if (_GLFW_X11 OR _GLFW_WAYLAND)
+    include(FindPkgConfig)
+    pkg_check_modules(XXHash3 libxxhash)
+    if (XXHash3_FOUND)
+        list(APPEND glfw_INCLUDE_DIRS "${XXHash3_INCLUDE_DIRS}")
+        set(HAVE_XXHASH TRUE)
+    endif()
+endif()
+
 #--------------------------------------------------------------------
 # Use Cocoa for window creation and NSOpenGL for context creation
 #--------------------------------------------------------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,10 @@ add_library(glfw "${GLFW_SOURCE_DIR}/include/GLFW/glfw3.h"
                  internal.h mappings.h context.c init.c input.c monitor.c
                  vulkan.c window.c)
 
+if (HAVE_XXHASH)
+    target_sources(glfw PRIVATE cache.c cache.h)
+endif()
+
 if (_GLFW_COCOA)
     target_sources(glfw PRIVATE cocoa_platform.h cocoa_joystick.h posix_thread.h
                                 nsgl_context.h egl_context.h osmesa_context.h

--- a/src/cache.c
+++ b/src/cache.c
@@ -155,8 +155,7 @@ cacheRead(const char *path, _GLFWmapping** out, int* count)
     {
         mapping = &mappings[i];
         FREAD_n(mapping->name, 128, f);
-        FREAD_n(mapping->guid, 32, f);
-        mapping->guid[32] = '\0';
+        FREAD_n(mapping->guid, 16, f);
         FREAD_n(mapping->buttons, 15, f);
         FREAD_n(mapping->axes, 6, f);
     }
@@ -202,7 +201,7 @@ cacheWrite(const char *path, const _GLFWmapping* mappings, int count)
     for (i = 0; i < count; ++i) {
         mapping = &mappings[i];
         FWRITE_n(mapping->name, 128, f);
-        FWRITE_n(mapping->guid, 32, f);
+        FWRITE_n(mapping->guid, 16, f);
         FWRITE_n(mapping->buttons, 15, f);
         FWRITE_n(mapping->axes, 6, f);
     }

--- a/src/cache.c
+++ b/src/cache.c
@@ -1,0 +1,223 @@
+//========================================================================
+// GLFW 3.4 - www.glfw.org
+//------------------------------------------------------------------------
+// Copyright (c) 2021 Emmanuel Gil Peyrot <linkmauve@linkmauve.fr>
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would
+//    be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such, and must not
+//    be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source
+//    distribution.
+//
+//========================================================================
+// Please use C89 style variable declarations in this file because VS 2010
+//========================================================================
+
+#define _XOPEN_SOURCE 500
+
+#include "cache.h"
+
+#ifndef HAVE_XXHASH
+#error "libxxhash is required for the compose cache"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#define XXH_INLINE_ALL
+#include <xxhash.h>
+
+static GLFWbool
+hashString(const char *string, size_t len, XXH128_canonical_t *out)
+{
+    XXH3_state_t *state;
+    XXH_errorcode err;
+    XXH128_hash_t hash;
+
+    state = XXH3_createState();
+    if (!state)
+        return GLFW_FALSE;
+
+    err = XXH3_128bits_reset(state);
+    if (err != XXH_OK)
+    {
+        XXH3_freeState(state);
+        return GLFW_FALSE;
+    }
+
+    err = XXH3_128bits_update(state, string, len);
+    if (err != XXH_OK)
+    {
+        XXH3_freeState(state);
+        return GLFW_FALSE;
+    }
+
+    hash = XXH3_128bits_digest(state);
+    XXH3_freeState(state);
+    XXH128_canonicalFromHash(out, hash);
+    return GLFW_TRUE;
+}
+
+GLFWbool
+cacheGetPathFromString(const char *string, char **cachePath)
+{
+    const char *home, *xdg;
+    char *path;
+    int length;
+    char *hash_part;
+    XXH128_canonical_t hash;
+
+    /* Mostly copied over from xkb_context_include_path_append_default(). */
+    home = getenv("HOME");
+    xdg = getenv("XDG_CACHE_HOME");
+    if (xdg != NULL)
+    {
+        length = strlen(xdg) + strlen("/glfw/") + 32 + 1;
+        path = malloc(length);
+        sprintf(path, "%s/glfw/", xdg);
+    }
+    else if (home != NULL)
+    {
+        /* XDG_CACHE_HOME fallback is $HOME/.cache/ */
+        length = strlen(home) + strlen("/.cache/glfw/") + 32 + 1;
+        path = malloc(length);
+        sprintf(path, "%s/.cache/glfw/", home);
+    }
+    else
+    {
+        return GLFW_FALSE;
+    }
+
+    if (!hashString(string, strlen(string), &hash))
+    {
+        free(path);
+        return GLFW_FALSE;
+    }
+
+    hash_part = strrchr(path, '/') + 1;
+    *hash_part = '\0';
+    mkdir(path, 0755);
+
+    for (int i = 0; i < 16; i++)
+    {
+        sprintf(hash_part, "%2.2x", hash.digest[i]);
+        hash_part += 2;
+    }
+
+    *cachePath = path;
+    return GLFW_TRUE;
+}
+
+GLFWbool
+cacheRead(const char *path, _GLFWmapping** out, int* count)
+{
+    FILE *f;
+    int length, i;
+    _GLFWmapping* mappings;
+    _GLFWmapping* mapping;
+
+#define FREAD(ptr, size, nmemb, stream) \
+    do \
+    { \
+        if (fread(ptr, size, nmemb, stream) < nmemb) \
+            return GLFW_FALSE; \
+    } while (0)
+#define FREAD_n(ptr, nmemb, stream) \
+    FREAD(ptr, sizeof(*ptr), nmemb, stream)
+#define FREAD_1(value, stream) \
+    FREAD_n(&value, 1, stream)
+
+    f = fopen(path, "rb");
+    if (!f)
+        return GLFW_FALSE;
+
+    FREAD_1(length, f);
+    mappings = malloc(length * sizeof(_GLFWmapping));
+    if (!mappings)
+        goto error;
+
+    for (i = 0; i < length; ++i)
+    {
+        mapping = &mappings[i];
+        FREAD_n(mapping->name, 128, f);
+        FREAD_n(mapping->guid, 32, f);
+        mapping->guid[32] = '\0';
+        FREAD_n(mapping->buttons, 15, f);
+        FREAD_n(mapping->axes, 6, f);
+    }
+
+#undef FREAD_1
+#undef FREAD_n
+#undef FREAD
+
+    fclose(f);
+    *count = length;
+    *out = mappings;
+    return GLFW_TRUE;
+
+error:
+    fclose(f);
+    unlink(path);
+    return GLFW_FALSE;
+}
+
+void
+cacheWrite(const char *path, const _GLFWmapping* mappings, int count)
+{
+    FILE *f;
+    int i;
+    const _GLFWmapping* mapping;
+
+#define FWRITE(ptr, size, nmemb, stream) \
+    do \
+    { \
+        if (fwrite(ptr, size, nmemb, stream) < nmemb) \
+            goto error; \
+    } while (0)
+#define FWRITE_n(ptr, nmemb, stream) \
+    FWRITE(ptr, sizeof(*ptr), nmemb, stream)
+#define FWRITE_1(value, stream) \
+    FWRITE_n(&value, 1, stream)
+
+    f = fopen(path, "wb");
+    if (!f)
+        return;
+
+    FWRITE_1(count, f);
+    for (i = 0; i < count; ++i) {
+        mapping = &mappings[i];
+        FWRITE_n(mapping->name, 128, f);
+        FWRITE_n(mapping->guid, 32, f);
+        FWRITE_n(mapping->buttons, 15, f);
+        FWRITE_n(mapping->axes, 6, f);
+    }
+
+    if (fclose(f) != 0)
+        goto fclose_error;
+
+    return;
+
+#undef FWRITE_1
+#undef FWRITE_n
+#undef FWRITE
+
+error:
+    fclose(f);
+fclose_error:
+    unlink(path);
+}

--- a/src/cache.h
+++ b/src/cache.h
@@ -1,0 +1,44 @@
+//========================================================================
+// GLFW 3.4 - www.glfw.org
+//------------------------------------------------------------------------
+// Copyright (c) 2021 Emmanuel Gil Peyrot <linkmauve@linkmauve.fr>
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would
+//    be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such, and must not
+//    be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source
+//    distribution.
+//
+//========================================================================
+// Please use C89 style variable declarations in this file because VS 2010
+//========================================================================
+
+#pragma once
+
+#include "internal.h"
+
+#ifndef HAVE_XXHASH
+#error "libxxhash is required for the compose cache"
+#endif
+
+GLFWbool
+cacheGetPathFromString(const char *string, char **cachePath);
+
+GLFWbool
+cacheRead(const char *path, _GLFWmapping** out, int* count);
+
+void
+cacheWrite(const char *path, const _GLFWmapping* mappings, int count);

--- a/src/glfw_config.h.in
+++ b/src/glfw_config.h.in
@@ -55,4 +55,6 @@
 #cmakedefine HAVE_XKBCOMMON_COMPOSE_H
 // Define this to 1 if the libc supports memfd_create()
 #cmakedefine HAVE_MEMFD_CREATE
+// Define this to 1 if xxhash has been found at build time
+#cmakedefine HAVE_XXHASH
 

--- a/src/init.c
+++ b/src/init.c
@@ -260,15 +260,25 @@ GLFWAPI int glfwInit(void)
 
     {
         int i;
+        char *mappings;
+
+        // This is a hack because MSVC still doesn’t support literal strings
+        // longer than 65535 bytes.
+        // TODO: find the maximum length of an entry, currently I took the
+        // longest one instead of properly calculating it.
+        mappings = malloc(326 * sizeof(_glfwDefaultMappings) / sizeof(char *));
+        memset(mappings, '\n', 326 * sizeof(_glfwDefaultMappings) / sizeof(char *));
 
         for (i = 0;  _glfwDefaultMappings[i];  i++)
+            memcpy(&mappings[326 * i], _glfwDefaultMappings[i], strlen(_glfwDefaultMappings[i]));
+
+        if (!glfwUpdateGamepadMappings(mappings))
         {
-            if (!glfwUpdateGamepadMappings(_glfwDefaultMappings[i]))
-            {
-                terminate();
-                return GLFW_FALSE;
-            }
+            free(mappings);
+            terminate();
+            return GLFW_FALSE;
         }
+        free(mappings);
     }
 
     return GLFW_TRUE;

--- a/src/init.c
+++ b/src/init.c
@@ -36,6 +36,10 @@
 #include <stdarg.h>
 #include <assert.h>
 
+#ifdef HAVE_XXHASH
+#include <sys/mman.h>
+#endif
+
 
 // The global variables below comprise all mutable global data in GLFW
 //
@@ -86,7 +90,12 @@ static void terminate(void)
     _glfw.monitors = NULL;
     _glfw.monitorCount = 0;
 
-    free(_glfw.mappings);
+#ifdef HAVE_XXHASH
+    if (_glfw.mappingMmapped)
+        munmap((void*)_glfw.mappings - 4, 4 + _glfw.mappingCount * sizeof(_GLFWmapping));
+    else
+#endif
+        free(_glfw.mappings);
     _glfw.mappings = NULL;
     _glfw.mappingCount = 0;
 

--- a/src/input.c
+++ b/src/input.c
@@ -71,7 +71,7 @@ static _GLFWmapping* findMapping(const char* guid)
 
     for (i = 0;  i < _glfw.mappingCount;  i++)
     {
-        if (strcmp(_glfw.mappings[i].guid, guid) == 0)
+        if (strncmp(_glfw.mappings[i].guid, guid, 32) == 0)
             return _glfw.mappings + i;
     }
 

--- a/src/input.c
+++ b/src/input.c
@@ -1194,7 +1194,7 @@ GLFWAPI int glfwUpdateGamepadMappings(const char* string)
     const char* c = string;
 #ifdef HAVE_XXHASH
     char *cachePath;
-    GLFWbool usableCache, readFromCache = GLFW_FALSE;
+    GLFWbool usableCache;
 #endif
 
     assert(string != NULL);
@@ -1206,9 +1206,10 @@ GLFWAPI int glfwUpdateGamepadMappings(const char* string)
 
     if (usableCache && cacheRead(cachePath, &_glfw.mappings, &_glfw.mappingCount))
     {
-        readFromCache = GLFW_TRUE;
+        _glfw.mappingMmapped = GLFW_TRUE;
         goto doMapping;
     }
+    _glfw.mappingMmapped = GLFW_FALSE;
 #endif
 
     while (*c)
@@ -1264,7 +1265,7 @@ doMapping:
     }
 
 #ifdef HAVE_XXHASH
-    if (usableCache && !readFromCache)
+    if (usableCache && !_glfw.mappingMmapped)
         cacheWrite(cachePath, _glfw.mappings, _glfw.mappingCount);
 
     free(cachePath);

--- a/src/internal.h
+++ b/src/internal.h
@@ -477,7 +477,7 @@ struct _GLFWmapelement
 struct _GLFWmapping
 {
     char            name[128];
-    char            guid[33];
+    uint8_t         guid[16];
     _GLFWmapelement buttons[15];
     _GLFWmapelement axes[6];
 };
@@ -495,7 +495,8 @@ struct _GLFWjoystick
     int             hatCount;
     char*           name;
     void*           userPointer;
-    char            guid[33];
+    uint8_t         guid[16];
+    char            userReadableGUID[33];
     _GLFWmapping*   mapping;
 
     // This is defined in the joystick API's joystick.h
@@ -636,7 +637,7 @@ const char* _glfwPlatformGetClipboardString(void);
 GLFWbool _glfwPlatformInitJoysticks(void);
 void _glfwPlatformTerminateJoysticks(void);
 int _glfwPlatformPollJoystick(_GLFWjoystick* js, int mode);
-void _glfwPlatformUpdateGamepadGUID(char* guid);
+void _glfwPlatformUpdateGamepadGUID(uint8_t guid[16]);
 
 uint64_t _glfwPlatformGetTimerValue(void);
 uint64_t _glfwPlatformGetTimerFrequency(void);
@@ -778,7 +779,7 @@ void _glfwFreeGammaArrays(GLFWgammaramp* ramp);
 void _glfwSplitBPP(int bpp, int* red, int* green, int* blue);
 
 _GLFWjoystick* _glfwAllocJoystick(const char* name,
-                                  const char* guid,
+                                  const uint8_t guid[16],
                                   int axisCount,
                                   int buttonCount,
                                   int hatCount);

--- a/src/internal.h
+++ b/src/internal.h
@@ -544,6 +544,9 @@ struct _GLFWlibrary
     _GLFWjoystick       joysticks[GLFW_JOYSTICK_LAST + 1];
     _GLFWmapping*       mappings;
     int                 mappingCount;
+#ifdef HAVE_XXHASH
+    GLFWbool            mappingMmapped;
+#endif
 
     _GLFWtls            errorSlot;
     _GLFWtls            contextSlot;

--- a/src/linux_joystick.c
+++ b/src/linux_joystick.c
@@ -168,24 +168,25 @@ static GLFWbool openJoystickDevice(const char* path)
     if (ioctl(linjs.fd, EVIOCGNAME(sizeof(name)), name) < 0)
         strncpy(name, "Unknown", sizeof(name));
 
-    char guid[33] = "";
+    uint8_t guid[16] = {0};
 
     // Generate a joystick GUID that matches the SDL 2.0.5+ one
     if (id.vendor && id.product && id.version)
     {
-        sprintf(guid, "%02x%02x0000%02x%02x0000%02x%02x0000%02x%02x0000",
-                id.bustype & 0xff, id.bustype >> 8,
-                id.vendor & 0xff,  id.vendor >> 8,
-                id.product & 0xff, id.product >> 8,
-                id.version & 0xff, id.version >> 8);
+        guid[0] = id.bustype & 0xff;
+        guid[1] = id.bustype >> 8;
+        guid[4] = id.vendor & 0xff;
+        guid[5] = id.vendor >> 8;
+        guid[8] = id.product & 0xff;
+        guid[9] = id.product >> 8;
+        guid[12] = id.version & 0xff;
+        guid[13] = id.version >> 8;
     }
     else
     {
-        sprintf(guid, "%02x%02x0000%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x00",
-                id.bustype & 0xff, id.bustype >> 8,
-                name[0], name[1], name[2], name[3],
-                name[4], name[5], name[6], name[7],
-                name[8], name[9], name[10]);
+        guid[0] = id.bustype & 0xff;
+        guid[1] = id.bustype >> 8;
+        memcpy(&guid[4], name, 11);
     }
 
     int axisCount = 0, buttonCount = 0, hatCount = 0;
@@ -422,7 +423,7 @@ int _glfwPlatformPollJoystick(_GLFWjoystick* js, int mode)
     return js->present;
 }
 
-void _glfwPlatformUpdateGamepadGUID(char* guid)
+void _glfwPlatformUpdateGamepadGUID(uint8_t guid[16])
 {
 }
 

--- a/src/null_joystick.c
+++ b/src/null_joystick.c
@@ -47,7 +47,7 @@ int _glfwPlatformPollJoystick(_GLFWjoystick* js, int mode)
     return GLFW_FALSE;
 }
 
-void _glfwPlatformUpdateGamepadGUID(char* guid)
+void _glfwPlatformUpdateGamepadGUID(uint8_t guid[16])
 {
 }
 


### PR DESCRIPTION
Parsing this file was taking the most time out of `glfwInit()`, or about 14ms on my PinePhone before the start of this series.  In the case where the string is already in cache, it now takes only 0.95ms.

It would be possible to make that even faster, and additionally to keep that page shared with other GLFW processes, by using `mmap()` instead, but for now I opted to not change the memory representation.

I also changed the mappings.h format to be a single `\n`-separated string instead of multiple different strings, so that we can call `glfwUpdateGamepadMappings()` once instead of once per entry, this alone was a ~2ms win.

Part of the implementation is shared with https://github.com/xkbcommon/libxkbcommon/pull/220