### PR TITLE
macOS: Use CVDisplayLink for vsync

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -159,10 +159,11 @@ endif()
 if (GLFW_BUILD_COCOA)
     target_link_libraries(glfw PRIVATE "-framework Cocoa"
                                        "-framework IOKit"
-                                       "-framework CoreFoundation")
+                                       "-framework CoreFoundation"
+                                       "-framework CoreVideo")
 
     set(glfw_PKG_DEPS "")
-    set(glfw_PKG_LIBS "-framework Cocoa -framework IOKit -framework CoreFoundation")
+    set(glfw_PKG_LIBS "-framework Cocoa -framework IOKit -framework CoreFoundation -framework CoreVideo")
 endif()
 
 if (GLFW_BUILD_WAYLAND)

--- a/src/cocoa_platform.h
+++ b/src/cocoa_platform.h
@@ -37,8 +37,10 @@
 
 #if defined(__OBJC__)
 #import <Cocoa/Cocoa.h>
+#import <CoreVideo/CoreVideo.h>
 #else
 typedef void* id;
+typedef void* CVDisplayLinkRef;
 #endif
 
 // NOTE: Many Cocoa enum values have been renamed and we need to build across
@@ -124,6 +126,11 @@ typedef struct _GLFWcontextNSGL
 {
     id                pixelFormat;
     id                object;
+    int               swapInterval;
+    int               swapIntervalsPassed;
+    _GLFWmutex        swapIntervalLock;
+    _GLFWcondvar      swapIntervalCond;
+    CVDisplayLinkRef  displayLink;
 } _GLFWcontextNSGL;
 
 // NSGL-specific global data
@@ -299,4 +306,5 @@ GLFWbool _glfwCreateContextNSGL(_GLFWwindow* window,
                                 const _GLFWctxconfig* ctxconfig,
                                 const _GLFWfbconfig* fbconfig);
 void _glfwDestroyContextNSGL(_GLFWwindow* window);
+void _glfwUpdateDisplayLinkNSGL(_GLFWwindow* window);
 

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -276,6 +276,12 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
     _glfwInputWindowPos(window, x, y);
 }
 
+- (void)windowDidChangeScreen:(NSNotification *)notification
+{
+    if(window->context.source == GLFW_NATIVE_CONTEXT_API)
+        _glfwUpdateDisplayLinkNSGL(window);
+}
+
 - (void)windowDidMiniaturize:(NSNotification *)notification
 {
     if (window->monitor)

--- a/src/internal.h
+++ b/src/internal.h
@@ -77,6 +77,7 @@ typedef struct _GLFWmapping     _GLFWmapping;
 typedef struct _GLFWjoystick    _GLFWjoystick;
 typedef struct _GLFWtls         _GLFWtls;
 typedef struct _GLFWmutex       _GLFWmutex;
+typedef struct _GLFWcondvar     _GLFWcondvar;
 
 #define GL_VERSION 0x1f02
 #define GL_NONE 0
@@ -327,6 +328,32 @@ typedef void (APIENTRY * PFN_vkVoidFunction)(void);
 typedef PFN_vkVoidFunction (APIENTRY * PFN_vkGetInstanceProcAddr)(VkInstance,const char*);
 typedef VkResult (APIENTRY * PFN_vkEnumerateInstanceExtensionProperties)(const char*,uint32_t*,VkExtensionProperties*);
 #define vkGetInstanceProcAddr _glfw.vk.GetInstanceProcAddr
+
+#include "platform_thread.h"
+
+// Thread local storage structure
+//
+struct _GLFWtls
+{
+    // This is defined in platform_thread.h
+    GLFW_PLATFORM_TLS_STATE
+};
+
+// Mutex structure
+//
+struct _GLFWmutex
+{
+    // This is defined in platform_thread.h
+    GLFW_PLATFORM_MUTEX_STATE
+};
+
+// Conditional variable structure
+//
+struct _GLFWcondvar
+{
+    // This is defined in platform_thread.h
+    GLFW_PLATFORM_CONDVAR_STATE
+};
 
 #include "platform.h"
 
@@ -649,22 +676,6 @@ struct _GLFWjoystick
     GLFW_PLATFORM_JOYSTICK_STATE
 };
 
