### PR TITLE
CursorMode DISABLED on Windows gives wrong coordinates

### DIFF
--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -2096,20 +2096,22 @@ void _glfwPollEventsWin32(void)
         }
     }
 
-    window = _glfw.win32.disabledCursorWindow;
-    if (window)
-    {
-        int width, height;
-        _glfwGetWindowSizeWin32(window, &width, &height);
+    // Fixing the problem where recentering the cursor when the mouse move breaks the lastCursorPosX and lastCursorPosY
+    // and the coordinates sent in _glfwInputCursorPos are completly wrong.
+    //window = _glfw.win32.disabledCursorWindow;
+    //if (window)
+    //{
+    //    int width, height;
+    //    _glfwGetWindowSizeWin32(window, &width, &height);
 
-        // NOTE: Re-center the cursor only if it has moved since the last call,
-        //       to avoid breaking glfwWaitEvents with WM_MOUSEMOVE
-        if (window->win32.lastCursorPosX != width / 2 ||
-            window->win32.lastCursorPosY != height / 2)
-        {
-            _glfwSetCursorPosWin32(window, width / 2, height / 2);
-        }
-    }
+    //    // NOTE: Re-center the cursor only if it has moved since the last call,
+    //    //       to avoid breaking glfwWaitEvents with WM_MOUSEMOVE
+    //    if (window->win32.lastCursorPosX != width / 2 ||
+    //        window->win32.lastCursorPosY != height / 2)
+    //    {
+    //        _glfwSetCursorPosWin32(window, width / 2, height / 2);
+    //    }
+    //}
 }
 
 void _glfwWaitEventsWin32(void)


### PR DESCRIPTION
A suggestion to fix the issuse: https://github.com/glfw/glfw/issues/2427

I just commented the recentering of the mouse position in _glfwPollEventsWin32 in cursor disabled mode. It's seems to work on my computer but i don't known if it could create a side effect for others.

**CursorMode Disabled + RawMotion:**

Moving the mouse left:
![image](https://github.com/glfw/glfw/assets/81109165/e288ccf7-0856-46f8-94f9-7b643e28a8c1)


The problem seams caused by a recenter of the cursor in rawmotion.
I added a debug printf in _glfwPollEventsWin32:
![image](https://github.com/glfw/glfw/assets/81109165/41f5ed05-96db-45a3-ba1d-7705fb110bd5)

Add now when i move the mouse in Cursor Disabled mode and RawMotion, we can see the cursor is recentered at each mouse movement:
![image](https://github.com/glfw/glfw/assets/81109165/086a656c-ce6e-4eac-b99c-7b547192ae0a)

If i comment the recentering in _glfwPollEventsWin32, it's seems to work perfectly:
![image](https://github.com/glfw/glfw/assets/81109165/939fdeb3-2687-4e00-8ee2-cfb6893846ce)

**CursorMode Disabled + NoRawMotion:**
With the recentering commented, the direction changes are instant:
![image](https://github.com/glfw/glfw/assets/81109165/e84451a3-d165-4d6b-8013-29e97acb9faf)


