### PR TITLE
Rename BUILD_SHARED_LIBS to GLFW_BUILD_SHARED_LIBS

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,14 +30,14 @@ for:
             - GENERATOR: MinGW Makefiles
     build_script:
         - set PATH=%PATH:C:\Program Files\Git\usr\bin=C:\MinGW\bin%
-        - cmake -S . -B build -G "%GENERATOR%" -DBUILD_SHARED_LIBS=%BUILD_SHARED_LIBS%
+        - cmake -S . -B build -G "%GENERATOR%" -DGLFW_BUILD_SHARED_LIBS=%BUILD_SHARED_LIBS%
         - cmake --build build
 -
     matrix:
         only:
             - GENERATOR: Visual Studio 10 2010
     build_script:
-        - cmake -S . -B build -G "%GENERATOR%" -DBUILD_SHARED_LIBS=%BUILD_SHARED_LIBS%
+        - cmake -S . -B build -G "%GENERATOR%" -DGLFW_BUILD_SHARED_LIBS=%BUILD_SHARED_LIBS%
         - cmake --build build --target glfw
 notifications:
     - provider: Email

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
               run: cmake --build build-static --parallel
 
             - name: Configure shared library
-              run: cmake -S . -B build-shared -D BUILD_SHARED_LIBS=ON
+              run: cmake -S . -B build-shared -D GLFW_BUILD_SHARED_LIBS=ON
             - name: Build shared library
               run: cmake --build build-shared --parallel
 
@@ -50,7 +50,7 @@ jobs:
               run: cmake --build build-static --parallel
 
             - name: Configure shared library
-              run: cmake -S . -B build-shared -D GLFW_USE_WAYLAND=ON -D BUILD_SHARED_LIBS=ON
+              run: cmake -S . -B build-shared -D GLFW_USE_WAYLAND=ON -D GLFW_BUILD_SHARED_LIBS=ON
             - name: Build shared library
               run: cmake --build build-shared --parallel
 
@@ -73,7 +73,7 @@ jobs:
               run: cmake --build build-static --parallel
 
             - name: Configure shared library
-              run: cmake -S . -B build-shared -D GLFW_USE_OSMESA=ON -D BUILD_SHARED_LIBS=ON
+              run: cmake -S . -B build-shared -D GLFW_USE_OSMESA=ON -D GLFW_BUILD_SHARED_LIBS=ON
             - name: Build shared library
               run: cmake --build build-shared --parallel
 
@@ -92,7 +92,7 @@ jobs:
               run: cmake --build build-static --parallel
 
             - name: Configure shared library
-              run: cmake -S . -B build-shared -D BUILD_SHARED_LIBS=ON
+              run: cmake -S . -B build-shared -D GLFW_BUILD_SHARED_LIBS=ON
             - name: Build shared library
               run: cmake --build build-shared --parallel
 
@@ -110,7 +110,7 @@ jobs:
               run: cmake --build build-static --parallel
 
             - name: Configure shared library
-              run: cmake -S . -B build-shared -G "Visual Studio 16 2019" -D BUILD_SHARED_LIBS=ON
+              run: cmake -S . -B build-shared -G "Visual Studio 16 2019" -D GLFW_BUILD_SHARED_LIBS=ON
             - name: Build shared library
               run: cmake --build build-shared --parallel
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
     set(GLFW_STANDALONE TRUE)
 endif()
 
-option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
+option(GLFW_BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option(GLFW_BUILD_EXAMPLES "Build the GLFW example programs" ${GLFW_STANDALONE})
 option(GLFW_BUILD_TESTS "Build the GLFW test programs" ${GLFW_STANDALONE})
 option(GLFW_BUILD_DOCS "Build the GLFW documentation" ON)
@@ -41,7 +41,7 @@ cmake_dependent_option(GLFW_USE_WAYLAND "Use Wayland for window creation" OFF
 cmake_dependent_option(USE_MSVC_RUNTIME_LIBRARY_DLL "Use MSVC runtime library DLL" ON
                        "MSVC" OFF)
 
-if (BUILD_SHARED_LIBS AND UNIX)
+if (GLFW_BUILD_SHARED_LIBS AND UNIX)
     # On Unix-like systems, shared libraries can use the soname system.
     set(GLFW_LIB_NAME glfw)
 else()
@@ -49,7 +49,7 @@ else()
 endif()
 
 if (GLFW_VULKAN_STATIC)
-    if (BUILD_SHARED_LIBS)
+    if (GLFW_BUILD_SHARED_LIBS)
         # If you absolutely must do this, remove this line and add the Vulkan
         # loader static library via the CMAKE_SHARED_LINKER_FLAGS
         message(FATAL_ERROR "You are trying to link the Vulkan loader static library into the GLFW shared library")

--- a/docs/compile.dox
+++ b/docs/compile.dox
@@ -199,14 +199,14 @@ Finally, if you don't want to use any GUI, you can set options from the `cmake`
 command-line with the `-D` flag.
 
 @code{.sh}
-cmake -DBUILD_SHARED_LIBS=ON .
+cmake -DGLFW_BUILD_SHARED_LIBS=ON .
 @endcode
 
 
 @subsubsection compile_options_shared Shared CMake options
 
-@anchor BUILD_SHARED_LIBS
-__BUILD_SHARED_LIBS__ determines whether GLFW is built as a static
+@anchor GLFW_BUILD_SHARED_LIBS
+__GLFW_BUILD_SHARED_LIBS__ determines whether GLFW is built as a static
 library or as a DLL / shared library / dynamic library.
 
 @anchor GLFW_BUILD_EXAMPLES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,10 @@
+if(GLFW_BUILD_SHARED_LIBS)
+    add_library(glfw SHARED)
+else()
+    add_library(glfw STATIC)
+endif()
 
-add_library(glfw "${GLFW_SOURCE_DIR}/include/GLFW/glfw3.h"
+target_sources(glfw PRIVATE "${GLFW_SOURCE_DIR}/include/GLFW/glfw3.h"
                  "${GLFW_SOURCE_DIR}/include/GLFW/glfw3native.h"
                  internal.h mappings.h context.c init.c input.c monitor.c
                  vulkan.c window.c)
@@ -83,7 +88,7 @@ if (_GLFW_WAYLAND)
         "${GLFW_BINARY_DIR}/src/wayland-idle-inhibit-unstable-v1-client-protocol")
 endif()
 
-if (WIN32 AND BUILD_SHARED_LIBS)
+if (WIN32 AND GLFW_BUILD_SHARED_LIBS)
     configure_file(glfw.rc.in glfw.rc @ONLY)
     target_sources(glfw PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/glfw.rc")
 endif()
@@ -181,7 +186,7 @@ if (MSVC90)
     endif()
 endif()
 
-if (BUILD_SHARED_LIBS)
+if (GLFW_BUILD_SHARED_LIBS)
     if (WIN32)
         if (MINGW)
             # Remove the dependency on the shared version of libgcc


### PR DESCRIPTION
So lately I was trying to use GLFW in my project combined with other libs.
I needed GLFW to be built as a shared library, but the option `BUILD_SHARED_LIBS` actually sets a CMake flag (https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
This flag turns all libraries that don't explicitly specify themselves as `STATIC` or `SHARED` into shared libraries, conflicting with some libraries.

This addresses #279. 