### PR TITLE
cocoa: fixup move to non-deprecated default IOKit mach port

### DIFF
--- a/src/cocoa_monitor.m
+++ b/src/cocoa_monitor.m
@@ -58,7 +58,7 @@ static char* getMonitorName(CGDirectDisplayID displayID, NSScreen* screen)
     io_service_t service;
     CFDictionaryRef info;
 
-    if (IOServiceGetMatchingServices(kIOMainPortDefault,
+    if (IOServiceGetMatchingServices(MACH_PORT_NULL,
                                      IOServiceMatching("IODisplayConnect"),
                                      &it) != 0)
     {
@@ -231,7 +231,7 @@ static double getFallbackRefreshRate(CGDirectDisplayID displayID)
     io_iterator_t it;
     io_service_t service;
 
-    if (IOServiceGetMatchingServices(kIOMainPortDefault,
+    if (IOServiceGetMatchingServices(MACH_PORT_NULL,
                                      IOServiceMatching("IOFramebuffer"),
                                      &it) != 0)
     {

--- a/src/cocoa_platform.h
+++ b/src/cocoa_platform.h
@@ -44,13 +44,6 @@ typedef void* id;
 // NOTE: Many Cocoa enum values have been renamed and we need to build across
 //       SDK versions where one is unavailable or the other deprecated
 //       We use the newer names in code and these macros to handle compatibility
-#if MAC_OS_X_VERSION_MAX_ALLOWED < 120000
- #define kIOMainPortDefault kIOMasterPortDefault
-#endif
-
-// NOTE: Many Cocoa enum values have been renamed and we need to build across
-//       SDK versions where one is unavailable or the other deprecated
-//       We use the newer names in code and these macros to handle compatibility
 #if MAC_OS_X_VERSION_MAX_ALLOWED < 101400
  #define NSOpenGLContextParameterSwapInterval NSOpenGLCPSwapInterval
  #define NSOpenGLContextParameterSurfaceOpacity NSOpenGLCPSurfaceOpacity


### PR DESCRIPTION
f75c251deccde745d3d3f313aa81955095369d6f was a valiant attempt, but unfortunately  [`kIOMasterPortDefault`](https://developer.apple.com/documentation/iokit/kiomasterportdefault?language=objc) and [`kIOMainPortDefault`](https://developer.apple.com/documentation/iokit/kiomainportdefault?language=objc) are not enum values, but instead external `mach_port_t` symbols.

Thus just checking if the SDK is new enough to support this symbol's definition is not enough, and will cause compilation warnings with f.ex. SDK from Xcode 13.1 and the target being macOS <12.0. This is due to the new symbol being utilized unconditionally without `@available` runtime conditions (`unguarded-availability-new` warnings, which I wonder why they're not just errors by default). And during runtime it doesn't find the symbol and crashes :)

This PR contains the "three stages of grief" I went through when figuring out how to best fix this, and thus I am posting them so that one of them could be picked for upstream inclusion.

1. Just switch the #define check to target version instead of SDK version.
   
   **Pros**: compiles without warnings for both targets.
   **Cons**: if the old external symbol is removed, a build built against an older target doesn't work on a newer system any more.
2. Properly utilize `@available` for runtime checking and utilization of new or old symbol depending on its availability.
   
   **Pros**: compiles without warnings for both targets, utilizes new symbol for new OS versions (although I think I am missing another elif for target > 12.0 where only the new symbol is utilized).
   **Cons**: requires both ifdefs and a function.
3. Notice a comment in the definition of the symbol that:

   > When specifying a primary port to IOKit functions, the NULL argument indicates "use the default". This is a synonym for NULL, if you'd rather use a named constant.

   ... and thus just utilizing MACH_PORT_NULL should be good enough?
   
   **Pros**: simplest if it works.
   **Cons**: I am not sure if I got proper values out of my macOS 11.6 system with either `kIOMasterPortDefault` or `MACH_PORT_NULL` within libplacebo's plplay that I was testing things against.

I'm pretty sure versions 1 and 2 should work as expected (I will have to adjust the ifdeffery if that ends up being the preferred route), for version 3 I would like someone who does get values out of these APIs to verify that `MACH_PORT_NULL` works just like documentation hints that it does.

