### PR TITLE
Fix MoltenVK Loading on macOS

### DIFF
--- a/src/cocoa_init.m
+++ b/src/cocoa_init.m
@@ -465,7 +465,7 @@ void* _glfwLoadLocalVulkanLoaderCocoa(void)
         return NULL;
 
     CFURLRef loaderUrl = CFURLCreateCopyAppendingPathComponent(
-        kCFAllocatorDefault, frameworksUrl, CFSTR("libvulkan.1.dylib"), false);
+        kCFAllocatorDefault, frameworksUrl, CFSTR("libMoltenVK.dylib"), false);
     if (!loaderUrl)
     {
         CFRelease(frameworksUrl);

--- a/src/vulkan.c
+++ b/src/vulkan.c
@@ -60,7 +60,7 @@ GLFWbool _glfwInitVulkan(int mode)
 #elif defined(_GLFW_WIN32)
         _glfw.vk.handle = _glfwPlatformLoadModule("vulkan-1.dll");
 #elif defined(_GLFW_COCOA)
-        _glfw.vk.handle = _glfwPlatformLoadModule("libvulkan.1.dylib");
+        _glfw.vk.handle = _glfwPlatformLoadModule("libMoltenVK.dylib");
         if (!_glfw.vk.handle)
             _glfw.vk.handle = _glfwLoadLocalVulkanLoaderCocoa();
 #elif defined(__OpenBSD__) || defined(__NetBSD__)


### PR DESCRIPTION
Loading Vulkan fails on macOS even if the user has libMoltenVK.dylib. This is because it tries to load libvulkan.1.dylib, not libMoltenVK.dylib.