### PR TITLE
Empty Event Callback, fired by glfwPostEmptyEvent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,7 +100,3 @@ tests/title
 tests/triangle-vulkan
 tests/window
 tests/windows
-
-/.idea
-/cmake-build-debug
-/.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ tests/triangle-vulkan
 tests/window
 tests/windows
 
+/.idea
+/cmake-build-debug
+/.gitignore

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -1974,6 +1974,23 @@ typedef void (* GLFWmonitorfun)(GLFWmonitor* monitor, int event);
  */
 typedef void (* GLFWjoystickfun)(int jid, int event);
 
+/*! @brief The function pointer type for empty event callbacks.
+ *
+ *  This is the function pointer type for empty event callbacks.
+ *  An empty event callback function has the following signature:
+ *  @code
+ *  void function_name()
+ *  @endcode
+ *
+ *  @sa @ref empty_event
+ *  @sa @ref glfwSetEmptyEventCallback
+ *
+ *  @since Added in version 3.2.
+ *
+ *  @ingroup input
+ */
+typedef void (* GLFWemptyeventfun)(void);
+
 /*! @brief Video mode type.
  *
  *  This describes a single video mode.
@@ -5697,7 +5714,36 @@ GLFWAPI int glfwJoystickIsGamepad(int jid);
  *
  *  @ingroup input
  */
-GLFWAPI GLFWjoystickfun glfwSetJoystickCallback(GLFWjoystickfun callback);
+GLFWAPI GLFWjoystickfun glfwSetJoystickCallback(GLFWjoystickfun callback);/*! @brief Sets the joystick configuration callback.
+ *
+ *
+ *  This function sets the empty event callback, or removes the currently
+ *  set callback. This is called on the GLFW thread at some point in the future
+ *  when glfwPostEmptyEvent is called from any thread.
+ *
+ *  @param[in] callback The new callback, or `NULL` to remove the currently set
+ *  callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or the
+ *  library had not been [initialized](@ref intro_init).
+ *
+ *  @callback_signature
+ *  @code
+ *  void function_name()
+ *  @endcode
+ *  For more information about the callback parameters, see the
+ *  [function pointer type](@ref GLFWemptyeventfun).
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function may be called from any thread
+ *
+ *  @sa @ref empty_event
+ *
+ *  @since Added in version TODO
+ *
+ *  @ingroup input
+ */
+GLFWAPI GLFWemptyeventfun glfwSetEmptyEventCallback(GLFWemptyeventfun callback);
 
 /*! @brief Adds the specified SDL_GameControllerDB gamepad mappings.
  *

--- a/src/input.c
+++ b/src/input.c
@@ -1253,6 +1253,13 @@ GLFWAPI GLFWjoystickfun glfwSetJoystickCallback(GLFWjoystickfun cbfun)
     return cbfun;
 }
 
+GLFWAPI GLFWemptyeventfun glfwSetEmptyEventCallback(GLFWemptyeventfun cbfun)
+{
+    _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
+    _GLFW_SWAP(GLFWemptyeventfun, _glfw.callbacks.emptyEvent, cbfun);
+    return cbfun;
+}
+
 GLFWAPI int glfwUpdateGamepadMappings(const char* string)
 {
     int jid;

--- a/src/internal.h
+++ b/src/internal.h
@@ -866,6 +866,7 @@ struct _GLFWlibrary
     struct {
         GLFWmonitorfun  monitor;
         GLFWjoystickfun joystick;
+        GLFWemptyeventfun emptyEvent;
     } callbacks;
 
     // These are defined in platform.h

--- a/src/win32_init.c
+++ b/src/win32_init.c
@@ -363,6 +363,19 @@ static LRESULT CALLBACK helperWindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LP
 
             break;
         }
+
+        default:
+        {
+            // this check may not be necessary, but it checks just in case the message
+            // has not been registered. this skips having to check uMsg != WM_NULL
+            UINT emptyEventMsg = _glfw.win32.emptyEventMessage;
+            if (emptyEventMsg != 0 && uMsg == emptyEventMsg)
+            {
+                if (_glfw.callbacks.emptyEvent)
+                    _glfw.callbacks.emptyEvent();
+            }
+            break;
+        }
     }
 
     return DefWindowProcW(hWnd, uMsg, wParam, lParam);
@@ -402,6 +415,14 @@ static GLFWbool createHelperWindow(void)
     {
         _glfwInputErrorWin32(GLFW_PLATFORM_ERROR,
                              "Win32: Failed to create helper window");
+        return GLFW_FALSE;
+    }
+
+    _glfw.win32.emptyEventMessage = RegisterWindowMessageW(L"GLFW.EmptyEventMessage");
+    if (!_glfw.win32.emptyEventMessage)
+    {
+        _glfwInputErrorWin32(GLFW_PLATFORM_ERROR,
+                             "Win32: Failed to register empty event message");
         return GLFW_FALSE;
     }
 

--- a/src/win32_platform.h
+++ b/src/win32_platform.h
@@ -457,6 +457,7 @@ typedef struct _GLFWlibraryWin32
     RAWINPUT*           rawInput;
     int                 rawInputSize;
     UINT                mouseTrailSize;
+    UINT                emptyEventMessage;
 
     struct {
         HINSTANCE                       instance;

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -2128,7 +2128,7 @@ void _glfwWaitEventsTimeoutWin32(double timeout)
 
 void _glfwPostEmptyEventWin32(void)
 {
-    PostMessageW(_glfw.win32.helperWindowHandle, WM_NULL, 0, 0);
+    PostMessageW(_glfw.win32.helperWindowHandle, _glfw.win32.emptyEventMessage, 0, 0);
 }
 
 void _glfwGetCursorPosWin32(_GLFWwindow* window, double* xpos, double* ypos)


### PR DESCRIPTION
This implements a callback for when `glfwPostEmptyEvent` is fired, based on the issue I created #2442, and the test does work (in `src/tests/window.c`). I don't know how to implement this for anything other than Windows though, so I'm not sure how to go about supporting this on other platforms