### PR TITLE
Fix/macos controller segfault

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -263,6 +263,7 @@ video tutorials.
  - Jonas Ådahl
  - Lasse Öörni
  - Leonard König
+ - Daniel Hauser
  - All the unmentioned and anonymous contributors in the GLFW community, for bug
    reports, patches, feedback, testing and encouragement
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ information on what to include when reporting a bug.
    application (#2110)
  - [Cocoa] Bugfix: The Vulkan loader was not loaded from the `Frameworks` bundle
    subdirectory (#2113,#2120)
+ - [Cocoa] Bugfix: A connected joystick, for which input monitoring permissions
+   have not been granted, would cause a segfault (#2320).
  - [X11] Bugfix: The CMake files did not check for the XInput headers (#1480)
  - [X11] Bugfix: Key names were not updated when the keyboard layout changed
    (#1462,#1528)


### PR DESCRIPTION
Fixes #2320

This change is very simple and only mitigates the issue by fixing the null pointer deref. 

For the future, it might be a good idea to add functionality to GLFW to detect controllers that are detected, but are not accessible due to missing input monitoring consent. Perhaps a function similar to `glfwJoystickPresent`, like `glfwJoystickAllowed`. This would allow applications to notify the end user about granting permission.