### PR TITLE
Fix some keys not repeating in Wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ information on what to include when reporting a bug.
  - [Wayland] Bugfix: Client-Side Decorations were destroyed in the wrong worder
    (#1798)
  - [Wayland] Bugfix: Monitors physical size could report zero (#1784,#1792)
+ - [Wayland] Bugfix: Some keys were not repeating in Wayland
  - [POSIX] Bugfix: `CLOCK_MONOTONIC` was not correctly tested for or enabled
  - [NSGL] Removed enforcement of forward-compatible flag for core contexts
  - [NSGL] Bugfix: `GLFW_COCOA_RETINA_FRAMEBUFFER` had no effect on newer
@@ -472,6 +473,7 @@ skills.
  - Jonas Ådahl
  - Lasse Öörni
  - Leonard König
+ - Koray Kilinc
  - All the unmentioned and anonymous contributors in the GLFW community, for bug
    reports, patches, feedback, testing and encouragement
 

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -552,7 +552,7 @@ static GLFWbool inputChar(_GLFWwindow* window, uint32_t key)
         }
     }
 
-    return xkb_keymap_key_repeats(_glfw.wl.xkb.keymap, syms[0]);
+    return xkb_keymap_key_repeats(_glfw.wl.xkb.keymap, code);
 }
 
 static void keyboardHandleKey(void* data,


### PR DESCRIPTION
According to https://xkbcommon.org/doc/current/group__components.html#ga9d7f998efeca98b3afc7c257bbac90a8, xkb_keymap_key_repeats requires keymap and keycode as input.

```
int xkb_keymap_key_repeats( struct xkb_keymap * keymap,
			    xkb_keycode_t key
)
```

However, in wl_init.c:inputChar, we are passing in xkb_keysym_t which was a type mismatch.

This results in some keys not repeating when they should and vice versa.