### PR TITLE
Fix pkg-config on Windows

### DIFF
--- a/CMake/glfw3.pc.in
+++ b/CMake/glfw3.pc.in
@@ -8,6 +8,6 @@ Description: A multi-platform library for OpenGL, window and input
 Version: @GLFW_VERSION@
 URL: https://www.glfw.org/
 Requires.private: @GLFW_PKG_CONFIG_REQUIRES_PRIVATE@
-Libs: -L${libdir} -l@GLFW_LIB_NAME@
+Libs: -L${libdir} -l@GLFW_LIB_NAME@@GLFW_LIB_NAME_SUFFIX@
 Libs.private: @GLFW_PKG_CONFIG_LIBS_PRIVATE@
 Cflags: -I${includedir}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,6 +126,7 @@ if (UNIX AND GLFW_BUILD_SHARED_LIBRARY)
 else()
     set(GLFW_LIB_NAME glfw3)
 endif()
+set(GLFW_LIB_NAME_SUFFIX "")
 
 set_target_properties(glfw PROPERTIES
                       OUTPUT_NAME ${GLFW_LIB_NAME}
@@ -337,6 +338,7 @@ if (GLFW_BUILD_SHARED_LIBRARY)
             # Add a suffix to the import library to avoid naming conflicts
             set_target_properties(glfw PROPERTIES IMPORT_SUFFIX "dll.lib")
         endif()
+        set (GLFW_LIB_NAME_SUFFIX "dll")
 
         target_compile_definitions(glfw INTERFACE GLFW_DLL)
     endif()


### PR DESCRIPTION
If building on Windows as shared library GLFW adds the suffix "dll" to the library name. This suffix is missing in the pkg-config file.