### PR TITLE
Save and restore original X11 error handler

### DIFF
--- a/src/glx_context.c
+++ b/src/glx_context.c
@@ -495,7 +495,7 @@ GLFWbool _glfwCreateContextGLX(_GLFWwindow* window,
         }
     }
 
-    _glfwGrabErrorHandlerX11();
+    int (*orighandler)() = _glfwGrabErrorHandlerX11();
 
     if (_glfw.glx.ARB_create_context)
     {
@@ -605,7 +605,7 @@ GLFWbool _glfwCreateContextGLX(_GLFWwindow* window,
             createLegacyContextGLX(window, native, share);
     }
 
-    _glfwReleaseErrorHandlerX11();
+    _glfwReleaseErrorHandlerX11(orighandler);
 
     if (!window->context.glx.handle)
     {

--- a/src/x11_init.c
+++ b/src/x11_init.c
@@ -523,7 +523,7 @@ static void detectEWMH(void)
         return;
     }
 
-    _glfwGrabErrorHandlerX11();
+    int (*orighandler)() = _glfwGrabErrorHandlerX11();
 
     // If it exists, it should be the XID of a top-level window
     // Then we look for the same property on that window
@@ -538,7 +538,7 @@ static void detectEWMH(void)
         return;
     }
 
-    _glfwReleaseErrorHandlerX11();
+    _glfwReleaseErrorHandlerX11(orighandler);
 
     // If the property exists, it should contain the XID of the window
 
@@ -1093,19 +1093,19 @@ static int errorHandler(Display *display, XErrorEvent* event)
 
 // Sets the X error handler callback
 //
-void _glfwGrabErrorHandlerX11(void)
+int (*_glfwGrabErrorHandlerX11(void))()
 {
     _glfw.x11.errorCode = Success;
-    XSetErrorHandler(errorHandler);
+    return XSetErrorHandler(errorHandler);
 }
 
 // Clears the X error handler callback
 //
-void _glfwReleaseErrorHandlerX11(void)
+void _glfwReleaseErrorHandlerX11(int (*orighandler)())
 {
     // Synchronize to make sure all commands are processed
     XSync(_glfw.x11.display, False);
-    XSetErrorHandler(NULL);
+    XSetErrorHandler(orighandler);
 }
 
 // Reports the specified error, appending information about the last X error

--- a/src/x11_platform.h
+++ b/src/x11_platform.h
@@ -983,8 +983,8 @@ unsigned long _glfwGetWindowPropertyX11(Window window,
                                         unsigned char** value);
 GLFWbool _glfwIsVisualTransparentX11(Visual* visual);
 
-void _glfwGrabErrorHandlerX11(void);
-void _glfwReleaseErrorHandlerX11(void);
+int (*_glfwGrabErrorHandlerX11(void))();
+void _glfwReleaseErrorHandlerX11(int (*orighandler)());
 void _glfwInputErrorX11(int error, const char* message);
 
 void _glfwPushSelectionToManagerX11(void);

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -573,7 +573,7 @@ static GLFWbool createNativeWindow(_GLFWwindow* window,
                     ExposureMask | FocusChangeMask | VisibilityChangeMask |
                     EnterWindowMask | LeaveWindowMask | PropertyChangeMask;
 
-    _glfwGrabErrorHandlerX11();
+    int (*orighandler)() = _glfwGrabErrorHandlerX11();
 
     window->x11.parent = _glfw.x11.root;
     window->x11.handle = XCreateWindow(_glfw.x11.display,
@@ -587,7 +587,7 @@ static GLFWbool createNativeWindow(_GLFWwindow* window,
                                        CWBorderPixel | CWColormap | CWEventMask,
                                        &wa);
 
-    _glfwReleaseErrorHandlerX11();
+    _glfwReleaseErrorHandlerX11(orighandler);
 
     if (!window->x11.handle)
     {
@@ -1452,7 +1452,7 @@ static void processEvent(XEvent *event)
             //       the position into root (screen) coordinates
             if (!event->xany.send_event && window->x11.parent != _glfw.x11.root)
             {
-                _glfwGrabErrorHandlerX11();
+                int (*orighandler)() = _glfwGrabErrorHandlerX11();
 
                 Window dummy;
                 XTranslateCoordinates(_glfw.x11.display,
@@ -1462,7 +1462,7 @@ static void processEvent(XEvent *event)
                                       &xpos, &ypos,
                                       &dummy);
 
-                _glfwReleaseErrorHandlerX11();
+                _glfwReleaseErrorHandlerX11(orighandler);
                 if (_glfw.x11.errorCode == BadWindow)
                     return;
             }
@@ -2526,13 +2526,13 @@ int _glfwWindowHoveredX11(_GLFWwindow* window)
         int rootX, rootY, childX, childY;
         unsigned int mask;
 
-        _glfwGrabErrorHandlerX11();
+        int (*orighandler)() = _glfwGrabErrorHandlerX11();
 
         const Bool result = XQueryPointer(_glfw.x11.display, w,
                                           &root, &w, &rootX, &rootY,
                                           &childX, &childY, &mask);
 
-        _glfwReleaseErrorHandlerX11();
+        _glfwReleaseErrorHandlerX11(orighandler);
 
         if (_glfw.x11.errorCode == BadWindow)
             w = _glfw.x11.root;


### PR DESCRIPTION
Greetings, I am proposing a patch to save&restore the X11 error handler that user might have set instead of restoring the default one. The point is that default X11 error handler is a bit ugly because it exits the program unconditionally, so the glfw user may override this (as GLFW also does).