### PR TITLE
Win32: Always return the current video mode

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -260,6 +260,7 @@ video tutorials.
  - Jonas Ådahl
  - Lasse Öörni
  - Leonard König
+ - comp500
  - All the unmentioned and anonymous contributors in the GLFW community, for bug
    reports, patches, feedback, testing and encouragement
 

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ information on what to include when reporting a bug.
  - [Win32] Bugfix: Instance-local operations used executable instance (#469,#1296,#1395)
  - [Win32] Bugfix: The OSMesa library was not unloaded on termination
  - [Win32] Bugfix: Right shift emitted `GLFW_KEY_UNKNOWN` when using a CJK IME (#2050)
+ - [Win32] Bugfix: GLFW refuses to go fullscreen with custom resolution refresh rate (#1904)
  - [Cocoa] Added support for `VK_EXT_metal_surface` (#1619)
  - [Cocoa] Added locating the Vulkan loader at runtime in an application bundle
  - [Cocoa] Moved main menu creation to GLFW initialization time (#1649)

--- a/src/win32_monitor.c
+++ b/src/win32_monitor.c
@@ -397,10 +397,13 @@ void _glfwGetMonitorWorkareaWin32(_GLFWmonitor* monitor,
 
 GLFWvidmode* _glfwGetVideoModesWin32(_GLFWmonitor* monitor, int* count)
 {
-    int modeIndex = 0, size = 0;
+    int modeIndex = 0, size = 1;
     GLFWvidmode* result = NULL;
 
-    *count = 0;
+    *count = 1;
+    // HACK: Always return the current video mode
+    result = _glfw_calloc(1, sizeof(GLFWvidmode));
+    _glfwGetVideoModeWin32(monitor, result);
 
     for (;;)
     {
@@ -459,14 +462,6 @@ GLFWvidmode* _glfwGetVideoModesWin32(_GLFWmonitor* monitor, int* count)
 
         (*count)++;
         result[*count - 1] = mode;
-    }
-
-    if (!*count)
-    {
-        // HACK: Report the current mode if no valid modes were found
-        result = _glfw_calloc(1, sizeof(GLFWvidmode));
-        _glfwGetVideoModeWin32(monitor, result);
-        *count = 1;
     }
 
     return result;


### PR DESCRIPTION
Always returns the currently used video mode from _glfwGetVideoModesWin32. This handles the existing edge case (where there are no valid video modes) as well as custom resolutions added in the driver that might not necessarily be supported by the display; see https://github.com/glfw/glfw/issues/1904 and https://github.com/comp500/BorderlessMining/issues/26.

These custom resolutions don't show up in EnumDisplaySettings (unless you pass EDS_RAWMODE which can return invalid resolutions - could be an opt-in flag but shouldn't be default functionality) but retrieving them as the current video mode should allow a custom resolution to be used if it is already set; particularly for applications that only allow resolutions returned in the video mode list. There should be no need to use CDS_TEST as the mode is already current.

Fixes https://github.com/glfw/glfw/issues/1904.