### PR TITLE
Win32: Expose native HDC with glfwGetWGLContextDC

### DIFF
--- a/include/GLFW/glfw3native.h
+++ b/include/GLFW/glfw3native.h
@@ -185,6 +185,20 @@ GLFWAPI HWND glfwGetWin32Window(GLFWwindow* window);
  *  @ingroup native
  */
 GLFWAPI HGLRC glfwGetWGLContext(GLFWwindow* window);
+
+/*! @brief Returns the `HDC` of the specified window.
+ *
+ *  @return The `HDC` of the specified window, or `NULL` if an
+ *  [error](@ref error_handling) occurred.
+ *
+ *  @thread_safety This function may be called from any thread.  Access is not
+ *  synchronized.
+ *
+ *  @since Added in version 3.TODO.
+ *
+ *  @ingroup native
+ */
+GLFWAPI HDC glfwGetWGLContextDC(GLFWwindow* window);
 #endif
 
 #if defined(GLFW_EXPOSE_NATIVE_COCOA)

--- a/src/wgl_context.c
+++ b/src/wgl_context.c
@@ -796,3 +796,16 @@ GLFWAPI HGLRC glfwGetWGLContext(GLFWwindow* handle)
     return window->context.wgl.handle;
 }
 
+GLFWAPI HDC glfwGetWGLContextDC(GLFWwindow* handle)
+{
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
+
+    if (window->context.client == GLFW_NO_API)
+    {
+        _glfwInputError(GLFW_NO_WINDOW_CONTEXT, NULL);
+        return NULL;
+    }
+
+    return window->context.wgl.dc;
+}


### PR DESCRIPTION
OpenXR requires both HDC and HGLRC, so I added getter for HDC.