### PR TITLE
Consistent subsections in compile guide

### DIFF
--- a/docs/compile.dox
+++ b/docs/compile.dox
@@ -109,7 +109,7 @@ Once you have installed the necessary packages, move on to @ref
 compile_generate.
 
 
-@subsection compile_deps_osmesa Dependencies for Linux and OSMesa
+@subsubsection compile_deps_osmesa Dependencies for Linux and OSMesa
 
 To compile GLFW for OSMesa, you need to install the OSMesa library and header
 packages.  For example, on Ubuntu and other distributions based on Debian


### PR DESCRIPTION
In the compile guide, the "Dependencies for Linux and OSMesa" section looks to be one level too high in the hierarchy. I've moved it to be in line with the similarly-named sub-sub-sections.