### PR TITLE
Add a window hint for setting app_id on wayland

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -157,6 +157,7 @@ video tutorials.
  - Peoro
  - Braden Pellett
  - Christopher Pelloux
+ - Michael Pennington
  - Arturo J. Pérez
  - Vladimir Perminov
  - Anthony Pesch

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ information on what to include when reporting a bug.
 
 ## Changelog
 
+ - Added `GLFW_WAYLAND_APP_ID` window hint string for wayland app_id selection
+   (#2121)
  - Added `GLFW_PLATFORM` init hint for runtime platform selection (#1958)
  - Added `GLFW_ANY_PLATFORM`, `GLFW_PLATFORM_WIN32`, `GLFW_PLATFORM_COCOA`,
    `GLFW_PLATFORM_WAYLAND`, `GLFW_PLATFORM_X11` and `GLFW_PLATFORM_NULL` symbols to

--- a/docs/news.dox
+++ b/docs/news.dox
@@ -9,6 +9,11 @@
 
 @subsection features_34 New features in version 3.4
 
+@subsubsection wayland_app_id_32 Wayland app_id specification
+
+GLFW now supports specifying the app_id for a wayland window using the
+@ref GLFW_WAYLAND_APP_ID window hint string.
+
 @subsubsection runtime_platform_34 Runtime platform selection
 
 GLFW now supports being compiled for multiple backends and selecting between

--- a/docs/window.dox
+++ b/docs/window.dox
@@ -492,6 +492,13 @@ __GLFW_X11_CLASS_NAME__ and __GLFW_X11_INSTANCE_NAME__ specifies the desired
 ASCII encoded class and instance parts of the ICCCM `WM_CLASS` window property.
 These are set with @ref glfwWindowHintString.
 
+@subsubsection window_hints_wayland Wayland specific window hints
+
+@anchor GLFW_WAYLAND_APP_ID_hint
+__GLFW_WAYLAND_APP_ID__ specifies the wayland app_id for a wayland window, used
+by window managers to identify types of windows. This is set with
+@ref glfwWindowHintString.
+
 
 @subsubsection window_hints_values Supported and default values
 
@@ -540,6 +547,7 @@ GLFW_COCOA_FRAME_NAME         | `""`                        | A UTF-8 encoded fr
 GLFW_COCOA_GRAPHICS_SWITCHING | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
 GLFW_X11_CLASS_NAME           | `""`                        | An ASCII encoded `WM_CLASS` class name
 GLFW_X11_INSTANCE_NAME        | `""`                        | An ASCII encoded `WM_CLASS` instance name
+GLFW_WAYLAND_APP_ID           | `""`                        | An ASCII encoded wayland `app_id` name
 
 
 @section window_events Window event processing

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -1104,6 +1104,11 @@ extern "C" {
  *  [window hint](@ref GLFW_X11_CLASS_NAME_hint).
  */
 #define GLFW_X11_INSTANCE_NAME      0x00024002
+
+#define GLFW_WAYLAND_APP_ID         0x00026001
+/*! @brief Wayland specific
+ *  [window hint](@ref GLDW_WAYLAND_CLASS_NAME_hint).
+ */
 #define GLFW_WIN32_KEYBOARD_MENU    0x00025001
 /*! @} */
 

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -1104,11 +1104,12 @@ extern "C" {
  *  [window hint](@ref GLFW_X11_CLASS_NAME_hint).
  */
 #define GLFW_X11_INSTANCE_NAME      0x00024002
-
-#define GLFW_WAYLAND_APP_ID         0x00026001
 /*! @brief Wayland specific
- *  [window hint](@ref GLDW_WAYLAND_CLASS_NAME_hint).
+ *  [window hint](@ref GLFW_WAYLAND_APP_ID_hint).
+ *  
+ *  Allows specification of the wayland app_id.
  */
+#define GLFW_WAYLAND_APP_ID         0x00026001
 #define GLFW_WIN32_KEYBOARD_MENU    0x00025001
 /*! @} */
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -421,6 +421,9 @@ struct _GLFWwndconfig
     struct {
         GLFWbool  keymenu;
     } win32;
+    struct {
+        char      appId[256];
+    } wl;
 };
 
 // Context configuration

--- a/src/window.c
+++ b/src/window.c
@@ -417,6 +417,10 @@ GLFWAPI void glfwWindowHintString(int hint, const char* value)
             strncpy(_glfw.hints.window.x11.instanceName, value,
                     sizeof(_glfw.hints.window.x11.instanceName) - 1);
             return;
+        case GLFW_WAYLAND_APP_ID:
+            strncpy(_glfw.hints.window.wl.appId, value,
+                    sizeof(_glfw.hints.window.wl.appId) - 1);
+            return;
     }
 
     _glfwInputError(GLFW_INVALID_ENUM, "Invalid window hint string 0x%08X", hint);

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -249,6 +249,7 @@ typedef struct _GLFWwindowWayland
     double                      cursorPosX, cursorPosY;
 
     char*                       title;
+    char*                       appId;
 
     // We need to track the monitors the window spans on to calculate the
     // optimal scaling factor.

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -579,6 +579,9 @@ static GLFWbool createXdgSurface(_GLFWwindow* window)
                               &xdgToplevelListener,
                               window);
 
+    if (strlen(window->wl.appId))
+      xdg_toplevel_set_app_id(window->wl.xdg.toplevel, window->wl.appId);
+
     if (window->wl.title)
         xdg_toplevel_set_title(window->wl.xdg.toplevel, window->wl.title);
 
@@ -637,6 +640,8 @@ static GLFWbool createSurface(_GLFWwindow* window,
     window->wl.height = wndconfig->height;
     window->wl.scale = 1;
     window->wl.title = _glfw_strdup(wndconfig->title);
+    if (strlen(wndconfig->wl.appId))
+        window->wl.appId = _glfw_strdup(wndconfig->wl.appId);
 
     window->wl.transparent = fbconfig->transparent;
     if (!window->wl.transparent)


### PR DESCRIPTION
Simple change to support setting app_id on wayland windows, as specified in #2121 .