### PR TITLE
Check if _GNU_SOURCE is already defined

### DIFF
--- a/src/posix_poll.c
+++ b/src/posix_poll.c
@@ -26,7 +26,9 @@
 // It is fine to use C99 in this file because it will not be built with VS
 //========================================================================
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #include "internal.h"
 

--- a/src/posix_poll.c
+++ b/src/posix_poll.c
@@ -26,8 +26,8 @@
 // It is fine to use C99 in this file because it will not be built with VS
 //========================================================================
 
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
+#if !defined(_GNU_SOURCE)
+ #define _GNU_SOURCE
 #endif
 
 #include "internal.h"


### PR DESCRIPTION
This prevents compiler warnings in case _GNU_SOURCE is already defined somewhere else.