### PR TITLE
Windows: avoid modifying the global keyboard state with ToUnicode

### DIFF
--- a/src/win32_init.c
+++ b/src/win32_init.c
@@ -487,13 +487,13 @@ void _glfwUpdateKeyNamesWin32(void)
 
         length = ToUnicode(vk, scancode, state,
                            chars, sizeof(chars) / sizeof(WCHAR),
-                           0);
+                           1 << 2);
 
         if (length == -1)
         {
             length = ToUnicode(vk, scancode, state,
                                chars, sizeof(chars) / sizeof(WCHAR),
-                               0);
+                               1 << 2);
         }
 
         if (length < 1)


### PR DESCRIPTION
Since Windows 10 version 1607 we can make use of a new flag that
makes ToUnicode operate on a process-private keyboard state.

Reference:
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-tounicode

Note: this is a coordinated effort across various open source projects

* [GTK](https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/4195)
* [Chromium](https://chromium-review.googlesource.com/c/chromium/src/+/3360877)