### PR TITLE
Add various metal helping functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,8 @@ cmake_dependent_option(GLFW_USE_HYBRID_HPG "Force use of high-performance GPU on
 cmake_dependent_option(USE_MSVC_RUNTIME_LIBRARY_DLL "Use MSVC runtime library DLL" ON
                        "MSVC" OFF)
 
+cmake_dependent_option(GLFW_USE_METALKIT "Allow GLFW to include MetalKit.h for metal support" OFF GLFW_BUILD_COCOA ON)
+
 set(GLFW_LIBRARY_TYPE "${GLFW_LIBRARY_TYPE}" CACHE STRING
     "Library type override for GLFW (SHARED, STATIC, OBJECT, or empty to follow BUILD_SHARED_LIBS)")
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ information on what to include when reporting a bug.
 
 ## Changelog
 
+ - Added `glfwAddCocoaMTKSubview` function for better metal support
  - Added `GLFW_PLATFORM` init hint for runtime platform selection (#1958)
  - Added `GLFW_ANY_PLATFORM`, `GLFW_PLATFORM_WIN32`, `GLFW_PLATFORM_COCOA`,
    `GLFW_PLATFORM_WAYLAND`, `GLFW_PLATFORM_X11` and `GLFW_PLATFORM_NULL` symbols to

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ information on what to include when reporting a bug.
 
 ## Changelog
 
+ - Added `GLFW_USE_METALKIT` to cmake build options to make metal support optional 
+ - [Cocoa] Added `glfwResetCocoaMTKFramesize` function for metal view resizing
  - [Cocoa] Added `glfwAddCocoaMTKSubview` function for better metal support
  - Added `GLFW_PLATFORM` init hint for runtime platform selection (#1958)
  - Added `GLFW_ANY_PLATFORM`, `GLFW_PLATFORM_WIN32`, `GLFW_PLATFORM_COCOA`,

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ information on what to include when reporting a bug.
 
 ## Changelog
 
- - Added `glfwAddCocoaMTKSubview` function for better metal support
+ - [Cocoa] Added `glfwAddCocoaMTKSubview` function for better metal support
  - Added `GLFW_PLATFORM` init hint for runtime platform selection (#1958)
  - Added `GLFW_ANY_PLATFORM`, `GLFW_PLATFORM_WIN32`, `GLFW_PLATFORM_COCOA`,
    `GLFW_PLATFORM_WAYLAND`, `GLFW_PLATFORM_X11` and `GLFW_PLATFORM_NULL` symbols to

--- a/include/GLFW/glfw3native.h
+++ b/include/GLFW/glfw3native.h
@@ -275,6 +275,20 @@ GLFWAPI CGDirectDisplayID glfwGetCocoaMonitor(GLFWmonitor* monitor);
  *  @ingroup native
  */
 GLFWAPI id glfwGetCocoaWindow(GLFWwindow* window);
+
+/*! @brief Adds an 'MTKView' to the window's main NSView as a subview
+ *
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety Call this function from the main thread.
+ *
+ *  @since Added in version 3.3.
+ *
+ *  @ingroup native
+ */
+GLFWAPI void glfwAddCocoaMTKSubview(GLFWwindow* window, void* view);
+
 #endif
 
 #if defined(GLFW_EXPOSE_NATIVE_NSGL)

--- a/include/GLFW/glfw3native.h
+++ b/include/GLFW/glfw3native.h
@@ -289,6 +289,20 @@ GLFWAPI id glfwGetCocoaWindow(GLFWwindow* window);
  */
 GLFWAPI void glfwAddCocoaMTKSubview(GLFWwindow* window, void* view);
 
+
+/*! @brief Resizes an 'MTKView' to the window's framebuffer size -helpful because the Apple metal-cpp API lacks the ability to do this
+ *
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety Call this function from the main thread.
+ *
+ *  @since Added in version 3.3.
+ *
+ *  @ingroup native
+ */
+GLFWAPI void glfwResetCocoaMTKFramesize(GLFWwindow* window, void* view);
+
 #endif
 
 #if defined(GLFW_EXPOSE_NATIVE_NSGL)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,9 @@ set_target_properties(update_mappings PROPERTIES FOLDER "GLFW3")
 
 if (GLFW_BUILD_COCOA)
     target_compile_definitions(glfw PRIVATE _GLFW_COCOA)
+    if(GLFW_USE_METALKIT)
+        target_compile_definitions(glfw PRIVATE _GLFW_BUILD_METAL_DEPENDENCIES)
+    endif()
     target_sources(glfw PRIVATE cocoa_platform.h cocoa_joystick.h cocoa_init.m
                                 cocoa_joystick.m cocoa_monitor.m cocoa_window.m
                                 nsgl_context.m)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -164,6 +164,15 @@ if (GLFW_BUILD_COCOA)
                                        "-framework IOKit"
                                        "-framework CoreFoundation")
 
+    if(GLFW_USE_METALKIT)
+
+        target_link_libraries(glfw PRIVATE "-framework Metal"  
+                                           "-framework MetalKit")
+
+    endif()
+
+
+
     set(glfw_PKG_DEPS "")
     set(glfw_PKG_LIBS "-framework Cocoa -framework IOKit -framework CoreFoundation")
 endif()

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -30,7 +30,6 @@
 
 #include <float.h>
 #include <string.h>
-#import <MetalKit/MetalKit.h>
 
 // Returns the style mask corresponding to the window settings
 //
@@ -276,6 +275,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
         window->ns.height = contentRect.size.height;
         _glfwInputWindowSize(window, contentRect.size.width, contentRect.size.height);
     }
+
 }
 
 - (void)windowDidMove:(NSNotification *)notification
@@ -363,6 +363,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
 
         [self updateTrackingAreas];
         [self registerForDraggedTypes:@[NSPasteboardTypeURL]];
+        
     }
 
     return self;
