### PR TITLE
Use wglGetPixelFormatAttribivARB to get pixel format count

### DIFF
--- a/src/wgl_context.c
+++ b/src/wgl_context.c
@@ -72,10 +72,20 @@ static int choosePixelFormatWGL(_GLFWwindow* window,
     int attribs[40];
     int values[sizeof(attribs) / sizeof(attribs[0])];
 
-    nativeCount = DescribePixelFormat(window->context.wgl.dc,
-                                      1,
-                                      sizeof(PIXELFORMATDESCRIPTOR),
-                                      NULL);
+    if (_glfw.wgl.ARB_pixel_format)
+    {
+        int attrib[] = { WGL_NUMBER_PIXEL_FORMATS_ARB };
+
+        wglGetPixelFormatAttribivARB(window->context.wgl.dc, 1, 0,
+                                     1, attrib, &nativeCount);
+    }
+    else
+    {
+        nativeCount = DescribePixelFormat(window->context.wgl.dc,
+                                          1,
+                                          sizeof(PIXELFORMATDESCRIPTOR),
+                                          NULL);
+    }
 
     if (_glfw.wgl.ARB_pixel_format)
     {


### PR DESCRIPTION
DescribePixelFormat can return a very different number of pixel formats than does wglGetPixelFormatAttribivARB: 220 vs 670 on my system (Nvidia GTX 965 M). Being different in that direction is not a problem, but if DescribePixelFormat returns more formats than
wglGetPixelFormatAttribivARB, the loop will fail and terminate the context creation.