### PR TITLE
Cocoa: Fix cursor movement delay after restoring a GLFW_CURSOR_DISABLED cursor

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -114,10 +114,10 @@ static void updateCursorMode(_GLFWwindow* window)
     else if (_glfw.ns.disabledCursorWindow == window)
     {
         _glfw.ns.disabledCursorWindow = NULL;
-        CGAssociateMouseAndMouseCursorPosition(true);
         _glfwPlatformSetCursorPos(window,
                                   _glfw.ns.restoreCursorPosX,
                                   _glfw.ns.restoreCursorPosY);
+        CGAssociateMouseAndMouseCursorPosition(true);
     }
 
     if (cursorInContentArea(window))


### PR DESCRIPTION
This patch fixes LWJGL/lwjgl3#576, which has been a [long-standing issue](https://bugs.mojang.com/browse/MC-134546) in Minecraft.

The commit message includes some technical information. References to other projects facing the same problem and resolving it with this fix:

* https://github.com/Hammerspoon/hammerspoon/issues/2005
* https://www.winehq.org/pipermail/wine-patches/2015-October/143826.html
* https://stackoverflow.com/questions/8215413/why-is-cgwarpmousecursorposition-causing-a-delay-if-it-is-not-what-is/17559012#17559012