### PR TITLE
Add possible errors comment

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -5703,6 +5703,8 @@ GLFWAPI int glfwUpdateGamepadMappings(const char* string);
  *  joystick is not present, does not have a mapping or an
  *  [error](@ref error_handling) occurred.
  *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref GLFW_INVALID_ENUM.
+ *
  *  @pointer_lifetime The returned string is allocated and freed by GLFW.  You
  *  should not free it yourself.  It is valid until the specified joystick is
  *  disconnected, the gamepad mappings are updated or the library is terminated.


### PR DESCRIPTION
The top-level source for `glfwGetGamepadName` shows it is possible for it to set `GLFW_NOT_INITIALIZED` and `GLFW_INVALID_ENUM`.