### PR TITLE
ci: Update to actions/checkout@v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
             CC: clang
             CFLAGS: -Werror
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Install dependencies
               run: |
                   sudo apt update
@@ -38,7 +38,7 @@ jobs:
             CC: clang
             CFLAGS: -Werror
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Install dependencies
               run: |
                   sudo apt update
@@ -61,7 +61,7 @@ jobs:
             CFLAGS: -Werror
             MACOSX_DEPLOYMENT_TARGET: 10.8
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Configure static library
               run: cmake -S . -B build-static
@@ -79,7 +79,7 @@ jobs:
         env:
             CFLAGS: /WX
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Configure static library
               run: cmake -S . -B build-static -G "Visual Studio 17 2022"


### PR DESCRIPTION
Fixes the following CI warning:

"Node.js 12 actions are deprecated. Please update the following
actions to use Node.js 16: actions/checkout@v2..."