### PR TITLE
Clarified that window titles should be Non-NULL

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ information on what to include when reporting a bug.
 
 ## Changelog
 
+ - Added clarification for `glfwCreateWindow` title parameter to documentation (#2232)
  - Added `GLFW_PLATFORM` init hint for runtime platform selection (#1958)
  - Added `GLFW_ANY_PLATFORM`, `GLFW_PLATFORM_WIN32`, `GLFW_PLATFORM_COCOA`,
    `GLFW_PLATFORM_WAYLAND`, `GLFW_PLATFORM_X11` and `GLFW_PLATFORM_NULL` symbols to

--- a/docs/window.dox
+++ b/docs/window.dox
@@ -860,7 +860,8 @@ glfwGetWindowPos(window, &xpos, &ypos);
 
 All GLFW windows have a title, although undecorated or full screen windows may
 not display it or only display it in a task bar or similar interface.  You can
-set a UTF-8 encoded window title with @ref glfwSetWindowTitle.
+set a UTF-8 encoded window title with @ref glfwSetWindowTitle. The set title
+should not be `NULL`.
 
 @code
 glfwSetWindowTitle(window, "My Window");

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -3077,7 +3077,7 @@ GLFWAPI void glfwWindowHintString(int hint, const char* value);
  *  This must be greater than zero.
  *  @param[in] height The desired height, in screen coordinates, of the window.
  *  This must be greater than zero.
- *  @param[in] title The initial, UTF-8 encoded window title.
+ *  @param[in] title The initial, UTF-8 encoded, non-NULL window title.
  *  @param[in] monitor The monitor to use for full screen mode, or `NULL` for
  *  windowed mode.
  *  @param[in] share The window whose context to share resources with, or `NULL`


### PR DESCRIPTION
This PR is a simple fix for documentation regarding `glfwWindowCreate()` and its title parameter. Specifically, what type of string can be passed to it.

__Closes__: #2232

---

Should I add my name to CONTRIBUTORS.md?