### PR TITLE
Add the suffix of dll

### DIFF
--- a/CMake/glfw3.pc.in
+++ b/CMake/glfw3.pc.in
@@ -8,6 +8,6 @@ Description: A multi-platform library for OpenGL, window and input
 Version: @GLFW_VERSION@
 URL: https://www.glfw.org/
 Requires.private: @GLFW_PKG_CONFIG_REQUIRES_PRIVATE@
-Libs: -L${libdir} -l@GLFW_LIB_NAME@
+Libs: -L${libdir} -l@GLFW_LIB_NAME@@GLFW_LIB_NAME_SUFFIX@
 Libs.private: @GLFW_PKG_CONFIG_LIBS_PRIVATE@
 Cflags: -I${includedir}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -387,7 +387,12 @@ set(GLFW_PKG_CONFIG_REQUIRES_PRIVATE "${deps}" CACHE INTERNAL
     "GLFW pkg-config Requires.private")
 set(GLFW_PKG_CONFIG_LIBS_PRIVATE "${libs}" CACHE INTERNAL
     "GLFW pkg-config Libs.private")
-
+set(GLFW_LIB_NAME_SUFFIX "")
+if (BUILD_SHARED_LIBS)
+    if (WIN32)
+      set(GLFW_LIB_NAME_SUFFIX "dll")
+    endif()
+endif()
 configure_file("${GLFW_SOURCE_DIR}/CMake/glfw3.pc.in" glfw3.pc @ONLY)
 
 if (GLFW_INSTALL)


### PR DESCRIPTION
The pkg-config files installed with GLFW refers to "-lglfw3", but the installed lib file is called lib/glfw3dll.lib. GLFW seems to use a suffix for building a shared lib, see https://github.com/glfw/glfw/blob/3.3.8/src/CMakeLists.txt#L169
Fix the inconsistency between the library name and the link library name in the pc file when dynamically compiling on the window platform.