### PR TITLE
Allow to set initial surface swap interval

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -939,6 +939,8 @@ extern "C" {
  */
 #define GLFW_POSITION_Y             0x0002000F
 
+#define GLFW_SWAP_INTERVAL          0x00020010
+
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_RED_BITS).

--- a/src/context.c
+++ b/src/context.c
@@ -364,6 +364,9 @@ GLFWbool _glfwRefreshContextAttribs(_GLFWwindow* window,
     previous = _glfwPlatformGetTls(&_glfw.contextSlot);
     glfwMakeContextCurrent((GLFWwindow*) window);
 
+    if (window->swapInterval != -1)
+        window->context.swapInterval(window->swapInterval);
+
     window->context.GetIntegerv = (PFNGLGETINTEGERVPROC)
         window->context.getProcAddress("glGetIntegerv");
     window->context.GetString = (PFNGLGETSTRINGPROC)

--- a/src/internal.h
+++ b/src/internal.h
@@ -408,6 +408,7 @@ struct _GLFWwndconfig
     GLFWbool      focusOnShow;
     GLFWbool      mousePassthrough;
     GLFWbool      scaleToMonitor;
+    int           swapInterval;
     struct {
         GLFWbool  retina;
         char      frameName[256];
@@ -532,6 +533,7 @@ struct _GLFWwindow
     GLFWbool            focusOnShow;
     GLFWbool            mousePassthrough;
     GLFWbool            shouldClose;
+    int                 swapInterval;
     void*               userPointer;
     GLFWbool            doublebuffer;
     GLFWvidmode         videoMode;

--- a/src/window.c
+++ b/src/window.c
@@ -235,6 +235,7 @@ GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height,
     window->focusOnShow      = wndconfig.focusOnShow;
     window->mousePassthrough = wndconfig.mousePassthrough;
     window->cursorMode       = GLFW_CURSOR_NORMAL;
+    window->swapInterval     = wndconfig.swapInterval;
 
     window->doublebuffer = fbconfig.doublebuffer;
 
@@ -276,6 +277,7 @@ void glfwDefaultWindowHints(void)
     _glfw.hints.window.focusOnShow  = GLFW_TRUE;
     _glfw.hints.window.xpos         = GLFW_ANY_POSITION;
     _glfw.hints.window.ypos         = GLFW_ANY_POSITION;
+    _glfw.hints.window.swapInterval = -1;
 
     // The default is 24 bits of color, 24 bits of depth and 8 bits of stencil,
     // double buffered
@@ -396,6 +398,9 @@ GLFWAPI void glfwWindowHint(int hint, int value)
             return;
         case GLFW_MOUSE_PASSTHROUGH:
             _glfw.hints.window.mousePassthrough = value ? GLFW_TRUE : GLFW_FALSE;
+            return;
+        case GLFW_SWAP_INTERVAL:
+            _glfw.hints.window.swapInterval = value;
             return;
         case GLFW_CLIENT_API:
             _glfw.hints.context.client = value;


### PR DESCRIPTION
After creating surface context in _glfwPlatformCreateWindow function proceeds with reading context parameters in _glfwRefreshContextAttribs, which ends with clearing the front buffer when double buffering is enabled.

Such buffer clearing implicitly calls swapBuffer, which may not behave properly with the default swap interval. And user has no control to override this swap interval value with the glfwSwapInterval, because latter may only be called after the glfwCreateWindow, when it is too late.

Either clearing buffer should be disablable, or user should have control on the initial swap interval value before implicit swapBuffer is invoked.

This patch implements latter by introducing GLFW_SWAP_INTERVAL window hint. Default value is -1, which matches current policy of avoiding to override swap interval.