### PR TITLE
Win32: Prevent white window background during initialization

### DIFF
--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -1122,11 +1122,6 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
             break;
         }
 
-        case WM_ERASEBKGND:
-        {
-            return TRUE;
-        }
-
         case WM_NCACTIVATE:
         case WM_NCPAINT:
         {
@@ -1265,6 +1260,7 @@ static int createNativeWindow(_GLFWwindow* window,
         wc.lpfnWndProc   = windowProc;
         wc.hInstance     = _glfw.win32.instance;
         wc.hCursor       = LoadCursorW(NULL, IDC_ARROW);
+        wc.hbrBackground = (HBRUSH)GetStockObject(BLACK_BRUSH);
 #if defined(_GLFW_WNDCLASSNAME)
         wc.lpszClassName = _GLFW_WNDCLASSNAME;
 #else


### PR DESCRIPTION
Some applications do not render frames immediately after spawning a window.
Currently, GLFW windows have a white background, which causes a white flash when an application is launched.

This white flash is quite annoying in the situations GLFW is used (assuming mainly games and similar applications that will start with a dark background).
A white flash before a dark background is far worse than displaying a black window before light content takes over.

This commit sets the window's background color to black and lets Windows handle painting the background.

Alternatively, if having a fixed, dark background is not desired, I suggest setting `hbrBackground` to `NULL` or `(HBRUSH)GetStockObject(BLACK_BRUSH)` depending on a hint.
`WM_ERASEBKGND` shouldn't be handled either way.

Here's an example where I've added a 1 second sleep between window creation and rendering the first frame.

Before:

https://user-images.githubusercontent.com/328798/214606517-1f2acd91-81c8-4955-8f1d-4ecb4c6fb90f.mp4

After:

https://user-images.githubusercontent.com/328798/214606559-8139aaac-68bd-487e-858c-0b1127934f92.mp4

