### PR TITLE
#2042 Joystick without buttons are not working

### DIFF
--- a/src/linux_joystick.c
+++ b/src/linux_joystick.c
@@ -157,7 +157,7 @@ static GLFWbool openJoystickDevice(const char* path)
     }
 
     // Ensure this device supports the events expected of a joystick
-    if (!isBitSet(EV_KEY, evBits) || !isBitSet(EV_ABS, evBits))
+    if (!isBitSet(EV_ABS, evBits))
     {
         close(linjs.fd);
         return GLFW_FALSE;


### PR DESCRIPTION
Joysticks in linux without buttons are not working.
Remove the mandatory button attribute from detection.