### PR TITLE
Linux: Modify _glfwPollJoystickLinux return true only when new valid event

### DIFF
--- a/src/linux_joystick.c
+++ b/src/linux_joystick.c
@@ -385,6 +385,7 @@ void _glfwTerminateJoysticksLinux(void)
 GLFWbool _glfwPollJoystickLinux(_GLFWjoystick* js, int mode)
 {
     // Read all queued events (non-blocking)
+    GLFWbool event_valid = GLFW_FALSE;
     for (;;)
     {
         struct input_event e;
@@ -395,6 +396,8 @@ GLFWbool _glfwPollJoystickLinux(_GLFWjoystick* js, int mode)
             // Reset the joystick slot if the device was disconnected
             if (errno == ENODEV)
                 closeJoystick(js);
+            else if ((errno == EAGAIN) && (mode != _GLFW_POLL_PRESENCE))
+                return event_valid;
 
             break;
         }
@@ -406,6 +409,7 @@ GLFWbool _glfwPollJoystickLinux(_GLFWjoystick* js, int mode)
             else if (e.code == SYN_REPORT)
             {
                 _glfw.linjs.dropped = GLFW_FALSE;
+                event_valid = GLFW_TRUE;
                 pollAbsState(js);
             }
         }


### PR DESCRIPTION
To keep consistent with the event reporting mechanism, and returns true only when a new valid event occurs.