-// Thread local storage structure
-//
-struct _GLFWtls
-{
-    // This is defined in platform.h
-    GLFW_PLATFORM_TLS_STATE
-};
-
-// Mutex structure
-//
-struct _GLFWmutex
-{
-    // This is defined in platform.h
-    GLFW_PLATFORM_MUTEX_STATE
-};
-
 // Platform API structure
 //
 struct _GLFWplatform
@@ -893,6 +904,11 @@ GLFWbool _glfwPlatformCreateMutex(_GLFWmutex* mutex);
 void _glfwPlatformDestroyMutex(_GLFWmutex* mutex);
 void _glfwPlatformLockMutex(_GLFWmutex* mutex);
 void _glfwPlatformUnlockMutex(_GLFWmutex* mutex);
+
+GLFWbool _glfwPlatformCreateCondVar(_GLFWcondvar* condvar);
+void _glfwPlatformDestroyCondvar(_GLFWcondvar* condvar);
+void _glfwPlatformCondWait(_GLFWcondvar* condvar, _GLFWmutex* mutex);
+void _glfwPlatformCondSignal(_GLFWcondvar* condvar);
 
 void* _glfwPlatformLoadModule(const char* path);
 void _glfwPlatformFreeModule(void* module);

--- a/src/platform.h
+++ b/src/platform.h
@@ -27,11 +27,9 @@
 
 #if defined(GLFW_BUILD_WIN32_TIMER) || \
     defined(GLFW_BUILD_WIN32_MODULE) || \
-    defined(GLFW_BUILD_WIN32_THREAD) || \
     defined(GLFW_BUILD_COCOA_TIMER) || \
     defined(GLFW_BUILD_POSIX_TIMER) || \
     defined(GLFW_BUILD_POSIX_MODULE) || \
-    defined(GLFW_BUILD_POSIX_THREAD) || \
     defined(GLFW_BUILD_POSIX_POLL) || \
     defined(GLFW_BUILD_LINUX_JOYSTICK)
  #error "You must not define these; define zero or more _GLFW_<platform> macros instead"
@@ -155,22 +153,6 @@
         GLFW_WGL_LIBRARY_CONTEXT_STATE \
         GLFW_NSGL_LIBRARY_CONTEXT_STATE \
         GLFW_GLX_LIBRARY_CONTEXT_STATE
-
-#if defined(_WIN32)
- #define GLFW_BUILD_WIN32_THREAD
-#else
- #define GLFW_BUILD_POSIX_THREAD
-#endif
-
-#if defined(GLFW_BUILD_WIN32_THREAD)
- #include "win32_thread.h"
- #define GLFW_PLATFORM_TLS_STATE    GLFW_WIN32_TLS_STATE
- #define GLFW_PLATFORM_MUTEX_STATE  GLFW_WIN32_MUTEX_STATE
-#elif defined(GLFW_BUILD_POSIX_THREAD)
- #include "posix_thread.h"
- #define GLFW_PLATFORM_TLS_STATE    GLFW_POSIX_TLS_STATE
- #define GLFW_PLATFORM_MUTEX_STATE  GLFW_POSIX_MUTEX_STATE
-#endif
 
 #if defined(_WIN32)
  #define GLFW_BUILD_WIN32_TIMER

--- a/src/platform_thread.h
+++ b/src/platform_thread.h
@@ -1,8 +1,7 @@
 //========================================================================
-// GLFW 3.4 Win32 - www.glfw.org
+// GLFW 3.4 - www.glfw.org
 //------------------------------------------------------------------------
-// Copyright (c) 2002-2006 Marcus Geelnard
-// Copyright (c) 2006-2017 Camilla Löwy <elmindreda@glfw.org>
+// Copyright (c) 2023 Camilla Löwy <elmindreda@glfw.org>
 //
 // This software is provided 'as-is', without any express or implied
 // warranty. In no event will the authors be held liable for any damages
@@ -25,32 +24,25 @@
 //
 //========================================================================
 
