### PR TITLE
Fix invalid preprocessor command 'warning'

### DIFF
--- a/src/win32_init.c
+++ b/src/win32_init.c
@@ -40,7 +40,7 @@ static const GUID _glfw_GUID_DEVINTERFACE_HID =
 #if defined(_GLFW_USE_HYBRID_HPG) || defined(_GLFW_USE_OPTIMUS_HPG)
 
 #if defined(_GLFW_BUILD_DLL)
- #warning "These symbols must be exported by the executable and have no effect in a DLL"
+ #pragma message("These symbols must be exported by the executable and have no effect in a DLL")
 #endif
 
 // Executables (but not DLLs) exporting this symbol with this value will be


### PR DESCRIPTION
Building GLFW 3.3.4 on Windows 10 (x64) MSVC results in a compiler error: `Invalid preprocessor command 'warning'`.
`#warning` macro is not supported in MSVC.

OS and version: Microsoft Windows 10 Pro (10.0.19043 Build 19043)
Compiler version: 19.29.30133 (x64)
Release or commit: 3.3.4

CMake properties:
![image](https://user-images.githubusercontent.com/12068816/130537012-f6c3e4d3-a513-4564-9efc-50882e817c89.png)

Build log:
```
C:\Development\Build\glfw-3.3.4>msbuild GLFW.sln /t:Build /p:Configuration=Release
Microsoft (R) Build Engine version 16.11.0+0538acc04 for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

Building the projects in this solution one at a time. To enable parallel build, please add the "-m" switch.
Build started 24/08/2021 02:18:59.
Project "C:\Development\Build\glfw-3.3.4\GLFW.sln" on node 1 (Build target(s)).
ValidateSolutionConfiguration:
  Building solution configuration "Release|x64".
ValidateProjects:
  The project "ALL_BUILD" is not selected for building in solution configuration "Release|x64".
Project "C:\Development\Build\glfw-3.3.4\GLFW.sln" (1) is building "C:\Development\Build\glfw-3.3.4\ZERO_CHECK.vcxproj"
 (2) on node 1 (default targets).
PrepareForBuild:
  Creating directory "x64\Release\ZERO_CHECK\".
  Creating directory "x64\Release\ZERO_CHECK\ZERO_CHECK.tlog\".
InitializeBuildStatus:
  Creating "x64\Release\ZERO_CHECK\ZERO_CHECK.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
CustomBuild:
  Checking Build System
FinalizeBuildStatus:
  Deleting file "x64\Release\ZERO_CHECK\ZERO_CHECK.tlog\unsuccessfulbuild".
  Touching "x64\Release\ZERO_CHECK\ZERO_CHECK.tlog\ZERO_CHECK.lastbuildstate".
Done Building Project "C:\Development\Build\glfw-3.3.4\ZERO_CHECK.vcxproj" (default targets).

Project "C:\Development\Build\glfw-3.3.4\GLFW.sln" (1) is building "C:\Development\Build\glfw-3.3.4\src\glfw.vcxproj.me
taproj" (3) on node 1 (default targets).
Project "C:\Development\Build\glfw-3.3.4\src\glfw.vcxproj.metaproj" (3) is building "C:\Development\Build\glfw-3.3.4\sr
c\glfw.vcxproj" (4) on node 1 (default targets).
PrepareForBuild:
  Creating directory "glfw.dir\Release\".
  Creating directory "C:\Development\Build\glfw-3.3.4\src\Release\".
  Creating directory "glfw.dir\Release\glfw.tlog\".
InitializeBuildStatus:
  Creating "glfw.dir\Release\glfw.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
CustomBuild:
  Building Custom Rule C:/Development/Libraries/glfw-3.3.4/src/CMakeLists.txt
ClCompile:
  C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\bin\HostX64\x64\CL.exe /c /I"
  C:\Development\Libraries\glfw-3.3.4\include" /I"C:\Development\Libraries\glfw-3.3.4\src" /I"C:\Development\Build\glfw
  -3.3.4\src" /nologo /W3 /WX- /diagnostics:column /O2 /Ob2 /D _WINDLL /D _UNICODE /D UNICODE /D WIN32 /D _WINDOWS /D N
  DEBUG /D _GLFW_USE_CONFIG_H /D _UNICODE /D _CRT_SECURE_NO_WARNINGS /D "CMAKE_INTDIR=\"Release\"" /D glfw_EXPORTS /Gm-
   /MD /GS /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /Fo"glfw.dir\Release\\" /Fd"glfw.dir\Release\vc142.pdb" /ext
  ernal:W3 /Gd /TC /errorReport:queue "C:\Development\Libraries\glfw-3.3.4\src\context.c" "C:\Development\Libraries\glf
  w-3.3.4\src\init.c" "C:\Development\Libraries\glfw-3.3.4\src\input.c" "C:\Development\Libraries\glfw-3.3.4\src\monito
  r.c" "C:\Development\Libraries\glfw-3.3.4\src\vulkan.c" "C:\Development\Libraries\glfw-3.3.4\src\window.c" "C:\Develo
  pment\Libraries\glfw-3.3.4\src\win32_init.c" "C:\Development\Libraries\glfw-3.3.4\src\win32_joystick.c" "C:\Developme
  nt\Libraries\glfw-3.3.4\src\win32_monitor.c" "C:\Development\Libraries\glfw-3.3.4\src\win32_time.c" "C:\Development\L
  ibraries\glfw-3.3.4\src\win32_thread.c" "C:\Development\Libraries\glfw-3.3.4\src\win32_window.c" "C:\Development\Libr
  aries\glfw-3.3.4\src\wgl_context.c" "C:\Development\Libraries\glfw-3.3.4\src\egl_context.c" "C:\Development\Libraries
  \glfw-3.3.4\src\osmesa_context.c"
  context.c
  init.c
  input.c
  monitor.c
  vulkan.c
  window.c
  win32_init.c
C:\Development\Libraries\glfw-3.3.4\src\win32_init.c(43,1): fatal error C1021: invalid preprocessor command 'warning' [
C:\Development\Build\glfw-3.3.4\src\glfw.vcxproj]
  win32_joystick.c
  win32_monitor.c
  win32_time.c
  win32_thread.c
  win32_window.c
  wgl_context.c
  egl_context.c
  osmesa_context.c
  Generating Code...
Done Building Project "C:\Development\Build\glfw-3.3.4\src\glfw.vcxproj" (default targets) -- FAILED.

Done Building Project "C:\Development\Build\glfw-3.3.4\src\glfw.vcxproj.metaproj" (default targets) -- FAILED.

Done Building Project "C:\Development\Build\glfw-3.3.4\GLFW.sln" (Build target(s)) -- FAILED.


Build FAILED.

"C:\Development\Build\glfw-3.3.4\GLFW.sln" (Build target) (1) ->
"C:\Development\Build\glfw-3.3.4\src\glfw.vcxproj.metaproj" (default target) (3) ->
"C:\Development\Build\glfw-3.3.4\src\glfw.vcxproj" (default target) (4) ->
(ClCompile target) ->
  C:\Development\Libraries\glfw-3.3.4\src\win32_init.c(43,1): fatal error C1021: invalid preprocessor command 'warning'
 [C:\Development\Build\glfw-3.3.4\src\glfw.vcxproj]

    0 Warning(s)
    1 Error(s)

Time Elapsed 00:00:02.54
```