### PR TITLE
Add glfwGetGLXFBConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ information on what to include when reporting a bug.
  - [EGL] Added ANGLE backend selection via `EGL_ANGLE_platform_angle` extension
    (#1380)
  - [EGL] Bugfix: The `GLFW_DOUBLEBUFFER` context attribute was ignored (#1843)
+ - [GLX] Made it possible to query the `GLXFBConfig` that was chosen to create a given window via `glfwGetGLXFBConfig`
 
 
 ## Contact

--- a/docs/news.dox
+++ b/docs/news.dox
@@ -53,6 +53,13 @@ Alt-and-then-Space shortcuts.  This may be useful for more GUI-oriented
 applications.
 
 
+@subsubsection features_34_glx_getfbconfig Query GLXFBConfig
+
+GLFW now provides the [glfwGetGLXFBConfig](@ref glfwGetGLXFBConfig)
+function that returns the GLXFBConfig that was chosen to create the 
+given window handle.
+
+
 @subsection caveats_34 Caveats for version 3.4
 
 @subsubsection joysticks_34 Joystick support is initialized on demand
@@ -118,6 +125,10 @@ then GLFW will fail to initialize.
 @subsection symbols_34 New symbols in version 3.4
 
 @subsubsection functions_34 New functions in version 3.4
+
+ - @ref glfwGetGLXFBConfig
+
+
 @subsubsection types_34 New types in version 3.4
 @subsubsection constants_34 New constants in version 3.4
 

--- a/include/GLFW/glfw3native.h
+++ b/include/GLFW/glfw3native.h
@@ -385,6 +385,21 @@ GLFWAPI GLXContext glfwGetGLXContext(GLFWwindow* window);
  *  @ingroup native
  */
 GLFWAPI GLXWindow glfwGetGLXWindow(GLFWwindow* window);
+
+/*! @brief Returns the `GLXFBConfig` that was chosen to create the 
+ *  specified window.
+ *
+ *  @return The `GLXFBConfig` that was chosen to create the specified 
+ *  window, or `NULL` if an [error](@ref error_handling) occurred.
+ *
+ *  @thread_safety This function may be called from any thread.  Access is not
+ *  synchronized.
+ *
+ *  @since Added in version 3.3.5
+ *
+ *  @ingroup native
+ */
+GLFWAPI GLXFBConfig glfwGetGLXFBConfig(GLFWwindow* window);
 #endif
 
 #if defined(GLFW_EXPOSE_NATIVE_WAYLAND)

--- a/include/GLFW/glfw3native.h
+++ b/include/GLFW/glfw3native.h
@@ -395,7 +395,7 @@ GLFWAPI GLXWindow glfwGetGLXWindow(GLFWwindow* window);
  *  @thread_safety This function may be called from any thread.  Access is not
  *  synchronized.
  *
- *  @since Added in version 3.3.5
+ *  @since Added in version 3.4
  *
  *  @ingroup native
  */

--- a/src/glx_context.c
+++ b/src/glx_context.c
@@ -242,6 +242,11 @@ static void destroyContextGLX(_GLFWwindow* window)
         glXDestroyContext(_glfw.x11.display, window->context.glx.handle);
         window->context.glx.handle = NULL;
     }
+
+    if (window->context.glx.fbConfig)
+    {
+        window->context.glx.fbConfig = NULL;
+    }
 }
 
 
@@ -620,6 +625,8 @@ GLFWbool _glfwCreateContextGLX(_GLFWwindow* window,
         return GLFW_FALSE;
     }
 
+    window->context.glx.fbConfig = native;
+
     window->context.makeCurrent = makeContextCurrentGLX;
     window->context.swapBuffers = swapBuffersGLX;
     window->context.swapInterval = swapIntervalGLX;
@@ -697,3 +704,16 @@ GLFWAPI GLXWindow glfwGetGLXWindow(GLFWwindow* handle)
     return window->context.glx.window;
 }
 
+GLFWAPI GLXFBConfig glfwGetGLXFBConfig(GLFWwindow* handle)
+{
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFW_REQUIRE_INIT_OR_RETURN(None);
+
+    if (window->context.client == GLFW_NO_API)
+    {
+        _glfwInputError(GLFW_NO_WINDOW_CONTEXT, NULL);
+        return NULL;
+    }
+
+    return window->context.glx.fbConfig;
+}

--- a/src/glx_context.h
+++ b/src/glx_context.h
@@ -117,6 +117,7 @@ typedef struct _GLFWcontextGLX
 {
     GLXContext      handle;
     GLXWindow       window;
+    GLXFBConfig     fbConfig;
 
 } _GLFWcontextGLX;
 


### PR DESCRIPTION
**Description**
This commit adds a new function called `glfwGetGLXFBConfig` that will return the `GLXFBConfig` that was chosen to create a given window.

**Motivation**
This is needed to create an OpenXR session with OpenGL rendering on some Linux systems: It is needed to set the `glxFBConfig` value of the `XrGraphicsBindingOpenGLXlibKHR` struct.

**Review notes**
I am not an experienced C developer and this is the first time I (try to) contribute to GLFW, so I might have missed something important. Also, I don't know a good way to test whether this works correctly; I only checked that it still compiles and that some of the examples still work.