### PR TITLE
Add macOS events for trackpad zoom and rotate gestures

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ information on what to include when reporting a bug.
    application (#2110)
  - [Cocoa] Bugfix: The Vulkan loader was not loaded from the `Frameworks` bundle
    subdirectory (#2113,#2120)
+ - [Cocoa] Added `glfwSetTrackpadZoomCallback` and `glfwSetTrackpadRotateCallback`
+   for trackpad zoom and rotate events (#90)
  - [X11] Bugfix: The CMake files did not check for the XInput headers (#1480)
  - [X11] Bugfix: Key names were not updated when the keyboard layout changed
    (#1462,#1528)

--- a/docs/news.dox
+++ b/docs/news.dox
@@ -223,6 +223,14 @@ the XDG-Shell protocol.  If your Wayland compositor does not support XDG-Shell
 then GLFW will fail to initialize.
 
 
+@subsubsection macos_trackpad_34 Support for trackpad zoom and rotate on macOS
+
+Trackpad zoom and rotate events are now supported on macOS using
+@ref glfwSetTrackpadZoomCallback and @ref glfwSetTrackpadRotateCallback. These
+events have not yet been implemented and currently will not emit anything on
+Windows, X11, and Wayland.
+
+
 @subsection symbols_34 New symbols in version 3.4
 
 @subsubsection functions_34 New functions in version 3.4
@@ -231,6 +239,8 @@ then GLFW will fail to initialize.
  - @ref glfwGetPlatform
  - @ref glfwPlatformSupported
  - @ref glfwInitVulkanLoader
+ - @ref glfwSetTrackpadZoomCallback
+ - @ref glfwSetTrackpadRotateCallback
 
 
 @subsubsection types_34 New types in version 3.4
@@ -239,6 +249,8 @@ then GLFW will fail to initialize.
  - @ref GLFWallocatefun
  - @ref GLFWreallocatefun
  - @ref GLFWdeallocatefun
+ - @ref GLFWtrackpadzoomfun
+ - @ref GLFWtrackpadrotatefun
 
 
 @subsubsection constants_34 New constants in version 3.4

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -1832,6 +1832,40 @@ typedef void (* GLFWcursorenterfun)(GLFWwindow* window, int entered);
  */
 typedef void (* GLFWscrollfun)(GLFWwindow* window, double xoffset, double yoffset);
 
+/*! @brief The function pointer type for trackpad zoom callbacks.
+ *
+ *  This is the function pointer type for trackpad zoom callbacks.  A zoom
+ *  callback function has the following signature:
+ *  @code
+ *  void function_name(GLFWwindow* window, double scale)
+ *  @endcode
+ *
+ *  @param[in] window The window that received the event.
+ *  @param[in] scale The manigification amount
+ *
+ *  @sa @ref glfwSetTrackpadZoomCallback
+ *
+ *  @ingroup input
+ */
+typedef void (* GLFWtrackpadzoomfun)(GLFWwindow* window, double scale);
+
+/*! @brief The function pointer type for trackpad rotate callbacks.
+ *
+ *  This is the function pointer type for trackpad rotate callbacks.  A rotate
+ *  callback function has the following signature:
+ *  @code
+ *  void function_name(GLFWwindow* window, double angle)
+ *  @endcode
+ *
+ *  @param[in] window The window that received the event.
+ *  @param[in] angle The rotation amount
+ *
+ *  @sa @ref glfwSetTrackpadRotateCallback
+ *
+ *  @ingroup input
+ */
+typedef void (* GLFWtrackpadrotatefun)(GLFWwindow* window, double angle);
+
 /*! @brief The function pointer type for keyboard key callbacks.
  *
  *  This is the function pointer type for keyboard key callbacks.  A keyboard
@@ -5315,6 +5349,58 @@ GLFWAPI GLFWcursorenterfun glfwSetCursorEnterCallback(GLFWwindow* window, GLFWcu
  *  @ingroup input
  */
 GLFWAPI GLFWscrollfun glfwSetScrollCallback(GLFWwindow* window, GLFWscrollfun callback);
+
+/*! @brief Sets the trackpad zoom callback.
+ *
+ *  This function sets the trackpad zoom of the specified window, which is
+ *  called when a trackpad magnification gesture is used on macOS.
+ *
+ *  @param[in] window The window whose callback to set.
+ *  @param[in] callback The new trackpad zoom callback, or `NULL` to remove the
+ *  currently set callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or the
+ *  library had not been [initialized](@ref intro_init).
+ *
+ *  @callback_signature
+ *  @code
+ *  void function_name(GLFWwindow* window, double scale)
+ *  @endcode
+ *  For more information about the callback parameters, see the
+ *  [function pointer type](@ref GLFWtrackpadzoomfun).
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @ingroup input
+ */
+GLFWAPI GLFWtrackpadzoomfun glfwSetTrackpadZoomCallback(GLFWwindow* window, GLFWtrackpadzoomfun callback);
+
+/*! @brief Sets the trackpad rotate callback.
+ *
+ *  This function sets the trackpad rotate of the specified window, which is
+ *  called when a trackpad rotation gesture is used on macOS.
+ *
+ *  @param[in] window The window whose callback to set.
+ *  @param[in] callback The new trackpad rotate callback, or `NULL` to remove the
+ *  currently set callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or the
+ *  library had not been [initialized](@ref intro_init).
+ *
+ *  @callback_signature
+ *  @code
+ *  void function_name(GLFWwindow* window, double angle)
+ *  @endcode
+ *  For more information about the callback parameters, see the
+ *  [function pointer type](@ref GLFWtrackpadrotatefun).
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @ingroup input
+ */
+GLFWAPI GLFWtrackpadrotatefun glfwSetTrackpadRotateCallback(GLFWwindow* window, GLFWtrackpadrotatefun callback);
 
 /*! @brief Sets the path drop callback.
  *

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -610,6 +610,22 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
         _glfwInputScroll(window, deltaX, deltaY);
 }
 
+- (void)magnifyWithEvent:(NSEvent *)event
+{
+    double magnification = [event magnification];
+
+    if (fabs(magnification) > 0.0)
+        _glfwInputTrackpadZoom(window, magnification);
+}
+
+- (void)rotateWithEvent:(NSEvent *)event
+{
+    double rotation = [event rotation];
+
+    if (fabs(rotation) > 0.0)
+        _glfwInputTrackpadRotate(window, rotation);
+}
+
 - (NSDragOperation)draggingEntered:(id <NSDraggingInfo>)sender
 {
     // HACK: We don't know what to say here because we don't know what the

--- a/src/input.c
+++ b/src/input.c
@@ -344,6 +344,30 @@ void _glfwInputScroll(_GLFWwindow* window, double xoffset, double yoffset)
         window->callbacks.scroll((GLFWwindow*) window, xoffset, yoffset);
 }
 
+// Notifies shared code of a trackpad zoom event
+//
+void _glfwInputTrackpadZoom(_GLFWwindow* window, double scale)
+{
+    assert(window != NULL);
+    assert(scale > -FLT_MAX);
+    assert(scale < FLT_MAX);
+
+    if (window->callbacks.trackpadZoom)
+        window->callbacks.trackpadZoom((GLFWwindow*) window, scale);
+}
+
+// Notifies shared code of a trackpad rotate event
+//
+void _glfwInputTrackpadRotate(_GLFWwindow* window, double angle)
+{
+    assert(window != NULL);
+    assert(angle > -FLT_MAX);
+    assert(angle < FLT_MAX);
+
+    if (window->callbacks.trackpadRotate)
+        window->callbacks.trackpadRotate((GLFWwindow*) window, angle);
+}
+
 // Notifies shared code of a mouse button click event
 //
 void _glfwInputMouseClick(_GLFWwindow* window, int button, int action, int mods)
@@ -1009,6 +1033,28 @@ GLFWAPI GLFWscrollfun glfwSetScrollCallback(GLFWwindow* handle,
 
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
     _GLFW_SWAP(GLFWscrollfun, window->callbacks.scroll, cbfun);
+    return cbfun;
+}
+
+GLFWAPI GLFWtrackpadzoomfun glfwSetTrackpadZoomCallback(GLFWwindow* handle,
+                                                        GLFWtrackpadzoomfun cbfun)
+{
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    assert(window != NULL);
+
+    _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
+    _GLFW_SWAP(GLFWtrackpadzoomfun, window->callbacks.trackpadZoom, cbfun);
+    return cbfun;
+}
+
+GLFWAPI GLFWtrackpadzoomfun glfwSetTrackpadRotateCallback(GLFWwindow* handle,
+                                                          GLFWtrackpadrotatefun cbfun)
+{
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    assert(window != NULL);
+
+    _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
+    _GLFW_SWAP(GLFWtrackpadrotatefun, window->callbacks.trackpadRotate, cbfun);
     return cbfun;
 }
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -568,6 +568,8 @@ struct _GLFWwindow
         GLFWcursorposfun          cursorPos;
         GLFWcursorenterfun        cursorEnter;
         GLFWscrollfun             scroll;
+        GLFWtrackpadzoomfun       trackpadZoom;
+        GLFWtrackpadrotatefun     trackpadRotate;
         GLFWkeyfun                key;
         GLFWcharfun               character;
         GLFWcharmodsfun           charmods;
@@ -923,6 +925,8 @@ void _glfwInputKey(_GLFWwindow* window,
 void _glfwInputChar(_GLFWwindow* window,
                     uint32_t codepoint, int mods, GLFWbool plain);
 void _glfwInputScroll(_GLFWwindow* window, double xoffset, double yoffset);
+void _glfwInputTrackpadZoom(_GLFWwindow* window, double scale);
+void _glfwInputTrackpadRotate(_GLFWwindow* window, double angle);
 void _glfwInputMouseClick(_GLFWwindow* window, int button, int action, int mods);
 void _glfwInputCursorPos(_GLFWwindow* window, double xpos, double ypos);
 void _glfwInputCursorEnter(_GLFWwindow* window, GLFWbool entered);

--- a/tests/events.c
+++ b/tests/events.c
@@ -397,6 +397,20 @@ static void scroll_callback(GLFWwindow* window, double x, double y)
            counter++, slot->number, glfwGetTime(), x, y);
 }
 
+static void trackpad_zoom_callback(GLFWwindow* window, double scale)
+{
+    Slot* slot = glfwGetWindowUserPointer(window);
+    printf("%08x to %i at %0.3f: Trackpad Zoom: %0.3f\n",
+           counter++, slot->number, glfwGetTime(), scale);
+}
+
+static void trackpad_rotate_callback(GLFWwindow* window, double angle)
+{
+    Slot* slot = glfwGetWindowUserPointer(window);
+    printf("%08x to %i at %0.3f: Trackpad Rotate: %0.3f\n",
+           counter++, slot->number, glfwGetTime(), angle);
+}
+
 static void key_callback(GLFWwindow* window, int key, int scancode, int action, int mods)
 {
     Slot* slot = glfwGetWindowUserPointer(window);
@@ -636,6 +650,8 @@ int main(int argc, char** argv)
         glfwSetCursorPosCallback(slots[i].window, cursor_position_callback);
         glfwSetCursorEnterCallback(slots[i].window, cursor_enter_callback);
         glfwSetScrollCallback(slots[i].window, scroll_callback);
+        glfwSetTrackpadZoomCallback(slots[i].window, trackpad_zoom_callback);
+        glfwSetTrackpadRotateCallback(slots[i].window, trackpad_rotate_callback);
         glfwSetKeyCallback(slots[i].window, key_callback);
         glfwSetCharCallback(slots[i].window, char_callback);
         glfwSetDropCallback(slots[i].window, drop_callback);


### PR DESCRIPTION
Implements #90 for macOS with two new events: TrackpadZoom and TrackpadRotate. These events can also be implemented for Windows and Linux X11/Wayland, but I do not have a way to test those platforms. Zoom will need to make sure to use a similar scale on all platforms and rotate should use degrees.

- [x]    Change log entry in README.md, listing all new symbols
- [x]    News page entry, briefly describing the feature
- [ ]    Guide documentation, with minimal examples, in the relevant guide
- [ ]    Reference documentation, with all applicable tags
- [ ]    Cross-references and mentions in appropriate places
- [ ]    Credits entries for all authors of the feature
