### PR TITLE
Fix undefined behaviour in X11 keypress handling

### DIFF
--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -1269,7 +1269,7 @@ static void processEvent(XEvent *event)
                 //       (the server never sends a timestamp of zero)
                 // NOTE: Timestamp difference is compared to handle wrap-around
                 Time diff = event->xkey.time - window->x11.keyPressTimes[keycode];
-                if (diff == event->xkey.time || (diff > 0 && diff < (1 << 31)))
+                if (diff == event->xkey.time || (diff > 0 && diff < ((Time)1 << 31)))
                 {
                     if (keycode)
                         _glfwInputKey(window, key, keycode, GLFW_PRESS, mods);


### PR DESCRIPTION
`1 << 31` is undefined because 1 is an int, so the shift would set the sign bit

Related to (and discovered in the same way as) #1986