### PR TITLE
Add a function to get the monitor on which a window is currently being displayed

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -3898,6 +3898,24 @@ GLFWAPI void glfwFocusWindow(GLFWwindow* window);
  */
 GLFWAPI void glfwRequestWindowAttention(GLFWwindow* window);
 
+/*! @brief Returns the monitor on which the window is being currently displayed.
+ *
+ *  The window should not be NULL.
+ *
+ *  @param[in] window The window to query.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_monitor
+ *
+ *  @since Added in version 3.4.
+ *
+ *  @ingroup window
+ */
+GLFWAPI GLFWmonitor* glfwGetMonitorHostingWindow(GLFWwindow *const window);
+
 /*! @brief Returns the monitor that the window uses for full screen mode.
  *
  *  This function returns the handle of the monitor that the specified window is

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -3914,7 +3914,7 @@ GLFWAPI void glfwRequestWindowAttention(GLFWwindow* window);
  *
  *  @ingroup window
  */
-GLFWAPI GLFWmonitor* glfwGetMonitorHostingWindow(GLFWwindow *const window);
+GLFWAPI GLFWmonitor* glfwGetMonitorDisplayingWindow(GLFWwindow* window);
 
 /*! @brief Returns the monitor that the window uses for full screen mode.
  *

--- a/src/internal.h
+++ b/src/internal.h
@@ -724,7 +724,7 @@ struct _GLFWplatform
     void (*showWindow)(_GLFWwindow*);
     void (*hideWindow)(_GLFWwindow*);
     void (*requestWindowAttention)(_GLFWwindow*);
-    _GLFWmonitor* (*getMonitorHostingWindow)(_GLFWwindow*);
+    _GLFWmonitor* (*getMonitorDisplayingWindow)(_GLFWwindow*);
     void (*focusWindow)(_GLFWwindow*);
     void (*setWindowMonitor)(_GLFWwindow*,_GLFWmonitor*,int,int,int,int,int);
     GLFWbool (*windowFocused)(_GLFWwindow*);

--- a/src/internal.h
+++ b/src/internal.h
@@ -724,6 +724,7 @@ struct _GLFWplatform
     void (*showWindow)(_GLFWwindow*);
     void (*hideWindow)(_GLFWwindow*);
     void (*requestWindowAttention)(_GLFWwindow*);
+    _GLFWmonitor* (*getMonitorHostingWindow)(_GLFWwindow*);
     void (*focusWindow)(_GLFWwindow*);
     void (*setWindowMonitor)(_GLFWwindow*,_GLFWmonitor*,int,int,int,int,int);
     GLFWbool (*windowFocused)(_GLFWwindow*);

--- a/src/null_init.c
+++ b/src/null_init.c
@@ -89,7 +89,7 @@ GLFWbool _glfwConnectNull(int platformID, _GLFWplatform* platform)
         _glfwShowWindowNull,
         _glfwHideWindowNull,
         _glfwRequestWindowAttentionNull,
-        _glfwGetMonitorHostingWindowNull,
+        _glfwGetMonitorDisplayingWindowNull,
         _glfwFocusWindowNull,
         _glfwSetWindowMonitorNull,
         _glfwWindowFocusedNull,

--- a/src/null_init.c
+++ b/src/null_init.c
@@ -89,6 +89,7 @@ GLFWbool _glfwConnectNull(int platformID, _GLFWplatform* platform)
         _glfwShowWindowNull,
         _glfwHideWindowNull,
         _glfwRequestWindowAttentionNull,
+        _glfwGetMonitorHostingWindowNull,
         _glfwFocusWindowNull,
         _glfwSetWindowMonitorNull,
         _glfwWindowFocusedNull,

--- a/src/null_platform.h
+++ b/src/null_platform.h
@@ -240,6 +240,7 @@ GLFWbool _glfwRawMouseMotionSupportedNull(void);
 void _glfwShowWindowNull(_GLFWwindow* window);
 void _glfwRequestWindowAttentionNull(_GLFWwindow* window);
 void _glfwRequestWindowAttentionNull(_GLFWwindow* window);
+_GLFWmonitor* _glfwGetMonitorHostingWindoNull(_GLFWwindow* const window);
 void _glfwHideWindowNull(_GLFWwindow* window);
 void _glfwFocusWindowNull(_GLFWwindow* window);
 GLFWbool _glfwWindowFocusedNull(_GLFWwindow* window);

--- a/src/null_platform.h
+++ b/src/null_platform.h
@@ -240,7 +240,7 @@ GLFWbool _glfwRawMouseMotionSupportedNull(void);
 void _glfwShowWindowNull(_GLFWwindow* window);
 void _glfwRequestWindowAttentionNull(_GLFWwindow* window);
 void _glfwRequestWindowAttentionNull(_GLFWwindow* window);
-_GLFWmonitor* _glfwGetMonitorHostingWindoNull(_GLFWwindow* const window);
+_GLFWmonitor* _glfwGetMonitorDisplayingWindoNull(_GLFWwindow* window);
 void _glfwHideWindowNull(_GLFWwindow* window);
 void _glfwFocusWindowNull(_GLFWwindow* window);
 GLFWbool _glfwWindowFocusedNull(_GLFWwindow* window);

--- a/src/null_window.c
+++ b/src/null_window.c
@@ -436,7 +436,7 @@ void _glfwRequestWindowAttentionNull(_GLFWwindow* window)
 {
 }
 
-_GLFWmonitor* _glfwGetMonitorHostingWindoNull(_GLFWwindow*const window)
+_GLFWmonitor* _glfwGetMonitorDisplayingWindoNull(_GLFWwindow* window)
 {
     return NULL;
 }

--- a/src/null_window.c
+++ b/src/null_window.c
@@ -436,6 +436,11 @@ void _glfwRequestWindowAttentionNull(_GLFWwindow* window)
 {
 }
 
+_GLFWmonitor* _glfwGetMonitorHostingWindoNull(_GLFWwindow*const window)
+{
+    return NULL;
+}
+
 void _glfwHideWindowNull(_GLFWwindow* window)
 {
     if (_glfw.null.focusedWindow == window)

--- a/src/win32_init.c
+++ b/src/win32_init.c
@@ -653,6 +653,7 @@ GLFWbool _glfwConnectWin32(int platformID, _GLFWplatform* platform)
         _glfwShowWindowWin32,
         _glfwHideWindowWin32,
         _glfwRequestWindowAttentionWin32,
+        _glfwGetMonitorHostingWindowWin32,
         _glfwFocusWindowWin32,
         _glfwSetWindowMonitorWin32,
         _glfwWindowFocusedWin32,

--- a/src/win32_init.c
+++ b/src/win32_init.c
@@ -653,7 +653,7 @@ GLFWbool _glfwConnectWin32(int platformID, _GLFWplatform* platform)
         _glfwShowWindowWin32,
         _glfwHideWindowWin32,
         _glfwRequestWindowAttentionWin32,
-        _glfwGetMonitorHostingWindowWin32,
+        _glfwGetMonitorDisplayingWindowWin32,
         _glfwFocusWindowWin32,
         _glfwSetWindowMonitorWin32,
         _glfwWindowFocusedWin32,

--- a/src/win32_platform.h
+++ b/src/win32_platform.h
@@ -558,7 +558,7 @@ void _glfwMaximizeWindowWin32(_GLFWwindow* window);
 void _glfwShowWindowWin32(_GLFWwindow* window);
 void _glfwHideWindowWin32(_GLFWwindow* window);
 void _glfwRequestWindowAttentionWin32(_GLFWwindow* window);
-_GLFWmonitor* _glfwGetMonitorHostingWindowWin32(_GLFWwindow* const window);
+_GLFWmonitor* _glfwGetMonitorDisplayingWindowWin32(_GLFWwindow* window);
 void _glfwFocusWindowWin32(_GLFWwindow* window);
 void _glfwSetWindowMonitorWin32(_GLFWwindow* window, _GLFWmonitor* monitor, int xpos, int ypos, int width, int height, int refreshRate);
 GLFWbool _glfwWindowFocusedWin32(_GLFWwindow* window);

--- a/src/win32_platform.h
+++ b/src/win32_platform.h
@@ -558,6 +558,7 @@ void _glfwMaximizeWindowWin32(_GLFWwindow* window);
 void _glfwShowWindowWin32(_GLFWwindow* window);
 void _glfwHideWindowWin32(_GLFWwindow* window);
 void _glfwRequestWindowAttentionWin32(_GLFWwindow* window);
+_GLFWmonitor* _glfwGetMonitorHostingWindowWin32(_GLFWwindow* const window);
 void _glfwFocusWindowWin32(_GLFWwindow* window);
 void _glfwSetWindowMonitorWin32(_GLFWwindow* window, _GLFWmonitor* monitor, int xpos, int ypos, int width, int height, int refreshRate);
 GLFWbool _glfwWindowFocusedWin32(_GLFWwindow* window);

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -1762,7 +1762,7 @@ void _glfwRequestWindowAttentionWin32(_GLFWwindow* window)
     FlashWindow(window->win32.handle, TRUE);
 }
 
-_GLFWmonitor* _glfwGetMonitorHostingWindowWin32(_GLFWwindow* const window)
+_GLFWmonitor* _glfwGetMonitorDisplayingWindowWin32(_GLFWwindow* window)
 {
     HMONITOR monitor = MonitorFromWindow(window->win32.handle, MONITOR_DEFAULTTONEAREST);
 

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -1762,6 +1762,19 @@ void _glfwRequestWindowAttentionWin32(_GLFWwindow* window)
     FlashWindow(window->win32.handle, TRUE);
 }
 
+_GLFWmonitor* _glfwGetMonitorHostingWindowWin32(_GLFWwindow* const window)
+{
+    HMONITOR monitor = MonitorFromWindow(window->win32.handle, MONITOR_DEFAULTTONEAREST);
+
+    for(int i = 0; i < _glfw.monitorCount; ++i)
+    {
+        if(_glfw.monitors[i]->win32.handle == monitor)
+            return _glfw.monitors[i];
+    }
+
+    return _glfw.monitors[0];
+}
+
 void _glfwFocusWindowWin32(_GLFWwindow* window)
 {
     BringWindowToTop(window->win32.handle);

--- a/src/window.c
+++ b/src/window.c
@@ -822,14 +822,14 @@ GLFWAPI void glfwRequestWindowAttention(GLFWwindow* handle)
     _glfw.platform.requestWindowAttention(window);
 }
 
-GLFWAPI GLFWmonitor* glfwGetMonitorHostingWindow(GLFWwindow* const handle)
+GLFWAPI GLFWmonitor* glfwGetMonitorDisplayingWindow(GLFWwindow* handle)
 {
     _GLFWwindow* const window = (_GLFWwindow*) handle;
     assert(handle != NULL);
     
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
 
-    return (GLFWmonitor*)_glfw.platform.getMonitorHostingWindow(window);
+    return (GLFWmonitor*)_glfw.platform.getMonitorDisplayingWindow(window);
 }
 
 GLFWAPI void glfwHideWindow(GLFWwindow* handle)

--- a/src/window.c
+++ b/src/window.c
@@ -822,6 +822,16 @@ GLFWAPI void glfwRequestWindowAttention(GLFWwindow* handle)
     _glfw.platform.requestWindowAttention(window);
 }
 
+GLFWAPI GLFWmonitor* glfwGetMonitorHostingWindow(GLFWwindow* const handle)
+{
+    _GLFWwindow* const window = (_GLFWwindow*) handle;
+    assert(handle != NULL);
+    
+    _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
+
+    return (GLFWmonitor*)_glfw.platform.getMonitorHostingWindow(window);
+}
+
 GLFWAPI void glfwHideWindow(GLFWwindow* handle)
 {
     _GLFWwindow* window = (_GLFWwindow*) handle;


### PR DESCRIPTION
Hello there,

Me again with another PR.

This time it is to add a function to retrieve the monitor on which a window is currently being displayed.

**I only did null and win32**

PRs are welcome for Linux and Mac OS.

Also I need some feedback on the naming documentation and such.

Cheers,
Scr3am