### PR TITLE
Wayland: Fix a wrong array size for _GLFWofferWayland

### DIFF
--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -1640,7 +1640,8 @@ static void dataDeviceHandleDataOffer(void* userData,
                                       struct wl_data_offer* offer)
 {
     _GLFWofferWayland* offers =
-        _glfw_realloc(_glfw.wl.offers, _glfw.wl.offerCount + 1);
+        _glfw_realloc(_glfw.wl.offers,
+                      sizeof(_GLFWofferWayland) * (_glfw.wl.offerCount + 1));
     if (!offers)
     {
         _glfwInputError(GLFW_OUT_OF_MEMORY, NULL);


### PR DESCRIPTION
Here is a sample valgrind report for this bug:
```
% valgrind --leak-check=full build-wayland/tests/events
==163693== Memcheck, a memory error detector
==163693== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==163693== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==163693== Command: build-wayland/tests/events
==163693== 
==163693== Warning: unimplemented fcntl command: 1033
==163693== Warning: unimplemented fcntl command: 1033
Library initialized
Creating windowed mode window 1 (640x480)
==163693== Warning: unimplemented fcntl command: 1033
Main loop starting
00000000 to 1 at 2.184: Window focused
==163693== Invalid write of size 8
==163693==    at 0x1325A4: dataDeviceHandleDataOffer (wl_window.c:1678)
==163693==    by 0x4FF6FF4: ??? (in /usr/lib/x86_64-linux-gnu/libffi.so.7.1.0)
==163693==    by 0x4FF6409: ??? (in /usr/lib/x86_64-linux-gnu/libffi.so.7.1.0)
==163693==    by 0x4FE83A7: ??? (in /usr/lib/x86_64-linux-gnu/libwayland-client.so.0.3.0)
==163693==    by 0x4FE4C47: ??? (in /usr/lib/x86_64-linux-gnu/libwayland-client.so.0.3.0)
==163693==    by 0x4FE621B: wl_display_dispatch_queue_pending (in /usr/lib/x86_64-linux-gnu/libwayland-client.so.0.3.0)
==163693==    by 0x130B99: handleEvents (wl_window.c:933)
==163693==    by 0x1342A5: _glfwWaitEventsWayland (wl_window.c:2629)
==163693==    by 0x128285: glfwWaitEvents (window.c:1140)
==163693==    by 0x11B4F5: main (events.c:716)
==163693==  Address 0xf02be50 is 0 bytes inside a block of size 1 alloc'd
==163693==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==163693==    by 0x11CEDF: defaultAllocate (init.c:72)
==163693==    by 0x11D77D: _glfw_calloc (init.c:305)
==163693==    by 0x11D869: _glfw_realloc (init.c:337)
==163693==    by 0x132529: dataDeviceHandleDataOffer (wl_window.c:1668)
==163693==    by 0x4FF6FF4: ??? (in /usr/lib/x86_64-linux-gnu/libffi.so.7.1.0)
==163693==    by 0x4FF6409: ??? (in /usr/lib/x86_64-linux-gnu/libffi.so.7.1.0)
==163693==    by 0x4FE83A7: ??? (in /usr/lib/x86_64-linux-gnu/libwayland-client.so.0.3.0)
==163693==    by 0x4FE4C47: ??? (in /usr/lib/x86_64-linux-gnu/libwayland-client.so.0.3.0)
==163693==    by 0x4FE621B: wl_display_dispatch_queue_pending (in /usr/lib/x86_64-linux-gnu/libwayland-client.so.0.3.0)
==163693==    by 0x130B99: handleEvents (wl_window.c:933)
==163693==    by 0x1342A5: _glfwWaitEventsWayland (wl_window.c:2629)
```

(We found it while checking our IME implementation in #2130)