### PR TITLE
X11: Fix inconsistent modifier state

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ information on what to include when reporting a bug.
    (#1380)
  - [EGL] Bugfix: The `GLFW_DOUBLEBUFFER` context attribute was ignored (#1843)
  - [GLX] Bugfix: Context creation failed if GLX 1.4 was not exported by GLX library
+ - [X11] Bugfix: Inconsistency for Key Event Modifiers between Windows and Linux/X11
 
 
 ## Contact


### PR DESCRIPTION
Use XkbGetState to poll modifier key state mask for up-to-date modifier state after modifier KeyPress/KeyRelease events.

Fixes https://github.com/glfw/glfw/issues/1630

Attached is a run of the events test with the UK keyboard layout on X11 with this patch applied. You can see that now the modifier state of each key press/release event is consistent with the state change caused by that modifier key press/release and that physical right alt (AltGr) is still correctly treated as a non-alt key.

    mantissa@MantissaXPS:~/Documents/glfw/build$ ./tests/events 
    Library initialized
    Creating windowed mode window 1 (640x480)
    Main loop starting
    00000000 to 1 at 0.142: Window position: 3890 181
    00000001 to 1 at 0.142: Window refresh
    00000002 to 1 at 0.154: Window focused
    00000003 to 1 at 4.051: Key 0x0155 Scancode 0x0025 (LEFT CONTROL) (with control) was pressed
    00000004 to 1 at 4.474: Key 0x0155 Scancode 0x0025 (LEFT CONTROL) (with no mods) was released
    00000005 to 1 at 5.179: Key 0x0154 Scancode 0x0032 (LEFT SHIFT) (with shift) was pressed
    00000006 to 1 at 5.610: Key 0x0154 Scancode 0x0032 (LEFT SHIFT) (with no mods) was released
    00000007 to 1 at 6.403: Key 0x0156 Scancode 0x0040 (LEFT ALT) (with alt) was pressed
    00000008 to 1 at 6.811: Key 0x0156 Scancode 0x0040 (LEFT ALT) (with no mods) was released
    00000009 to 1 at 8.835: Key 0x0155 Scancode 0x0025 (LEFT CONTROL) (with control) was pressed
    0000000a to 1 at 9.219: Key 0x0154 Scancode 0x0032 (LEFT SHIFT) (with shift control) was pressed
    0000000b to 1 at 9.923: Key 0x004d Scancode 0x003a (M) (m) (with shift control) was pressed
    0000000c to 1 at 10.323: Key 0x004d Scancode 0x003a (M) (m) (with shift control) was released
    0000000d to 1 at 10.395: Key 0x0154 Scancode 0x0032 (LEFT SHIFT) (with control) was released
    0000000e to 1 at 10.411: Key 0x0155 Scancode 0x0025 (LEFT CONTROL) (with no mods) was released
    0000000f to 1 at 11.836: Key 0x015a Scancode 0x006c (RIGHT ALT) (with no mods) was pressed
    00000010 to 1 at 12.507: Key 0x004c Scancode 0x002e (L) (l) (with no mods) was pressed
    (( lock key mods enabled ))
    00000011 to 1 at 12.508: Character 0x00000142 (ł) input
    00000012 to 1 at 12.859: Key 0x004c Scancode 0x002e (L) (l) (with no mods) was released
    00000013 to 1 at 14.316: Key 0x015a Scancode 0x006c (RIGHT ALT) (with no mods) was released
    00000014 to 1 at 16.996: Key 0x015a Scancode 0x006c (RIGHT ALT) (with no mods) was pressed
    00000015 to 1 at 17.364: Key 0x0034 Scancode 0x000d (4) (4) (with no mods) was pressed
    00000016 to 1 at 17.365: Character 0x000020ac (€) input
    00000017 to 1 at 17.740: Key 0x0034 Scancode 0x000d (4) (4) (with no mods) was released
    00000018 to 1 at 18.260: Key 0x015a Scancode 0x006c (RIGHT ALT) (with no mods) was released
    00000019 to 1 at 24.824: Window close
