### PR TITLE
Properly discard filtered events by XFilterEvent()

### DIFF
--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -1163,6 +1163,10 @@ static void processEvent(XEvent *event)
         keycode = event->xkey.keycode;
 
     filtered = XFilterEvent(event, None);
+    if (filtered)
+    {
+        return;
+    }
 
     if (_glfw.x11.randr.available)
     {


### PR DESCRIPTION
According to https://www.x.org/releases/current/doc/man/man3/XFilterEvent.3.xhtml,
an event should be discarded if XFilterEvent returns `True`. Fix #1794.