### PR TITLE
Don't crash when setting icon or getting focus on Wayland

### DIFF
--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -2112,8 +2112,7 @@ void _glfwSetWindowTitleWayland(_GLFWwindow* window, const char* title)
 void _glfwSetWindowIconWayland(_GLFWwindow* window,
                                int count, const GLFWimage* images)
 {
-    _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
-                    "Wayland: The platform does not support setting the window icon");
+   fprintf(stderr, "!!! Ignoring Error: Wayland: Setting window icon not supported\n");
 }
 
 void _glfwGetWindowPosWayland(_GLFWwindow* window, int* xpos, int* ypos)
@@ -2356,8 +2355,7 @@ void _glfwRequestWindowAttentionWayland(_GLFWwindow* window)
 
 void _glfwFocusWindowWayland(_GLFWwindow* window)
 {
-    _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
-                    "Wayland: The platform does not support setting the input focus");
+   fprintf(stderr, "!!! Ignoring Error: Wayland: Focusing a window requires user interaction\n");
 }
 
 void _glfwSetWindowMonitorWayland(_GLFWwindow* window,


### PR DESCRIPTION
Required for Minecraft on Wayland to work with modified GLFW. Upstreamed from https://github.com/Admicos/minecraft-wayland/pull/46.