-#include <windows.h>
+#if defined(GLFW_BUILD_WIN32_THREAD) || \
+    defined(GLFW_BUILD_POSIX_THREAD)
+ #error "You must not define these; define zero or more _GLFW_<platform> macros instead"
+#endif
 
-#define GLFW_WIN32_TLS_STATE            _GLFWtlsWin32     win32;
-#define GLFW_WIN32_MUTEX_STATE          _GLFWmutexWin32   win32;
-#define GLFW_WIN32_CONDVAR_STATE        _GLFWcondvarWin32 win32;
+#if defined(_WIN32)
+ #define GLFW_BUILD_WIN32_THREAD
+#else
+ #define GLFW_BUILD_POSIX_THREAD
+#endif
 
-// Win32-specific thread local storage data
-//
-typedef struct _GLFWtlsWin32
-{
-    GLFWbool            allocated;
-    DWORD               index;
-} _GLFWtlsWin32;
-
-// Win32-specific mutex data
-//
-typedef struct _GLFWmutexWin32
-{
-    GLFWbool            allocated;
-    CRITICAL_SECTION    section;
-} _GLFWmutexWin32;
-
-// Win32-specific conditional variable data
-//
-typedef struct _GLFWcondvarWin32
-{
-    GLFWbool            allocated;
-    CONDITION_VARIABLE  condvar;
-} _GLFWcondvarWin32;
+#if defined(GLFW_BUILD_WIN32_THREAD)
+ #include "win32_thread.h"
+ #define GLFW_PLATFORM_TLS_STATE    GLFW_WIN32_TLS_STATE
+ #define GLFW_PLATFORM_MUTEX_STATE  GLFW_WIN32_MUTEX_STATE
+ #define GLFW_PLATFORM_CONDVAR_STATE  GLFW_WIN32_CONDVAR_STATE
+#elif defined(GLFW_BUILD_POSIX_THREAD)
+ #include "posix_thread.h"
+ #define GLFW_PLATFORM_TLS_STATE    GLFW_POSIX_TLS_STATE
+ #define GLFW_PLATFORM_MUTEX_STATE  GLFW_POSIX_MUTEX_STATE
+ #define GLFW_PLATFORM_CONDVAR_STATE  GLFW_POSIX_CONDVAR_STATE
+#endif

--- a/src/posix_thread.c
+++ b/src/posix_thread.c
@@ -105,5 +105,41 @@ void _glfwPlatformUnlockMutex(_GLFWmutex* mutex)
     pthread_mutex_unlock(&mutex->posix.handle);
 }
 
+GLFWbool _glfwPlatformCreateCondVar(_GLFWcondvar* condvar)
+{
+    assert(condvar->posix.allocated == GLFW_FALSE);
+
+    if(pthread_cond_init(&condvar->posix.handle, NULL) != 0)
+    {
+        _glfwInputError(GLFW_PLATFORM_ERROR, "POSIX: Failed to create conditional variable");
+        return GLFW_FALSE;
+    }
+
+    return condvar->posix.allocated = GLFW_TRUE;
+}
+
+void _glfwPlatformDestroyCondvar(_GLFWcondvar* condvar)
+{
+    if (condvar->posix.allocated)
+        pthread_cond_destroy(&condvar->posix.handle);
+    memset(condvar, 0, sizeof(_GLFWcondvar));
+}
+
+void _glfwPlatformCondWait(_GLFWcondvar* condvar, _GLFWmutex* mutex)
+{
+    assert(condvar->posix.allocated == GLFW_TRUE);
+    assert(mutex->posix.allocated == GLFW_TRUE);
+
+    pthread_cond_wait(&condvar->posix.handle,
+        &mutex->posix.handle);
+}
+
+void _glfwPlatformCondSignal(_GLFWcondvar* condvar)
+{
+    assert(condvar->posix.allocated == GLFW_TRUE);
+
+    pthread_cond_signal(&condvar->posix.handle);
+}
+
 #endif // GLFW_BUILD_POSIX_THREAD
 

--- a/src/posix_thread.h
+++ b/src/posix_thread.h
@@ -27,8 +27,9 @@
 
 #include <pthread.h>
 
