### PR TITLE
Cocoa: Make sure NSWindowStyleMaskResizable is masked when entering fullscreen.

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -1279,7 +1279,7 @@ void _glfwSetWindowMonitorCocoa(_GLFWwindow* window,
 
     if (window->monitor)
     {
-        styleMask &= ~(NSWindowStyleMaskTitled | NSWindowStyleMaskClosable);
+        styleMask &= ~(NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskResizable);
         styleMask |= NSWindowStyleMaskBorderless;
     }
     else


### PR DESCRIPTION
On macOS Catalina and earlier, not having the resizable bit cleared in NSWindowStyleMask in fullscreen leads to windows minimising when clicked anywhere in the content area. This affects both my game engine and reportedly Minecraft, as detailed in issue #2377

This fix doesn't (and shouldn't need to) apply to Windows created in a fullscreen state as createNativeWindow in cocoa_window.m defines a default styleMask before altering it according to desired GLFW window hints and settings.

This hasn't been tested on newer macOS versions for regressions but should otherwise work there.