### PR TITLE
Fix #1281: glfwPostEmptyEvent sometimes doesn't wake up glfwWaitEvents on X11

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ information on what to include when reporting a bug.
 
 ## Changelog
 
+ - Bugfix: fixed glfwPostEmptyEvent not unblocking glfwWaitEvents on X11 (#1281)
  - Added `GLFW_PLATFORM` init hint for runtime platform selection (#1958)
  - Added `GLFW_ANY_PLATFORM`, `GLFW_PLATFORM_WIN32`, `GLFW_PLATFORM_COCOA`,
    `GLFW_PLATFORM_WAYLAND`, `GLFW_PLATFORM_X11` and `GLFW_PLATFORM_NULL` symbols to

--- a/src/x11_platform.h
+++ b/src/x11_platform.h
@@ -871,6 +871,10 @@ typedef struct _GLFWlibraryX11
         PFN_XShapeQueryVersion QueryVersion;
         PFN_XShapeCombineMask ShapeCombineMask;
     } xshape;
+
+    struct {
+        int pipe[2];
+    } eventLoopData;
 } _GLFWlibraryX11;
 
 // X11-specific per-monitor data


### PR DESCRIPTION
This is a rare race that triggers often when running GLFW programs on GitHub Actions with Xvfb.

The underlying issue is internal to Xlib: XSendEvent races with an external select() call and may get dispatched before select() has blocked on the display fd.

The fix observes a pipe in the select() call, and writes to that pipe from glfwPostEmptyEvent to make select() return.

The original issue reproduces locally once per minute when running the windowjs/windowjs tests in a loop;
The bug hasn't triggered after running for several hours with the fix.