@@ -1951,6 +1952,9 @@ GLFWAPI id glfwGetCocoaWindow(GLFWwindow* handle)
     return window->ns.object;
 }
 
+
+#ifdef _GLFW_BUILD_METAL_DEPENDENCIES
+#import <MetalKit/MetalKit.h>
 GLFWAPI void glfwAddCocoaMTKSubview(GLFWwindow* handle, void* view) {
 
     _GLFWwindow* window = (_GLFWwindow*) handle;
@@ -1968,3 +1972,44 @@ GLFWAPI void glfwAddCocoaMTKSubview(GLFWwindow* handle, void* view) {
 
 }
 
+GLFWAPI void glfwResetCocoaMTKFramesize(GLFWwindow* handle, void* view) { 
+
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFW_REQUIRE_INIT_OR_RETURN();
+
+    if (_glfw.platform.platformID != GLFW_PLATFORM_COCOA)
+    {
+        _glfwInputError(GLFW_PLATFORM_UNAVAILABLE,
+                        "Cocoa: Platform not initialized");
+        return;
+    }
+
+    MTKView* mtkView = (MTKView*) view;
+    int width, height;
+    _glfwGetFramebufferSizeCocoa(window, &width, &height);
+    NSSize size = NSMakeSize(width, height);
+    [mtkView setFrameSize: size];
+
+
+}
+
+#else
+GLFWAPI void glfwAddCocoaMTKSubview(GLFWwindow* handle, void* view) {
+
+    _GLFW_REQUIRE_INIT_OR_RETURN();
+    _glfwInputError(GLFW_PLATFORM_ERROR,
+                    "GLFW was compiled without \"GLFW_USE_METALKIT\" enabled");
+    
+
+}
+
+GLFWAPI void glfwResetCocoaMTKFramesize(GLFWwindow* handle, void* view) {
+
+    _GLFW_REQUIRE_INIT_OR_RETURN();
+    _glfwInputError(GLFW_PLATFORM_ERROR,
+                    "GLFW was compiled without \"GLFW_USE_METALKIT\" enabled");
+
+}
+
+
+#endif

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -30,6 +30,7 @@
 
 #include <float.h>
 #include <string.h>
+#import <MetalKit/MetalKit.h>
 
 // Returns the style mask corresponding to the window settings
 //
@@ -1948,5 +1949,22 @@ GLFWAPI id glfwGetCocoaWindow(GLFWwindow* handle)
     }
 
     return window->ns.object;
+}
+
+GLFWAPI void glfwAddCocoaMTKSubview(GLFWwindow* handle, void* view) {
+
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFW_REQUIRE_INIT_OR_RETURN();
+
+    if (_glfw.platform.platformID != GLFW_PLATFORM_COCOA)
+    {
+        _glfwInputError(GLFW_PLATFORM_UNAVAILABLE,
+                        "Cocoa: Platform not initialized");
+        return;
+    }
+
+    [window->ns.view addSubview: (MTKView*) view];
+
+
 }
 


### PR DESCRIPTION
GLFW was just a good 2 functions away from metal/metal-cpp integration being a breeze.

While accessing the Cocoa native window and setting the currentView to your metal MTKView was always possible- it came with a good amount of caveats. One of those being that the input system just stopped functioning.

I found the easiest way to work around this to be adding the MTKView as a subview to the GLFWwindow view.

so I introduced the cocoa native "glfwAddCocoaMTKSubview" function to do just that.

on a slightly less exciting note I also added the native "glfwResetCocoaMTKFramesize" function just because apple's
metal-cpp binding genuinely lacks the ability to resize the MTKView, so this function just helpfully sets the MTKView size to the window frame buffer size using the native Objective-C call.

I also made all of this new native API stuff optional by introducing the CMake build option "GLFW_USE_METALKIT" which is off by default.

I'm also fortunate enough to have access to Mac, linux, and windows so I was able to run all tests on all 3 platforms and they all worked flawlessly.

