### PR TITLE
Cocoa: Patched use of macOS 10.9 window occlusion API for macOS 10.8 compatibility

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -124,6 +124,7 @@ video tutorials.
  - Marco Lizza
  - Eyal Lotem
  - Aaron Loucks
+ - Ned Loynd
  - Luflosi
  - lukect
  - Tristam MacDonald

--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ information on what to include when reporting a bug.
    application (#2110)
  - [Cocoa] Bugfix: The Vulkan loader was not loaded from the `Frameworks` bundle
    subdirectory (#2113,#2120)
+ - [Cocoa] Bugfix: Patched use of macOS 10.9 window occlusion API for macOS 10.8 compatibility
  - [X11] Bugfix: The CMake files did not check for the XInput headers (#1480)
  - [X11] Bugfix: Key names were not updated when the keyboard layout changed
    (#1462,#1528)

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -37,6 +37,12 @@
 //       having been (according to documentation) added in Mac OS X 10.7
 #define NSWindowCollectionBehaviorFullScreenNone (1 << 9)
 
+// HACK: This enum value is only available on Mac OS X 10.9 onwards,
+//       so it needs to be defined on prior versions
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 1090
+#define NSWindowOcclusionStateVisible (1UL << 1)
+#endif
+
 // Returns whether the cursor is in the content area of the specified window
 //
 static GLFWbool cursorInContentArea(_GLFWwindow* window)
@@ -311,7 +317,11 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
 
 - (void)windowDidChangeOcclusionState:(NSNotification* )notification
 {
-    if ([window->ns.object occlusionState] & NSWindowOcclusionStateVisible)
+    if (
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 1090
+        [window->ns.object respondsToSelector:@selector(occlusionState)] && (NSUInteger)
+#endif
+        [window->ns.object occlusionState] & NSWindowOcclusionStateVisible)
         window->ns.occluded = GLFW_FALSE;
     else
         window->ns.occluded = GLFW_TRUE;


### PR DESCRIPTION
This fixes building against macOS SDKs older than 10.9, noted in #2161.

I'm not super familiar with Objective-C and this is my first time contributing to GLFW, so hopefully this PR is OK! I've tested this fix by building GLFW against the macOS 10.8 SDK on macOS 10.14, which now works.