### PR TITLE
Add cursor position to mouse button callback

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -1684,10 +1684,6 @@ typedef void (* GLFWwindowcontentscalefun)(GLFWwindow* window, float xscale, flo
  *  may add more actions.
  *  @param[in] mods Bit field describing which [modifier keys](@ref mods) were
  *  held down.
- *  @param[in] xpos The x-coordinate of the cursor, relative to the left edge of
- *  the content area.
- *  @param[in] ypos The y-coordinate of the cursor, relative to the top edge of
- *  the content area.
  *
  *  @sa @ref input_mouse_button
  *  @sa @ref glfwSetMouseButtonCallback
@@ -1697,7 +1693,32 @@ typedef void (* GLFWwindowcontentscalefun)(GLFWwindow* window, float xscale, flo
  *
  *  @ingroup input
  */
-typedef void (* GLFWmousebuttonfun)(GLFWwindow* window, int button, int action, int mods, double xpos, double ypos);
+typedef void (* GLFWmousebuttonfun)(GLFWwindow* window, int button, int action, int mods);
+
+/*! @brief The function pointer type for mouse button & position callbacks.
+ *  This is the function pointer type for mouse button & position callback functions.
+ *  A mouse button callback function has the following signature:
+ *  @code
+ *  void function_name(GLFWwindow* window, int button, int action, int mods, double xpos, double ypos)
+ *  @endcode
+ *
+ *  @param[in] window The window that received the vent.
+ *  @param[in] button The [mouse button](@ref buttons) that was pressed or
+ *  released.
+ *  @param[in] action One of 'GLFW_PRESS' or 'GLFW_RELEASE'. Future releases
+ *  may add more actions.
+ *  @param[in] mods Bit field describing which [modifier keys](@ref mods) were
+ *  held down.
+ *  @param[in] xpos The cursor x-position relative to the left edge of the
+ *  content area.
+ *  @param[in] xpos The cursor y-position relative to the right edge of the
+ *  content area.
+ *
+ *  @since Added in version 4.0
+ *
+ *  @ingroup input
+ */
+typedef void (* GLFWmousebuttonposfun)(GLFWwindow* window, int button, int action, int mods, double xpos, double ypos);
 
 /*! @brief The function pointer type for cursor position callbacks.
  *
@@ -5037,6 +5058,37 @@ GLFWAPI GLFWcharmodsfun glfwSetCharModsCallback(GLFWwindow* window, GLFWcharmods
  *  @ingroup input
  */
 GLFWAPI GLFWmousebuttonfun glfwSetMouseButtonCallback(GLFWwindow* window, GLFWmousebuttonfun callback);
+
+/*! @brief Sets the mouse button & position callback.
+ *
+ * This function sets the mouse button and position callback of the specified window, which
+ * is called when a mouse button is pressed or released.
+ *
+ * For more information see the @ref glfwSetMouseButtonCallback.
+ *
+ * When the callback is called it also provides the cursor position relative
+ * to the window content area.
+ *
+ * @param[in] window The window whose callback to set.
+ * @param[in] callback The new callback, or `NULL` to remove the currently set
+ * callback.
+ * @return The previously set callback, or `NULL` if no callback was set or the
+ * library had not been [initialized](@ref intro_init).
+ *
+ * @callback_signature
+ * @code
+ * void function_name(GLFWwindow* window, int button, int action, int mods, double xpos, double ypos)
+ * @endcode
+ * For more information about the callback parameters, see the
+ * [function pointer type](@ref GLFWmousebutonposfun).
+ *
+ * @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ * @thread_safety This function must only be called from the main thread.
+ *
+ * @ingroup input
+ */
+GLFWAPI GLFWmousebuttonposfun glfwSetMouseButtonPosCallback(GLFWwindow* window, GLFWmousebuttonposfun callback);
 
 /*! @brief Sets the cursor position callback.
  *

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -1684,6 +1684,10 @@ typedef void (* GLFWwindowcontentscalefun)(GLFWwindow* window, float xscale, flo
  *  may add more actions.
  *  @param[in] mods Bit field describing which [modifier keys](@ref mods) were
  *  held down.
+ *  @param[in] xpos The x-coordinate of the cursor, relative to the left edge of
+ *  the content area.
+ *  @param[in] ypos The y-coordinate of the cursor, relative to the top edge of
+ *  the content area.
  *
  *  @sa @ref input_mouse_button
  *  @sa @ref glfwSetMouseButtonCallback
@@ -1693,7 +1697,7 @@ typedef void (* GLFWwindowcontentscalefun)(GLFWwindow* window, float xscale, flo
  *
  *  @ingroup input
  */
-typedef void (* GLFWmousebuttonfun)(GLFWwindow* window, int button, int action, int mods);
+typedef void (* GLFWmousebuttonfun)(GLFWwindow* window, int button, int action, int mods, double xpos, double ypos);
 
 /*! @brief The function pointer type for cursor position callbacks.
  *

--- a/src/input.c
+++ b/src/input.c
@@ -336,7 +336,9 @@ void _glfwInputMouseClick(_GLFWwindow* window, int button, int action, int mods)
         window->mouseButtons[button] = (char) action;
 
     if (window->callbacks.mouseButton)
-        window->callbacks.mouseButton((GLFWwindow*) window, button, action, mods, window->virtualCursorPosX, window->virtualCursorPosY);
+        window->callbacks.mouseButton((GLFWwindow*) window, button, action, mods);
+    if (window->callbacks.mouseButtonPos)
+        window->callbacks.mouseButtonPos((GLFWwindow*) window, button, action, mods, window->virtualCursorPosX, window->virtualCursorPosY);
 }
 
 // Notifies shared code of a cursor motion event
@@ -887,6 +889,17 @@ GLFWAPI GLFWmousebuttonfun glfwSetMouseButtonCallback(GLFWwindow* handle,
 
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
     _GLFW_SWAP_POINTERS(window->callbacks.mouseButton, cbfun);
+    return cbfun;
+}
+
+GLFWAPI GLFWmousebuttonposfun glfwSetMouseButtonPosCallback(GLFWwindow *handle,
+                                                            GLFWmousebuttonposfun cbfun)
+{
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    assert(window != NULL);
+
+    _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
+    _GLFW_SWAP_POINTERS(window->callbacks.mouseButtonPos, cbfun);
     return cbfun;
 }
 

--- a/src/input.c
+++ b/src/input.c
@@ -336,7 +336,7 @@ void _glfwInputMouseClick(_GLFWwindow* window, int button, int action, int mods)
         window->mouseButtons[button] = (char) action;
 
     if (window->callbacks.mouseButton)
-        window->callbacks.mouseButton((GLFWwindow*) window, button, action, mods);
+        window->callbacks.mouseButton((GLFWwindow*) window, button, action, mods, window->virtualCursorPosX, window->virtualCursorPosY);
 }
 
 // Notifies shared code of a cursor motion event

--- a/src/internal.h
+++ b/src/internal.h
@@ -419,6 +419,7 @@ struct _GLFWwindow
         GLFWframebuffersizefun    fbsize;
         GLFWwindowcontentscalefun scale;
         GLFWmousebuttonfun        mouseButton;
+        GLFWmousebuttonposfun     mouseButtonPos;
         GLFWcursorposfun          cursorPos;
         GLFWcursorenterfun        cursorEnter;
         GLFWscrollfun             scroll;


### PR DESCRIPTION
Use of the mouse button callback generally requires the mouse position. By adding the cursor position to mouse button callback, it reduces redundancy.

See #752 