### PR TITLE
cmake: Update minimum to 3.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4...3.20 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.6...3.20 FATAL_ERROR)
 
 project(GLFW VERSION 3.4.0 LANGUAGES C)
 


### PR DESCRIPTION
As of CMake 3.27:

Compatibility with versions of CMake older than 3.5 is now deprecated and will be removed from a future version.

Calls to cmake_minimum_required() or cmake_policy() that set the policy version to an older value now issue a deprecation diagnostic.

https://cmake.org/cmake/help/latest/release/3.27.html#deprecated-and-removed-features