### PR TITLE
update docstring which inaccurately says GLFW_CONTEXT_REVISION is a window hint

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -1028,7 +1028,7 @@ extern "C" {
  *  and [attribute](@ref GLFW_CONTEXT_VERSION_MINOR_attrib).
  */
 #define GLFW_CONTEXT_VERSION_MINOR  0x00022003
-/*! @brief Context client API revision number hint and attribute.
+/*! @brief Context client API revision number attribute.
  *
  *  Context client API revision number
  *  [attribute](@ref GLFW_CONTEXT_REVISION_attrib).


### PR DESCRIPTION
This docstring previously indicated that `GLFW_CONTEXT_REVISION` was a window
hint and attribute, but in fact it is only a window attribute (there is no code
which uses this constant in any other context.)

We noticed this in https://github.com/hexops/mach/pull/71/files#r749741814

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>