### PR TITLE
Wayland: add possibility to disable scaling

### DIFF
--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -366,6 +366,15 @@ static void createKeyTables(void)
     }
 }
 
+static GLFWbool getScaleSetting(void)
+{
+    const char* scaleEnvString = getenv("GLFW_SCALE_TO_MONITOR");
+    if (scaleEnvString)
+        return GLFW_TRUE;
+    else
+        return GLFW_FALSE;
+}
+
 static GLFWbool loadCursorTheme(void)
 {
     int cursorSize = 16;
@@ -829,6 +838,8 @@ int _glfwInitWayland(void)
 
     if (!loadCursorTheme())
         return GLFW_FALSE;
+
+    _glfw.wl.scaleToMonitor = getScaleSetting();
 
     if (_glfw.wl.seat && _glfw.wl.dataDeviceManager)
     {

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -454,6 +454,7 @@ typedef struct _GLFWlibraryWayland
     int                         cursorTimerfd;
     uint32_t                    serial;
     uint32_t                    pointerEnterSerial;
+    GLFWbool                    scaleToMonitor;
 
     int                         keyRepeatTimerfd;
     int32_t                     keyRepeatRate;

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -1331,6 +1331,7 @@ static void pointerHandleMotion(void* userData,
     const double ypos = wl_fixed_to_double(sy);
     window->wl.cursorPosX = xpos;
     window->wl.cursorPosY = ypos;
+    int scale = _glfw.wl.scaleToMonitor ? window->wl.contentScale : 1;
 
     const char* cursorName = NULL;
 
@@ -1338,7 +1339,7 @@ static void pointerHandleMotion(void* userData,
     {
         case GLFW_MAIN_WINDOW:
             _glfw.wl.cursorPreviousName = NULL;
-            _glfwInputCursorPos(window, xpos, ypos);
+            _glfwInputCursorPos(window, xpos * scale, ypos * scale);
             return;
         case GLFW_TOP_DECORATION:
             if (ypos < GLFW_BORDER_SIZE)
@@ -2138,10 +2139,11 @@ void _glfwSetWindowPosWayland(_GLFWwindow* window, int xpos, int ypos)
 
 void _glfwGetWindowSizeWayland(_GLFWwindow* window, int* width, int* height)
 {
+    int scale = _glfw.wl.scaleToMonitor ? window->wl.contentScale : 1;
     if (width)
-        *width = window->wl.width;
+        *width = window->wl.width * scale;
     if (height)
-        *height = window->wl.height;
+        *height = window->wl.height * scale;
 }
 
 void _glfwSetWindowSizeWayland(_GLFWwindow* window, int width, int height)
@@ -2255,10 +2257,11 @@ void _glfwSetWindowAspectRatioWayland(_GLFWwindow* window, int numer, int denom)
 void _glfwGetFramebufferSizeWayland(_GLFWwindow* window, int* width, int* height)
 {
     _glfwGetWindowSizeWayland(window, width, height);
+    int scale = _glfw.wl.scaleToMonitor ? 1 : window->wl.contentScale;
     if (width)
-        *width *= window->wl.contentScale;
+        *width *= scale;
     if (height)
-        *height *= window->wl.contentScale;
+        *height *= scale;
 }
 
 void _glfwGetWindowFrameSizeWayland(_GLFWwindow* window,


### PR DESCRIPTION
Currently wayland displays can have some scalling applied (it is widely used with HiDPI displays).
It is then handled via a `viewporter` or `fractional-scale` protocols.
However it is sometimes desirable to explicitly disable scaling for some GLFW application to have a clear and perfect 1:1 pixel window content (ie. no scaling applied).

This PR adds such a possiblity.
To use it one can eg. set/export a variable like this:
`export GLFW_SCALE_TO_MONITOR=1`
and then start the application.