### PR TITLE
Fix Detecting New Joysticks On Wayland After Window Created

### DIFF
--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -873,6 +873,11 @@ static void inputText(_GLFWwindow* window, uint32_t scancode)
 
 static void handleEvents(double* timeout)
 {
+#if defined(GLFW_BUILD_LINUX_JOYSTICK)
+    if (_glfw.joysticksInitialized)
+        _glfwDetectJoystickConnectionLinux();
+#endif
+
     GLFWbool event = GLFW_FALSE;
     struct pollfd fds[] =
     {


### PR DESCRIPTION
Requires #2192.

Based on https://github.com/glfw/glfw/blob/dd8a678a66f1967372e5a5e3deac41ebf65ee127/src/x11_window.c#L2786-L2789.