### PR TITLE
Remove apparently spurious line in header

### DIFF
--- a/deps/glad/vulkan.h
+++ b/deps/glad/vulkan.h
@@ -6247,8 +6247,6 @@ static int glad_vk_find_extensions_vulkan( VkPhysicalDevice physical_device) {
     GLAD_VK_KHR_surface = glad_vk_has_extension("VK_KHR_surface", extension_count, extensions);
     GLAD_VK_KHR_swapchain = glad_vk_has_extension("VK_KHR_swapchain", extension_count, extensions);
 
-    (void) glad_vk_has_extension;
-
     glad_vk_free_extensions(extension_count, extensions);
 
     return 1;


### PR DESCRIPTION
When compiling glfw on a windows MSVC based system I get a warning about this line:
glfw\deps\glad/vulkan.h(6250,12): warning C4551: function call missing argument list 

The warning seems to be valid and removing the line appears to me to be safe.