### PR TITLE
X11: Fix segfault when _glfw.x11.display is higher than 1024

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ information on what to include when reporting a bug.
  - [X11] Bugfix: Icon pixel format conversion worked only by accident, relying on
    undefined behavior (#1986)
  - [X11] Bugfix: Dynamic loading on OpenBSD failed due to soname differences
+ - [X11] Bugfix: Fix segfault on linux when `_glfw.x11.display` is higher than 1024
  - [Wayland] Added dynamic loading of all Wayland libraries
  - [Wayland] Added support for key names via xkbcommon
  - [Wayland] Removed support for `wl_shell` (#1443)


### PR DESCRIPTION
FD_SETSIZE is hardcoded to 1024 in glibc. See the bugs section of the select call for more info.
In some cases, it is possible for _glfw.x11.display to be larger than FD_SETSIZE, causing a segfault or buffer overflow.
Replacing select() with poll() seems to be the recommended solution:
- https://www.man7.org/linux/man-pages/man2/select.2.html#BUGS
- https://access.redhat.com/solutions/488623
- https://stackoverflow.com/questions/7976388/increasing-limit-of-fd-setsize-and-select/7977082#7977082