### PR TITLE
Bugfix for issue#2137

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ information on what to include when reporting a bug.
 
 ## Changelog
 
+ - Added `glfwGetMonitorFromWindow` function to query the monitor where the
+   largest part of a window is currently located (#1699)
  - Added `GLFW_PLATFORM` init hint for runtime platform selection (#1958)
  - Added `GLFW_ANY_PLATFORM`, `GLFW_PLATFORM_WIN32`, `GLFW_PLATFORM_COCOA`,
    `GLFW_PLATFORM_WAYLAND`, `GLFW_PLATFORM_X11` and `GLFW_PLATFORM_NULL` symbols to

--- a/docs/window.dox
+++ b/docs/window.dox
@@ -907,6 +907,19 @@ glfwSetWindowIcon(window, 0, NULL);
 @endcode
 
 
+@subsection window_monitor_from Window monitor
+
+Windows are always located on one or more monitors. You can get the
+handle for the monitor were the biggest part of a specified window is 
+currently located with @ref glfwGetMonitorFromWindow
+
+@code
+GLFWmonitor* monitor = glfwGetMonitorFromWindow(window);
+@endcode
+
+This monitor handle is one of those returned by @ref glfwGetMonitors.
+
+
 @subsection window_monitor Window monitor
 
 Full screen windows are associated with a specific monitor.  You can get the

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -3890,6 +3890,28 @@ GLFWAPI void glfwFocusWindow(GLFWwindow* window);
  */
 GLFWAPI void glfwRequestWindowAttention(GLFWwindow* window);
 
+/*! @brief Returns the monitor with the largest intersection area of the window
+ *
+ *  This function returns the handle of the monitor which has the largest area of
+ *  intersection with the area of the specified window
+ *
+ *  @param[in] window The window to query.
+ *  @return The monitor, or `NULL`
+ *  [error](@ref error_handling) occurred.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_monitor
+ *  @sa @ref glfwGetWindowMonitor
+ *
+ *  @since Added in version 3.4.
+ *
+ *  @ingroup window
+ */
+GLFWAPI GLFWmonitor* glfwGetMonitorFromWindow(GLFWwindow* window);
+
 /*! @brief Returns the monitor that the window uses for full screen mode.
  *
  *  This function returns the handle of the monitor that the specified window is

--- a/src/window.c
+++ b/src/window.c
@@ -76,10 +76,35 @@ void _glfwInputWindowFocus(_GLFWwindow* window, GLFWbool focused)
 //
 void _glfwInputWindowPos(_GLFWwindow* window, int x, int y)
 {
-    assert(window != NULL);
+  GLFWmonitor* windowMon;
+  GLFWmonitor* detectedMon;
+  const GLFWvidmode* vidmode;
+  
+  assert(window != NULL);
 
-    if (window->callbacks.pos)
-        window->callbacks.pos((GLFWwindow*) window, x, y);
+  windowMon = glfwGetWindowMonitor((GLFWwindow *) window);
+  if (windowMon != NULL)
+  {
+    // When windowMon != NULL, this is a fullscreen window.
+    // We then check if windowMon is really the monitor where
+    // the window is located and if not we set the monitor for
+    // that window to the other monitor including width, height
+    // and refreshrate. At last we simply set the position vars
+    // to 0, because the relative position of a fullscreen window
+    // content area moving from one monitor to another is always 0, 0
+    detectedMon = glfwGetMonitorFromWindow((GLFWwindow*) window);
+    if (detectedMon != NULL && windowMon != detectedMon)
+    {
+      vidmode = glfwGetVideoMode(detectedMon);
+      if (vidmode != NULL)
+      {
+        glfwSetWindowMonitor((GLFWwindow*) window, detectedMon, x = 0, y = 0, vidmode->width, vidmode->height, vidmode->refreshRate);
+      }
+    }
+  }
+
+  if (window->callbacks.pos)
+    window->callbacks.pos((GLFWwindow*) window, x, y);
 }
 
 // Notifies shared code that a window has been resized

--- a/src/window.c
+++ b/src/window.c
@@ -981,16 +981,12 @@ GLFWAPI GLFWmonitor* glfwGetMonitorFromWindow(GLFWwindow* window)
   GLFWmonitor** monitors;
   const GLFWvidmode* vidmode;
 
-  int windowWidth, windowHeight;
-  int windowFrameLeft, windowFrameTop, windowFrameRight, windowFrameBottom;
-
   unsigned int currentDim, overlapDim;
-  int overlapMonitor;
-  int i;
+  int overlapMonitor, i;
 
   _rect windowRect;
   _rect monitorRect;
-  _rect currentRect = { 0, 0, 0, 0 };
+  _rect scratchRect = { 0, 0, 0, 0 };
   _rect overlapRect = { 0, 0, 0, 0 };
 
   assert(window != NULL);
@@ -1006,17 +1002,15 @@ GLFWAPI GLFWmonitor* glfwGetMonitorFromWindow(GLFWwindow* window)
   else if (monitorCount > 1)
   {
     glfwGetWindowPos(window, &windowRect.x, &windowRect.y);
-    glfwGetWindowSize(window, &windowWidth, &windowHeight);
-    windowRect.w = windowWidth;
-    windowRect.h = windowHeight;
+    glfwGetWindowSize(window, &windowRect.w, &windowRect.h);
 
-    glfwGetWindowFrameSize(window, &windowFrameLeft, &windowFrameTop,
-      &windowFrameRight, &windowFrameBottom);
+    glfwGetWindowFrameSize(window, &scratchRect.x, &scratchRect.y, 
+      &scratchRect.w, &scratchRect.h);
 
-    windowRect.x -= windowFrameLeft;
-    windowRect.y -= windowFrameTop;
-    windowRect.w += windowFrameLeft + windowFrameRight;
-    windowRect.h += windowFrameTop + windowFrameBottom;
+    windowRect.x -= scratchRect.x;
+    windowRect.y -= scratchRect.y;
+    windowRect.w += scratchRect.x + scratchRect.w;
+    windowRect.h += scratchRect.y + scratchRect.h;
 
     overlapMonitor = -1;
 
@@ -1028,14 +1022,14 @@ GLFWAPI GLFWmonitor* glfwGetMonitorFromWindow(GLFWwindow* window)
       monitorRect.w = vidmode->width;
       monitorRect.h = vidmode->height;
 
-      currentRect = _get_intersection(&windowRect, &monitorRect);
+      scratchRect = _get_intersection(&windowRect, &monitorRect);
 
-      currentDim = currentRect.w * currentRect.h;
+      currentDim = scratchRect.w * scratchRect.h;
       overlapDim = overlapRect.w * overlapRect.h;
 
       if (currentDim > 0 && currentDim > overlapDim)
       {
-        overlapRect = currentRect;
+        overlapRect = scratchRect;
         overlapMonitor = i;
       }
     }

--- a/src/window.c
+++ b/src/window.c
@@ -974,15 +974,30 @@ static _rect _get_intersection(_rect* ra, _rect* rb)
 }
 
 GLFWAPI GLFWmonitor* glfwGetMonitorFromWindow(GLFWwindow* window)
-{
+{  
+  GLFWmonitor* result = NULL;
+
+  int monitorCount;
+  GLFWmonitor** monitors;
+  const GLFWvidmode* vidmode;
+
+  int windowWidth, windowHeight;
+  int windowFrameLeft, windowFrameTop, windowFrameRight, windowFrameBottom;
+
+  unsigned int currentDim, overlapDim;
+  int overlapMonitor;
+  int i;
+
+  _rect windowRect;
+  _rect monitorRect;
+  _rect currentRect = { 0, 0, 0, 0 };
+  _rect overlapRect = { 0, 0, 0, 0 };
+
   assert(window != NULL);
 
   _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
 
-  GLFWmonitor* result = NULL;
-
-  int monitorCount;
-  GLFWmonitor** monitors = glfwGetMonitors(&monitorCount);
+  monitors = glfwGetMonitors(&monitorCount);
 
   if (monitorCount == 1)
   {
@@ -990,14 +1005,11 @@ GLFWAPI GLFWmonitor* glfwGetMonitorFromWindow(GLFWwindow* window)
   }
   else if (monitorCount > 1)
   {
-    _rect windowRect;
     glfwGetWindowPos(window, &windowRect.x, &windowRect.y);
-    int windowWidth, windowHeight;
     glfwGetWindowSize(window, &windowWidth, &windowHeight);
     windowRect.w = windowWidth;
     windowRect.h = windowHeight;
 
-    int windowFrameLeft, windowFrameTop, windowFrameRight, windowFrameBottom;
     glfwGetWindowFrameSize(window, &windowFrameLeft, &windowFrameTop,
       &windowFrameRight, &windowFrameBottom);
 
@@ -1006,18 +1018,13 @@ GLFWAPI GLFWmonitor* glfwGetMonitorFromWindow(GLFWwindow* window)
     windowRect.w += windowFrameLeft + windowFrameRight;
     windowRect.h += windowFrameTop + windowFrameBottom;
 
-    _rect currentRect = { 0, 0, 0, 0 };
-    _rect overlapRect = { 0, 0, 0, 0 };
-    unsigned int currentDim, overlapDim;
-    int overlapMonitor = -1;
+    overlapMonitor = -1;
 
-    int i;
     for (i = 0; i < monitorCount; i++)
     {
-      _rect monitorRect;
       glfwGetMonitorPos(monitors[i], &monitorRect.x, &monitorRect.y);
 
-      const GLFWvidmode* vidmode = glfwGetVideoMode(monitors[i]);
+      vidmode = glfwGetVideoMode(monitors[i]);
       monitorRect.w = vidmode->width;
       monitorRect.h = vidmode->height;
 


### PR DESCRIPTION
Based on my last proposed glfwGetMonitorFromWindow, it is possible to fix the behaviour mentioned in issue #2137 for moving (real) fullscreen windows between monitors in a platform indepent way.