### PR TITLE
Platform: Prefer Wayland over X11

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ information on what to include when reporting a bug.
  - [Wayland] Added dynamic loading of all Wayland libraries
  - [Wayland] Added support for key names via xkbcommon
  - [Wayland] Removed support for `wl_shell` (#1443)
+ - [Wayland] Prefer Wayland over X11 if both are available (#2035)
  - [Wayland] Bugfix: The `GLFW_HAND_CURSOR` shape used the wrong image (#1432)
  - [Wayland] Bugfix: `CLOCK_MONOTONIC` was not correctly enabled
  - [Wayland] Bugfix: Repeated keys could be reported with `NULL` window (#1704)

--- a/src/platform.c
+++ b/src/platform.c
@@ -45,11 +45,11 @@ static const struct
 #if defined(_GLFW_COCOA)
     { GLFW_PLATFORM_COCOA, _glfwConnectCocoa },
 #endif
-#if defined(_GLFW_X11)
-    { GLFW_PLATFORM_X11, _glfwConnectX11 },
-#endif
 #if defined(_GLFW_WAYLAND)
     { GLFW_PLATFORM_WAYLAND, _glfwConnectWayland },
+#endif
+#if defined(_GLFW_X11)
+    { GLFW_PLATFORM_X11, _glfwConnectX11 },
 #endif
 };
 


### PR DESCRIPTION
When GLFW_ANY_PLATFORM is used (which is the default) native
Wayland would previously never be chosen if XWayland is also available.

Another idea (TBD) would be to control this behavior by an environment variable (see Qt or Firefox) and otherwise default to X11.