### PR TITLE
Fix Joysticks On Linux

### DIFF
--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -394,7 +394,7 @@ GLFWbool _glfwConnectWayland(int platformID, _GLFWplatform* platform)
         _glfwGetKeyScancodeWayland,
         _glfwSetClipboardStringWayland,
         _glfwGetClipboardStringWayland,
-#if defined(_GLFW_LINUX_JOYSTICK)
+#if defined(GLFW_BUILD_LINUX_JOYSTICK)
         _glfwInitJoysticksLinux,
         _glfwTerminateJoysticksLinux,
         _glfwPollJoystickLinux,

--- a/src/x11_init.c
+++ b/src/x11_init.c
@@ -1184,7 +1184,7 @@ GLFWbool _glfwConnectX11(int platformID, _GLFWplatform* platform)
         _glfwGetKeyScancodeX11,
         _glfwSetClipboardStringX11,
         _glfwGetClipboardStringX11,
-#if defined(_GLFW_LINUX_JOYSTICK)
+#if defined(GLFW_BUILD_LINUX_JOYSTICK)
         _glfwInitJoysticksLinux,
         _glfwTerminateJoysticksLinux,
         _glfwPollJoystickLinux,

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -88,7 +88,7 @@ static GLFWbool waitForAnyEvent(double* timeout)
         { _glfw.x11.emptyEventPipe[0], POLLIN }
     };
 
-#if defined(_GLFW_LINUX_JOYSTICK)
+#if defined(GLFW_BUILD_LINUX_JOYSTICK)
     if (_glfw.joysticksInitialized)
         fds[count++] = (struct pollfd) { _glfw.linjs.inotify, POLLIN };
 #endif
@@ -2783,7 +2783,7 @@ void _glfwPollEventsX11(void)
 {
     drainEmptyEvents();
 
-#if defined(_GLFW_LINUX_JOYSTICK)
+#if defined(GLFW_BUILD_LINUX_JOYSTICK)
     if (_glfw.joysticksInitialized)
         _glfwDetectJoystickConnectionLinux();
 #endif


### PR DESCRIPTION
Joystick support isn't initialized unless ``_GLFW_LINUX_JOYSTICK`` is defined, and this is never defined. I replaced the checks with checks for ``GLFW_BUILD_LINUX_JOYSTICK``, which is actually defined.