### PR TITLE
Don't call SwapBuffers on single-buffer contexts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ information on what to include when reporting a bug.
  - Made joystick subsystem initialize at first use (#1284,#1646)
  - Updated the minimum required CMake version to 3.1
  - Disabled tests and examples by default when built as a CMake subdirectory
+ - Don't call SwapBuffers on single-buffer contexts.
  - Bugfix: The CMake config-file package used an absolute path and was not
    relocatable (#1470)
  - Bugfix: Video modes with a duplicate screen area were discarded (#1555,#1556)

--- a/src/context.c
+++ b/src/context.c
@@ -570,7 +570,9 @@ GLFWbool _glfwRefreshContextAttribs(_GLFWwindow* window,
         PFNGLCLEARPROC glClear = (PFNGLCLEARPROC)
             window->context.getProcAddress("glClear");
         glClear(GL_COLOR_BUFFER_BIT);
-        window->context.swapBuffers(window);
+        if (_glfw.hints.framebuffer.doublebuffer) {
+            window->context.swapBuffers(window);
+        }
     }
 
     glfwMakeContextCurrent((GLFWwindow*) previous);


### PR DESCRIPTION
It's generally harmless to call SwapBuffers on single-buffer contexts.

But it's unnecessary at the very least, and it confuses
https://github.com/apitrace/apitrace into thinking the GLFW3 application
is using double-buffered back-buffers even when it isn't.