### PR TITLE
Added a glfwGetVulkanResultString

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -6212,6 +6212,23 @@ GLFWAPI const char** glfwGetRequiredInstanceExtensions(uint32_t* count);
 
 #if defined(VK_VERSION_1_0)
 
+/*! @brief Returns the result as a string.
+ *
+ *  This function returns a string describing the specified error code.
+ *
+ *  @param[in] error The error code.
+ *  @return A static string describing the error.
+ *
+ *  @errors none
+ *
+ *  @thread_safety This function may be called from any thread.
+ *
+ *  @since Added in version 3.3.
+ *
+ *  @ingroup vulkan
+ */
+GLFWAPI const char* glfwGetVulkanResultString(VkResult result);
+
 /*! @brief Returns the address of the specified Vulkan instance function.
  *
  *  This function returns the address of the specified Vulkan core or extension

--- a/src/internal.h
+++ b/src/internal.h
@@ -305,12 +305,62 @@ typedef enum VkResult
     VK_ERROR_INCOMPATIBLE_DRIVER = -9,
     VK_ERROR_TOO_MANY_OBJECTS = -10,
     VK_ERROR_FORMAT_NOT_SUPPORTED = -11,
+    VK_ERROR_FRAGMENTED_POOL = -12,
+    VK_ERROR_UNKNOWN = -13,
+  // Provided by VK_VERSION_1_1
+    VK_ERROR_OUT_OF_POOL_MEMORY = -1000069000,
+  // Provided by VK_VERSION_1_1
+    VK_ERROR_INVALID_EXTERNAL_HANDLE = -1000072003,
+  // Provided by VK_VERSION_1_2
+    VK_ERROR_FRAGMENTATION = -1000161000,
+  // Provided by VK_VERSION_1_2
+    VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS = -1000257000,
+  // Provided by VK_VERSION_1_3
+    VK_PIPELINE_COMPILE_REQUIRED = 1000297000,
+  // Provided by VK_KHR_surface
     VK_ERROR_SURFACE_LOST_KHR = -1000000000,
-    VK_SUBOPTIMAL_KHR = 1000001003,
-    VK_ERROR_OUT_OF_DATE_KHR = -1000001004,
-    VK_ERROR_INCOMPATIBLE_DISPLAY_KHR = -1000003001,
+  // Provided by VK_KHR_surface
     VK_ERROR_NATIVE_WINDOW_IN_USE_KHR = -1000000001,
+  // Provided by VK_KHR_swapchain
+    VK_SUBOPTIMAL_KHR = 1000001003,
+  // Provided by VK_KHR_swapchain
+    VK_ERROR_OUT_OF_DATE_KHR = -1000001004,
+  // Provided by VK_KHR_display_swapchain
+    VK_ERROR_INCOMPATIBLE_DISPLAY_KHR = -1000003001,
+  // Provided by VK_EXT_debug_report
     VK_ERROR_VALIDATION_FAILED_EXT = -1000011001,
+  // Provided by VK_NV_glsl_shader
+    VK_ERROR_INVALID_SHADER_NV = -1000012000,
+  // Provided by VK_EXT_image_drm_format_modifier
+    VK_ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT = -1000158000,
+  // Provided by VK_KHR_global_priority
+    VK_ERROR_NOT_PERMITTED_KHR = -1000174001,
+  // Provided by VK_EXT_full_screen_exclusive
+    VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT = -1000255000,
+  // Provided by VK_KHR_deferred_host_operations
+    VK_THREAD_IDLE_KHR = 1000268000,
+  // Provided by VK_KHR_deferred_host_operations
+    VK_THREAD_DONE_KHR = 1000268001,
+  // Provided by VK_KHR_deferred_host_operations
+    VK_OPERATION_DEFERRED_KHR = 1000268002,
+  // Provided by VK_KHR_deferred_host_operations
+    VK_OPERATION_NOT_DEFERRED_KHR = 1000268003,
+  // Provided by VK_KHR_maintenance1
+    VK_ERROR_OUT_OF_POOL_MEMORY_KHR = VK_ERROR_OUT_OF_POOL_MEMORY,
+  // Provided by VK_KHR_external_memory
+    VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR = VK_ERROR_INVALID_EXTERNAL_HANDLE,
+  // Provided by VK_EXT_descriptor_indexing
+    VK_ERROR_FRAGMENTATION_EXT = VK_ERROR_FRAGMENTATION,
+  // Provided by VK_EXT_global_priority
+    VK_ERROR_NOT_PERMITTED_EXT = VK_ERROR_NOT_PERMITTED_KHR,
+  // Provided by VK_EXT_buffer_device_address
+    VK_ERROR_INVALID_DEVICE_ADDRESS_EXT = VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS,
+  // Provided by VK_KHR_buffer_device_address
+    VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS_KHR = VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS,
+  // Provided by VK_EXT_pipeline_creation_cache_control
+    VK_PIPELINE_COMPILE_REQUIRED_EXT = VK_PIPELINE_COMPILE_REQUIRED,
+  // Provided by VK_EXT_pipeline_creation_cache_control
+    VK_ERROR_PIPELINE_COMPILE_REQUIRED_EXT = VK_PIPELINE_COMPILE_REQUIRED,
     VK_RESULT_MAX_ENUM = 0x7FFFFFFF
 } VkResult;
 

--- a/src/vulkan.c
+++ b/src/vulkan.c
@@ -162,7 +162,7 @@ void _glfwTerminateVulkan(void)
 }
 
 const char* _glfwGetVulkanResultString(VkResult result)
-{
+{   
     switch (result)
     {
         case VK_SUCCESS:
@@ -177,6 +177,18 @@ const char* _glfwGetVulkanResultString(VkResult result)
             return "An event is unsignaled";
         case VK_INCOMPLETE:
             return "A return array was too small for the result";
+        case VK_SUBOPTIMAL_KHR:
+            return "A swapchain no longer matches the surface properties exactly, but can still be used to present to the surface successfully";
+        case VK_THREAD_IDLE_KHR:
+            return "A deferred operation is not complete but there is currently no work for this thread to do at the time of this call";
+        case VK_THREAD_DONE_KHR:
+            return "A deferred operation is not complete but there is no work remaining to assign to additional threads";
+        case VK_OPERATION_DEFERRED_KHR:
+            return "A deferred operation was requested and at least some of the work was deferred";
+        case VK_OPERATION_NOT_DEFERRED_KHR:
+            return "A deferred operation was requested and no work was deferred";
+        case VK_PIPELINE_COMPILE_REQUIRED:
+            return "A requested pipeline creation would have required compilation, but the application requested compilation to not be performed";
         case VK_ERROR_OUT_OF_HOST_MEMORY:
             return "A host memory allocation has failed";
         case VK_ERROR_OUT_OF_DEVICE_MEMORY:
@@ -194,25 +206,35 @@ const char* _glfwGetVulkanResultString(VkResult result)
         case VK_ERROR_FEATURE_NOT_PRESENT:
             return "A requested feature is not supported";
         case VK_ERROR_INCOMPATIBLE_DRIVER:
-            return "The requested version of Vulkan is not supported by the driver or is otherwise incompatible";
+            return "The requested version of Vulkan is not supported by the driver or is otherwise incompatible for implementation-specific reasons";
         case VK_ERROR_TOO_MANY_OBJECTS:
             return "Too many objects of the type have already been created";
         case VK_ERROR_FORMAT_NOT_SUPPORTED:
             return "A requested format is not supported on this device";
+        case VK_ERROR_FRAGMENTED_POOL:
+            return "A pool allocation has failed due to fragmentation of the pool's memory";
         case VK_ERROR_SURFACE_LOST_KHR:
             return "A surface is no longer available";
-        case VK_SUBOPTIMAL_KHR:
-            return "A swapchain no longer matches the surface properties exactly, but can still be used";
-        case VK_ERROR_OUT_OF_DATE_KHR:
-            return "A surface has changed in such a way that it is no longer compatible with the swapchain";
-        case VK_ERROR_INCOMPATIBLE_DISPLAY_KHR:
-            return "The display used by a swapchain does not use the same presentable image layout";
         case VK_ERROR_NATIVE_WINDOW_IN_USE_KHR:
             return "The requested window is already connected to a VkSurfaceKHR, or to some other non-Vulkan API";
-        case VK_ERROR_VALIDATION_FAILED_EXT:
-            return "A validation layer found an error";
+        case VK_ERROR_OUT_OF_DATE_KHR:
+            return "A surface has changed in such a way that it is no longer compatible with the swapchain, and further presentation requests using the swapchain will fail";
+        case VK_ERROR_INCOMPATIBLE_DISPLAY_KHR:
+            return "The display used by a swapchain does not use the same presentable image layout, or is incompatible in a way that prevents sharing an image";
+        case VK_ERROR_INVALID_SHADER_NV:
+            return "One or more shaders failed to compile or link";
+        case VK_ERROR_OUT_OF_POOL_MEMORY_KHR:
+            return "A pool memory allocation has failed";
+        case VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR:
+            return "A synchronization primitive returned an invalid external handle";
+        case VK_ERROR_FRAGMENTATION_EXT:
+            return "A descriptor pool creation has failed due to fragmentation";
+        case VK_ERROR_INVALID_DEVICE_ADDRESS_EXT:
+            return "A buffer creation failed because the requested address is not available";
+        case VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT:
+            return "A swapchain created with the full screen exclusive mode cannot be used to create another full screen exclusive swapchain";
         default:
-            return "ERROR: UNKNOWN VULKAN ERROR";
+            return "Unknown error";
     }
 }
 
@@ -225,6 +247,10 @@ GLFWAPI int glfwVulkanSupported(void)
 {
     _GLFW_REQUIRE_INIT_OR_RETURN(GLFW_FALSE);
     return _glfwInitVulkan(_GLFW_FIND_LOADER);
+}
+
+GLFWAPI const char* glfwGetVulkanResultString(VkResult result){
+    return _glfwGetVulkanResultString(result);
 }
 
 GLFWAPI const char** glfwGetRequiredInstanceExtensions(uint32_t* count)


### PR DESCRIPTION
This adds a public `glfwGetVulkanResultString` function, improves the already existing internal `_glfwGetVulkanResultString` function by adding all official error code descriptions and updating the internal [`VkResult`](https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkResult.html#_description) enum to the Vulkan 1.3 definition
The internal function is just exposed by this patch, but preserved to not break the internal API.