### PR TITLE
ci: Update to `actions/checkout@v4` from `v3`.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
             CC: clang
             CFLAGS: -Werror
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - name: Install dependencies
               run: |
                   sudo apt update
@@ -39,7 +39,7 @@ jobs:
             CC: clang
             CFLAGS: -Werror
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - name: Install dependencies
               run: |
                   sudo apt update
@@ -62,7 +62,7 @@ jobs:
             CFLAGS: -Werror
             MACOSX_DEPLOYMENT_TARGET: 10.8
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Configure static library
               run: cmake -S . -B build-static
@@ -80,7 +80,7 @@ jobs:
         env:
             CFLAGS: /WX
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Configure static library
               run: cmake -S . -B build-static -G "Visual Studio 17 2022"


### PR DESCRIPTION
This mainly updates the version of NodeJS used internally to keep up with what's going on at GitHub Actions.