### PR TITLE
Added glfwIsInitialized function

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -2364,6 +2364,22 @@ GLFWAPI const char* glfwGetVersionString(void);
  */
 GLFWAPI int glfwGetError(const char** description);
 
+/*! @brief Returns the initialization state.
+*   This function returns whether the library has been initialized or not.
+*   @return `GLFW_TRUE` if initialized, or `GLFW_FALSE` otherwise.
+*
+*   @errors None.
+*   
+*   @remark This function may be called before @ref glfwInit.
+*
+*   @thread_safety This function may be called from any thread.
+*   
+*   @since Added in version 3.3.6
+*   
+*   @ingroup init
+*/
+GLFWAPI int glfwIsInitialized(void);
+
 /*! @brief Sets the error callback.
  *
  *  This function sets the error callback, which is called with an error code
@@ -2408,6 +2424,7 @@ GLFWAPI int glfwGetError(const char** description);
  *
  *  @ingroup init
  */
+
 GLFWAPI GLFWerrorfun glfwSetErrorCallback(GLFWerrorfun callback);
 
 /*! @brief Returns the currently selected platform.

--- a/src/init.c
+++ b/src/init.c
@@ -484,6 +484,11 @@ GLFWAPI int glfwGetError(const char** description)
     return code;
 }
 
+GLFWAPI int glfwIsInitialized(void)
+{
+    return _glfw.initialized;
+}
+
 GLFWAPI GLFWerrorfun glfwSetErrorCallback(GLFWerrorfun cbfun)
 {
     _GLFW_SWAP(GLFWerrorfun, _glfwErrorCallback, cbfun);


### PR DESCRIPTION
This adds a `glfwIsInitialized` function, that just accesses the internal `initialized` paramter of the `GLFWlibrary` object.

This makes it more direct and convenient to check if glfw is already initialized.

As requested in [glfw#2036](https://github.com/glfw/glfw/issues/2036)