### PR TITLE
make windows opaque by default

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -277,7 +277,7 @@ void glfwDefaultWindowHints(void)
     _glfw.hints.framebuffer.redBits      = 8;
     _glfw.hints.framebuffer.greenBits    = 8;
     _glfw.hints.framebuffer.blueBits     = 8;
-    _glfw.hints.framebuffer.alphaBits    = 8;
+    _glfw.hints.framebuffer.alphaBits    = 0;
     _glfw.hints.framebuffer.depthBits    = 24;
     _glfw.hints.framebuffer.stencilBits  = 8;
     _glfw.hints.framebuffer.doublebuffer = GLFW_TRUE;

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -826,6 +826,9 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
         window->wl.visible = GLFW_FALSE;
     }
 
+    if (window->monitor)
+        setFullscreen(window, window->monitor, window->videoMode.refreshRate);
+
     window->wl.currentCursor = NULL;
 
     window->wl.monitors = calloc(1, sizeof(_GLFWmonitor*));

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -292,7 +292,6 @@ static void setOpaqueRegion(_GLFWwindow* window)
 
     wl_region_add(region, 0, 0, window->wl.width, window->wl.height);
     wl_surface_set_opaque_region(window->wl.surface, region);
-    wl_surface_commit(window->wl.surface);
     wl_region_destroy(region);
 }
 


### PR DESCRIPTION
Make all windows opaque by default to fix rendering issues with most of the tests and examples on Wayland.