### PR TITLE
Fix joystick EV_KEY handling indexing below 0 on keyboard input

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -278,6 +278,7 @@ video tutorials.
  - Jonas Ådahl
  - Lasse Öörni
  - Leonard König
+ - Liam Malone
  - All the unmentioned and anonymous contributors in the GLFW community, for bug
    reports, patches, feedback, testing and encouragement
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ information on what to include when reporting a bug.
 
 ## Changelog
 
+ - Bugfix: Linux joystick handling would crash with some keyboards, indexing the 
+   associated KeyMap with a value less than 0
  - Added `GLFW_PLATFORM` init hint for runtime platform selection (#1958)
  - Added `GLFW_ANY_PLATFORM`, `GLFW_PLATFORM_WIN32`, `GLFW_PLATFORM_COCOA`,
    `GLFW_PLATFORM_WAYLAND`, `GLFW_PLATFORM_X11` and `GLFW_PLATFORM_NULL` symbols to

--- a/src/linux_joystick.c
+++ b/src/linux_joystick.c
@@ -51,7 +51,7 @@
 //
 static void handleKeyEvent(_GLFWjoystick* js, int code, int value)
 {
-    _glfwInputJoystickButton(js,
+    if (code - BTN_MISC >= 0) _glfwInputJoystickButton(js,
                              js->linjs.keyMap[code - BTN_MISC],
                              value ? GLFW_PRESS : GLFW_RELEASE);
 }


### PR DESCRIPTION
This fixes an issue I was running into where input from my keyboard running ZMK firmware would be handled as a joystick, and would index the associated keymap with a value less than 0 (`code - BTN_MISC`, where `code` was smaller than `BTN_MISC`).

This issue was causing `SIGILL` crashes on my laptop every time I used that particular keyboard within my programs using glfw.