### PR TITLE
Fix modifier keys getting lost due to global system shortcuts

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -586,6 +586,15 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
         action = GLFW_RELEASE;
 
     _glfwInputKey(window, key, [event keyCode], action, mods);
+
+    _glfwInputKey(window, GLFW_KEY_LEFT_SHIFT   , _glfw.ns.scancodes[GLFW_KEY_LEFT_SHIFT   ], mods & GLFW_MOD_SHIFT   ? GLFW_PRESS : GLFW_RELEASE, mods);
+    _glfwInputKey(window, GLFW_KEY_LEFT_CONTROL , _glfw.ns.scancodes[GLFW_KEY_LEFT_CONTROL ], mods & GLFW_MOD_CONTROL ? GLFW_PRESS : GLFW_RELEASE, mods);
+    _glfwInputKey(window, GLFW_KEY_LEFT_ALT     , _glfw.ns.scancodes[GLFW_KEY_LEFT_ALT     ], mods & GLFW_MOD_ALT     ? GLFW_PRESS : GLFW_RELEASE, mods);
+    _glfwInputKey(window, GLFW_KEY_LEFT_SUPER   , _glfw.ns.scancodes[GLFW_KEY_LEFT_SUPER   ], mods & GLFW_MOD_SUPER   ? GLFW_PRESS : GLFW_RELEASE, mods);
+    _glfwInputKey(window, GLFW_KEY_RIGHT_SHIFT  , _glfw.ns.scancodes[GLFW_KEY_RIGHT_SHIFT  ], mods & GLFW_MOD_SHIFT   ? GLFW_PRESS : GLFW_RELEASE, mods);
+    _glfwInputKey(window, GLFW_KEY_RIGHT_CONTROL, _glfw.ns.scancodes[GLFW_KEY_RIGHT_CONTROL], mods & GLFW_MOD_CONTROL ? GLFW_PRESS : GLFW_RELEASE, mods);
+    _glfwInputKey(window, GLFW_KEY_RIGHT_ALT    , _glfw.ns.scancodes[GLFW_KEY_RIGHT_ALT    ], mods & GLFW_MOD_ALT     ? GLFW_PRESS : GLFW_RELEASE, mods);
+    _glfwInputKey(window, GLFW_KEY_RIGHT_SUPER  , _glfw.ns.scancodes[GLFW_KEY_RIGHT_SUPER  ], mods & GLFW_MOD_SUPER   ? GLFW_PRESS : GLFW_RELEASE, mods);
 }
 
 - (void)keyUp:(NSEvent *)event


### PR DESCRIPTION
In normal situations modifier key release triggers flagsChanged with the corresponding keyCode for that modifier key. If the user does a global system shortcut such as screenshoting with cmd+ctrl+shift+4 then we will see the keyDown for the cmd+ctrl+shift but no keyUp or flagsChanged after the screenshot is complete. This will leave window->keys in the wrong state: the modifier keys will be stuck in GLFW_PRESS until they are individually pressed and released again or window focus changes.

When the screenshot chord is finished we _do_ get a flagsChanged event but with the keyCode for "a" (which is weird) but the modifiers are valid so we simply just emit each of their states and let _glfwInputKey handle de-duplicating the event if needed.

Fixes #1011