### PR TITLE
Fix macOS libvulkan.1.dylib loading

### DIFF
--- a/src/cocoa_init.m
+++ b/src/cocoa_init.m
@@ -460,10 +460,17 @@ void* _glfwLoadLocalVulkanLoaderCocoa(void)
     if (!bundle)
         return NULL;
 
-    CFURLRef url =
-        CFBundleCopyAuxiliaryExecutableURL(bundle, CFSTR("libvulkan.1.dylib"));
-    if (!url)
+    CFURLRef frameworksUrl = CFBundleCopyPrivateFrameworksURL(bundle);
+    if (!frameworksUrl)
         return NULL;
+
+    CFURLRef url = CFURLCreateCopyAppendingPathComponent(
+        kCFAllocatorDefault, frameworksUrl, CFSTR("libvulkan.1.dylib"), false);
+    if (!url)
+    {
+        CFRelease(frameworksUrl);
+        return NULL;
+    }
 
     char path[PATH_MAX];
     void* handle = NULL;
@@ -472,6 +479,7 @@ void* _glfwLoadLocalVulkanLoaderCocoa(void)
         handle = _glfwPlatformLoadModule(path);
 
     CFRelease(url);
+    CFRelease(frameworksUrl);
     return handle;
 }
 


### PR DESCRIPTION
Fix for #2113.

Changed `libvulkan.1.dylib` search directory to the `Frameworks`.