### PR TITLE
Fix various typos

### DIFF
--- a/docs/compile.dox
+++ b/docs/compile.dox
@@ -71,7 +71,7 @@ pkg install xorgproto
 On Cygwin the `xorgproto` package in the Devel section of the GUI installer will
 install the headers and other development related files for all of X11.
 
-Once you have the required depdendencies, move on to @ref compile_generate.
+Once you have the required dependencies, move on to @ref compile_generate.
 
 
 @subsubsection compile_deps_wayland Dependencies for Wayland on Unix-like systems
@@ -101,7 +101,7 @@ packages.
 pkg install wayland libxkbcommon wayland-protocols
 @endcode
 
-Once you have the required depdendencies, move on to @ref compile_generate.
+Once you have the required dependencies, move on to @ref compile_generate.
 
 
 @subsection compile_generate Generating build files with CMake

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -372,7 +372,7 @@ extern "C" {
  *
  *  The naming of the key codes follow these rules:
  *   - The US keyboard layout is used
- *   - Names of printable alpha-numeric characters are used (e.g. "A", "R",
+ *   - Names of printable alphanumeric characters are used (e.g. "A", "R",
  *     "3", etc.)
  *   - For non-alphanumeric characters, Unicode:ish names are used (e.g.
  *     "COMMA", "LEFT_SQUARE_BRACKET", etc.). Note that some names do not

--- a/src/win32_platform.h
+++ b/src/win32_platform.h
@@ -319,7 +319,7 @@ typedef struct _GLFWwindowWin32
 
     // The last received cursor position, regardless of source
     int                 lastCursorPosX, lastCursorPosY;
-    // The last recevied high surrogate when decoding pairs of UTF-16 messages
+    // The last received high surrogate when decoding pairs of UTF-16 messages
     WCHAR               highSurrogate;
 
 } _GLFWwindowWin32;


### PR DESCRIPTION
Found via `codespell -q 3 -S ./deps -L fo,numer,te,uint,wille`