### PR TITLE
Potential memory leak when terminating joystick support

### DIFF
--- a/src/linux_joystick.c
+++ b/src/linux_joystick.c
@@ -326,7 +326,9 @@ GLFWbool _glfwInitJoysticksLinux(void)
 
     // Continue without device connection notifications if inotify fails
 
-    if (regcomp(&_glfw.linjs.regex, "^event[0-9]\\+$", 0) != 0)
+    _glfw.linjs.regex_compiled = regcomp(&_glfw.linjs.regex,
+                                         "^event[0-9]\\+$", 0) == 0;
+    if (!_glfw.linjs.regex_compiled)
     {
         _glfwInputError(GLFW_PLATFORM_ERROR, "Linux: Failed to compile regex");
         return GLFW_FALSE;
@@ -378,8 +380,10 @@ void _glfwTerminateJoysticksLinux(void)
             inotify_rm_watch(_glfw.linjs.inotify, _glfw.linjs.watch);
 
         close(_glfw.linjs.inotify);
-        regfree(&_glfw.linjs.regex);
     }
+
+    if (_glfw.linjs.regex_compiled)
+        regfree(&_glfw.linjs.regex);
 }
 
 GLFWbool _glfwPollJoystickLinux(_GLFWjoystick* js, int mode)

--- a/src/linux_joystick.h
+++ b/src/linux_joystick.h
@@ -50,6 +50,7 @@ typedef struct _GLFWlibraryLinux
     int                     inotify;
     int                     watch;
     regex_t                 regex;
+    GLFWbool                regex_compiled;
     GLFWbool                dropped;
 } _GLFWlibraryLinux;
 


### PR DESCRIPTION
regfree was only being called in _glfwTerminateJoysticksLinux if the inotify instance was valid.  This seems to be erroneous as the regex is always compiled in _glfwInitJoysticksLinux even if the inotify instance initialisation fails.