### PR TITLE
Add support for receiving control characters

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -314,7 +314,7 @@ void _glfwInputChar(_GLFWwindow* window, uint32_t codepoint, int mods, GLFWbool 
     assert(mods == (mods & GLFW_MOD_MASK));
     assert(plain == GLFW_TRUE || plain == GLFW_FALSE);
 
-    if (codepoint < 32 || (codepoint > 126 && codepoint < 160))
+    if (codepoint > 126 && codepoint < 160)
         return;
 
     if (!window->lockKeyMods)


### PR DESCRIPTION
This helps receiving special control characters that are ignored by GLFW, such as backspace ('\b') or newline ('\n').

Mainly to fix Vietnamese typing through Unikey.