### PR TITLE
Make a request for client version before no_error

### DIFF
--- a/src/egl_context.c
+++ b/src/egl_context.c
@@ -640,16 +640,16 @@ GLFWbool _glfwCreateContextEGL(_GLFWwindow* window,
             flags |= EGL_CONTEXT_OPENGL_ROBUST_ACCESS_BIT_KHR;
         }
 
-        if (ctxconfig->noerror)
-        {
-            if (_glfw.egl.KHR_create_context_no_error)
-                SET_ATTRIB(EGL_CONTEXT_OPENGL_NO_ERROR_KHR, GLFW_TRUE);
-        }
-
         if (ctxconfig->major != 1 || ctxconfig->minor != 0)
         {
             SET_ATTRIB(EGL_CONTEXT_MAJOR_VERSION_KHR, ctxconfig->major);
             SET_ATTRIB(EGL_CONTEXT_MINOR_VERSION_KHR, ctxconfig->minor);
+        }
+
+        if (ctxconfig->noerror)
+        {
+            if (_glfw.egl.KHR_create_context_no_error)
+                SET_ATTRIB(EGL_CONTEXT_OPENGL_NO_ERROR_KHR, GLFW_TRUE);
         }
 
         if (mask)


### PR DESCRIPTION
mesa egl requires major version >= 2 for GL_CONTEXT_OPENGL_NO_ERROR_KHR, so fulfill the request to set client version beforehand.

without this, a few pieces of software in the wild get

 libEGL debug: bad context attribute 0x31b3
 libEGL debug: EGL user error 0x3004 (EGL_BAD_ATTRIBUTE) in eglCreateContext

when running glfw under wayland.