-#define GLFW_POSIX_TLS_STATE    _GLFWtlsPOSIX   posix;
-#define GLFW_POSIX_MUTEX_STATE  _GLFWmutexPOSIX posix;
+#define GLFW_POSIX_TLS_STATE      _GLFWtlsPOSIX     posix;
+#define GLFW_POSIX_MUTEX_STATE    _GLFWmutexPOSIX   posix;
+#define GLFW_POSIX_CONDVAR_STATE  _GLFWcondvarPOSIX posix;
 
 
 // POSIX-specific thread local storage data
@@ -47,3 +48,9 @@ typedef struct _GLFWmutexPOSIX
     pthread_mutex_t handle;
 } _GLFWmutexPOSIX;
 
+// POSIX-specific conditional variable data
+typedef struct _GLFWcondvarPOSIX
+{
+    GLFWbool        allocated;
+    pthread_cond_t  handle;
+} _GLFWcondvarPOSIX;

--- a/src/win32_thread.c
+++ b/src/win32_thread.c
@@ -98,5 +98,36 @@ void _glfwPlatformUnlockMutex(_GLFWmutex* mutex)
     LeaveCriticalSection(&mutex->win32.section);
 }
 
+GLFWbool _glfwPlatformCreateCondVar(_GLFWcondvar* condvar)
+{
+    assert(condvar->win32.allocated == GLFW_FALSE);
+    InitializeConditionVariable(condvar->win32.condvar);
+    return condvar->win32.allocated = GLFW_TRUE;
+}
+
+void _glfwPlatformDestroyCondvar(_GLFWcondvar* condvar)
+{
+    if (condvar->win32.allocated)
+        DeleteConditionVariable(condvar->win32.condvar);
+    memset(condvar, 0, sizeof(_GLFWcondvar));
+}
+
+void _glfwPlatformCondWait(_GLFWcondvar* condvar, _GLFWmutex* mutex)
+{
+    assert(condvar->win32.allocated == GLFW_TRUE);
+    assert(mutex->win32.allocated == GLFW_TRUE);
+
+    SleepConditionVariableCS(&condvar->win32.condvar,
+        &mutex->win32.section,
+        INFINITE);
+}
+
+void _glfwPlatformCondSignal(_GLFWcondvar* condvar)
+{
+    assert(condvar->win32.allocated == GLFW_TRUE);
+
+    WakeConditionVariable(&condvar->win32.condvar);
+}
+
 #endif // GLFW_BUILD_WIN32_THREAD
 

--- a/src/win32_thread.c
+++ b/src/win32_thread.c
@@ -101,7 +101,7 @@ void _glfwPlatformUnlockMutex(_GLFWmutex* mutex)
 GLFWbool _glfwPlatformCreateCondVar(_GLFWcondvar* condvar)
 {
     assert(condvar->win32.allocated == GLFW_FALSE);
-    InitializeConditionVariable(condvar->win32.condvar);
+    InitializeConditionVariable(&condvar->win32.condvar);
     return condvar->win32.allocated = GLFW_TRUE;
 }
 


### PR DESCRIPTION
Fixes #2249, #1834.

Somewhere along the line, Apple broke NSOpenGLCPSwapInterval. I've been researching this for the past week or so from various sources, and I decided to go ahead with using CVDisplayLink instead of NSOpenGLCPSwapInterval. SDL ended up doing the same thing (see issue thread [here](https://github.com/libsdl-org/SDL/issues/4918)).

I fixed it in my fork, and I decided to make this PR back to upstream for discussion on whether GLFW wants to go down this route as well.

The approach is very similar to SDL; pause the main thread right before swapping buffers in NSGL (in `glfwSwapBuffers`), and wait for the CVDisplayLink callback to continue. `glfwSwapInterval` is respected by waiting that many callbacks.

Because `cocoa_platform.h` uses a mutex, I had to shuffle around the includes in `internal.h` to get it included before `cocoa_platform.h`. I also had to add conditional variables to `posix_thread.h` and `win32_thread.h`. Multi-threading isn't my strong suite so I wouldn't be surprised if this can be improved further.