### PR TITLE
Wayland: don't crash if no cursor theme is available

### DIFF
--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -2630,6 +2630,12 @@ GLFWbool _glfwCreateStandardCursorWayland(_GLFWcursor* cursor, int shape)
 {
     const char* name = NULL;
 
+    if (!_glfw.wl.cursorTheme) {
+        _glfwInputError(GLFW_CURSOR_UNAVAILABLE,
+                        "Wayland: No cursor theme");
+        return GLFW_FALSE;
+    }
+
     // Try the XDG names first
     switch (shape)
     {


### PR DESCRIPTION
On some embedded systems there is no cursor theme set, which results in a crash in this function when we call `wl_cursor_theme_get_cursor`.