### PR TITLE
Fix compilation when GLFW_BUILD_WAYLAND is on

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -87,12 +87,12 @@ if (GLFW_BUILD_WAYLAND)
             DEPENDS "${protocol_file}"
             VERBATIM)
 
-        add_custom_command(OUTPUT "${output_file}-code.h"
-            COMMAND "${WAYLAND_SCANNER_EXECUTABLE}" private-code "${protocol_file}" "${output_file}-code.h"
+        add_custom_command(OUTPUT "${output_file}-code.c"
+            COMMAND "${WAYLAND_SCANNER_EXECUTABLE}" private-code "${protocol_file}" "${output_file}-code.c"
             DEPENDS "${protocol_file}"
             VERBATIM)
 
-        target_sources(glfw PRIVATE "${output_file}.h" "${output_file}-code.h")
+        target_sources(glfw PRIVATE "${output_file}.h" "${output_file}-code.c")
     endmacro()
 
     wayland_generate(
@@ -176,6 +176,7 @@ if (GLFW_BUILD_WAYLAND)
         xkbcommon)
 
     target_include_directories(glfw PRIVATE ${Wayland_INCLUDE_DIRS})
+    target_link_libraries(glfw PRIVATE ${Wayland_LIBRARIES})
 
     if (NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
         find_package(EpollShim)

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -48,14 +48,6 @@
 #include "wayland-pointer-constraints-unstable-v1-client-protocol.h"
 #include "wayland-idle-inhibit-unstable-v1-client-protocol.h"
 
-#include "wayland-client-protocol-code.h"
-#include "wayland-xdg-shell-client-protocol-code.h"
-#include "wayland-xdg-decoration-client-protocol-code.h"
-#include "wayland-viewporter-client-protocol-code.h"
-#include "wayland-relative-pointer-unstable-v1-client-protocol-code.h"
-#include "wayland-pointer-constraints-unstable-v1-client-protocol-code.h"
-#include "wayland-idle-inhibit-unstable-v1-client-protocol-code.h"
-
 
 static inline int min(int n1, int n2)
 {

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -64,65 +64,8 @@ typedef void* (* PFN_wl_proxy_get_user_data)(struct wl_proxy*);
 typedef void (* PFN_wl_proxy_set_user_data)(struct wl_proxy*,void*);
 typedef uint32_t (* PFN_wl_proxy_get_version)(struct wl_proxy*);
 typedef struct wl_proxy* (* PFN_wl_proxy_marshal_flags)(struct wl_proxy*,uint32_t,const struct wl_interface*,uint32_t,uint32_t,...);
-#define wl_display_flush _glfw.wl.client.display_flush
-#define wl_display_cancel_read _glfw.wl.client.display_cancel_read
-#define wl_display_dispatch_pending _glfw.wl.client.display_dispatch_pending
-#define wl_display_read_events _glfw.wl.client.display_read_events
-#define wl_display_disconnect _glfw.wl.client.display_disconnect
-#define wl_display_roundtrip _glfw.wl.client.display_roundtrip
-#define wl_display_get_fd _glfw.wl.client.display_get_fd
-#define wl_display_prepare_read _glfw.wl.client.display_prepare_read
-#define wl_proxy_marshal _glfw.wl.client.proxy_marshal
-#define wl_proxy_add_listener _glfw.wl.client.proxy_add_listener
-#define wl_proxy_destroy _glfw.wl.client.proxy_destroy
-#define wl_proxy_marshal_constructor _glfw.wl.client.proxy_marshal_constructor
-#define wl_proxy_marshal_constructor_versioned _glfw.wl.client.proxy_marshal_constructor_versioned
-#define wl_proxy_get_user_data _glfw.wl.client.proxy_get_user_data
-#define wl_proxy_set_user_data _glfw.wl.client.proxy_set_user_data
-#define wl_proxy_get_version _glfw.wl.client.proxy_get_version
-#define wl_proxy_marshal_flags _glfw.wl.client.proxy_marshal_flags
 
 struct wl_shm;
-
-#define wl_display_interface _glfw_wl_display_interface
-#define wl_subcompositor_interface _glfw_wl_subcompositor_interface
-#define wl_compositor_interface _glfw_wl_compositor_interface
-#define wl_shm_interface _glfw_wl_shm_interface
-#define wl_data_device_manager_interface _glfw_wl_data_device_manager_interface
-#define wl_shell_interface _glfw_wl_shell_interface
-#define wl_buffer_interface _glfw_wl_buffer_interface
-#define wl_callback_interface _glfw_wl_callback_interface
-#define wl_data_device_interface _glfw_wl_data_device_interface
-#define wl_data_offer_interface _glfw_wl_data_offer_interface
-#define wl_data_source_interface _glfw_wl_data_source_interface
-#define wl_keyboard_interface _glfw_wl_keyboard_interface
-#define wl_output_interface _glfw_wl_output_interface
-#define wl_pointer_interface _glfw_wl_pointer_interface
-#define wl_region_interface _glfw_wl_region_interface
-#define wl_registry_interface _glfw_wl_registry_interface
-#define wl_seat_interface _glfw_wl_seat_interface
-#define wl_shell_surface_interface _glfw_wl_shell_surface_interface
-#define wl_shm_pool_interface _glfw_wl_shm_pool_interface
-#define wl_subsurface_interface _glfw_wl_subsurface_interface
-#define wl_surface_interface _glfw_wl_surface_interface
-#define wl_touch_interface _glfw_wl_touch_interface
-#define zwp_idle_inhibitor_v1_interface _glfw_zwp_idle_inhibitor_v1_interface
-#define zwp_idle_inhibit_manager_v1_interface _glfw_zwp_idle_inhibit_manager_v1_interface
-#define zwp_confined_pointer_v1_interface _glfw_zwp_confined_pointer_v1_interface
-#define zwp_locked_pointer_v1_interface _glfw_zwp_locked_pointer_v1_interface
-#define zwp_pointer_constraints_v1_interface _glfw_zwp_pointer_constraints_v1_interface
-#define zwp_relative_pointer_v1_interface _glfw_zwp_relative_pointer_v1_interface
-#define zwp_relative_pointer_manager_v1_interface _glfw_zwp_relative_pointer_manager_v1_interface
-#define wp_viewport_interface _glfw_wp_viewport_interface
-#define wp_viewporter_interface _glfw_wp_viewporter_interface
-#define xdg_toplevel_interface _glfw_xdg_toplevel_interface
-#define zxdg_toplevel_decoration_v1_interface _glfw_zxdg_toplevel_decoration_v1_interface
-#define zxdg_decoration_manager_v1_interface _glfw_zxdg_decoration_manager_v1_interface
-#define xdg_popup_interface _glfw_xdg_popup_interface
-#define xdg_positioner_interface _glfw_xdg_positioner_interface
-#define xdg_surface_interface _glfw_xdg_surface_interface
-#define xdg_toplevel_interface _glfw_xdg_toplevel_interface
-#define xdg_wm_base_interface _glfw_xdg_wm_base_interface
 
 #define GLFW_WAYLAND_WINDOW_STATE         _GLFWwindowWayland  wl;
 #define GLFW_WAYLAND_LIBRARY_WINDOW_STATE _GLFWlibraryWayland wl;


### PR DESCRIPTION
should fix #2016

Problems found:
1. [These lines](https://github.com/glfw/glfw/blob/master/src/CMakeLists.txt#L86-L91) should produce a source file (.c) not a header. So there's no need to include these files in `wl_init.c`
2. After that, hitting undefined symbols around [these lines](https://github.com/glfw/glfw/blob/master/src/wl_platform.h#L85-L123). I don't quite know the purpose of these lines but removing these lines don't seem to cause any harm
3. wayland-client [include paths are included](https://github.com/glfw/glfw/blob/master/src/CMakeLists.txt#L174) but its libraries are not linked

I have tested the change by first building with `GLFW_BUILD_WAYLAND=On` then, adding this line to `cursor.c`
```
    glfwInitHint(GLFW_PLATFORM, GLFW_PLATFORM_WAYLAND);
```
then testing the cursor program with the mutter compositor on Ubuntu 18.04