### PR TITLE
Added standard target export by adding alias glfw3::glfw3

### DIFF
--- a/CMake/glfw3Config.cmake.in
+++ b/CMake/glfw3Config.cmake.in
@@ -1,3 +1,4 @@
 include(CMakeFindDependencyMacro)
 find_dependency(Threads)
 include("${CMAKE_CURRENT_LIST_DIR}/glfw3Targets.cmake")
+add_library(glfw3::glfw3 ALIAS glfw)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,8 @@ add_library(glfw ${GLFW_LIBRARY_TYPE}
                  egl_context.c osmesa_context.c null_platform.h null_joystick.h
                  null_init.c null_monitor.c null_window.c null_joystick.c)
 
+add_library(glfw3::glfw3 ALIAS glfw)
+
 # The time, thread and module code is shared between all backends on a given OS,
 # including the null backend, which still needs those bits to be functional
 if (APPLE)


### PR DESCRIPTION
As title says! Fixes #2025. Allows users to link to `glfw3::glfw3` whether it's with `find_package(glfw3)` or `add_subdirectory(glfw3)`. Once a breaking release is being created like glfw4, we should export the library with a namespace instead of those aliases.