### PR TITLE
Allow setting the App's window class name via CMake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -274,7 +274,14 @@ elseif (CMAKE_C_COMPILER_ID STREQUAL "GNU" OR
 endif()
 
 if (GLFW_BUILD_WIN32)
-    target_compile_definitions(glfw PRIVATE UNICODE _UNICODE)
+    # If requested, create a C #define to set the app's window class name.
+    # This class name is baked in at compile time.
+    set(_GLFW_WCN "")
+    if (GLFW_WNDCLASSNAME)
+        set(_GLFW_WCN "_GLFW_WNDCLASSNAME=L\"${GLFW_WNDCLASSNAME}\"")
+    endif()
+
+    target_compile_definitions(glfw PRIVATE UNICODE _UNICODE ${_GLFW_WCN})
 endif()
 
 # HACK: When building on MinGW, WINVER and UNICODE need to be defined before


### PR DESCRIPTION
Allow setting the App's window class name via the CMake command line:
    cmake . -DGLFW_WNDCLASSNAME="MyWindowClassName"

In Windows, it's important to be able to compile an application with an unique Window Class Name (WCN). A WCN can be used to, programmatically, locate an App at runtime. This allows 2 running apps to locate each other at runtime, and then send messages back and forth to each other via the native Windows RPC functionality.

By default, GLFW sets the WCN to "GLFW30".  That value is set in file `win32_window.c`, at around line 1271. There is already code to use the #define named `_GLFW_WNDCLASSNAME` to set the WCN. However, setting that #define is not currently possible via CMake. 

This patch allows setting the value of the existing define `_GLFW_WNDCLASSNAME` from CMake.
Additionally, this opens up the possibility of setting that value via `vcpkg` ports functionality.