### PR TITLE
Wayland Drag and Drop

### DIFF
--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -773,7 +773,7 @@ static void dataDeviceHandleDataOffer(void* data,
                                       struct wl_data_device* dataDevice,
                                       struct wl_data_offer* id)
 {
-    wl_data_offer_add_listener(_glfw.wl.dataOffer, &dataOfferListener, NULL);
+    wl_data_offer_add_listener(id, &dataOfferListener, NULL);
 }
 
 static void dataDeviceHandleEnter(void* data,

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -282,6 +282,7 @@ typedef struct _GLFWlibraryWayland
     struct wl_data_device*      dataDevice;
     struct wl_data_offer*       dataOffer;
     struct wl_data_source*      dataSource;
+    struct wl_data_offer*       dragDataOffer;
     struct xdg_wm_base*         wmBase;
     struct zxdg_decoration_manager_v1*      decorationManager;
     struct wp_viewporter*       viewporter;
@@ -299,6 +300,7 @@ typedef struct _GLFWlibraryWayland
     int                         cursorTimerfd;
     uint32_t                    serial;
     uint32_t                    pointerEnterSerial;
+    uint32_t                    dragSerial;
 
     int32_t                     keyboardRepeatRate;
     int32_t                     keyboardRepeatDelay;
@@ -354,6 +356,7 @@ typedef struct _GLFWlibraryWayland
 
     _GLFWwindow*                pointerFocus;
     _GLFWwindow*                keyboardFocus;
+    _GLFWwindow*                dragFocus;
 
     struct {
         void*                                       handle;


### PR DESCRIPTION
Implements Drag and Drop for the Wayland backend.
This actually also fixes a bug in the previous implementation for the clipboard.
As the clipboard and drag and drop both use the wl_data_device, the dataDeviceHandleDataOffer callback is called for new clipboard and new drag and drop requests. So previously while an item has been hovered over the window the glfwGetClipboardString function would return the current drag and drop payload. The new version uses dataDeviceHandleSelection and dataDeviceHandleEnter to distinguish between clipboard and drag-and-drop data respectively.
Similar to the other backends, only the text/uri-list mimetype is handled. The uri-list is parsed with the parseUriList function which has been copied from the X11 backend. This function could be moved to a general utility file to remove this duplication.