### PR TITLE
Export GLFW targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,10 @@ if (GLFW_INSTALL)
     install(FILES "${GLFW_BINARY_DIR}/src/glfw3.pc"
             DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
+    export(EXPORT glfwTargets
+        FILE ${CMAKE_CURRENT_BINARY_DIR}/src/glfw3Targets.cmake
+        NAMESPACE "glfw3::")
+
     if (DOXYGEN_FOUND AND GLFW_BUILD_DOCS)
         install(DIRECTORY "${GLFW_BINARY_DIR}/docs/html"
                 DESTINATION "${CMAKE_INSTALL_DOCDIR}")


### PR DESCRIPTION
The current cmake code does not export its targets (modern cmake).

If you make a project that uses GLFW with the following CMakeListst.txt I would've expected it to work.
```
cmake_minimum_required(VERSION 3.16)
project(VulkanExample)

set(CMAKE_CXX_STANDARD 17)
find_package(Vulkan REQUIRED)
find_package(glfw3 REQUIRED)

add_executable(${PROJECT_NAME} main.cpp)

target_link_libraries(${PROJECT_NAME} Vulkan::Vulkan glfw3::glfw)
```

The old cmake solution would've been to write a find file for GLFW. Findglfw3.cmake. But modern cmake makes life easier. GLFW should instead produce glfw3Config.cmake file (already done in GLFW) that imports its own targets. No need to write a find. But this shouldn't effect finds in any way.

When find_package is run it will search glfw3_DIR, cmake path, & system path for a find (old cmake, or non-cmake libs) OR config file (modern).

GLFW config file is produced in <build dir>/src. When glfw3_DIR=<build dir>/src is given in a project. It fails to find any targets in the config. Looking at GLFW cmake code, no targets are exported. This PR is a fix for that. It now exports targets and the above cmake should work simply by providing glfw3_DIR=<build dir>/src. No need for a find.