### PR TITLE
Add glfw3impl.h, a single header implementation of GLFW for C/C++

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,6 +14,7 @@ video tutorials.
  - Luca Bacci
  - Keith Bauer
  - John Bartholomew
+ - Garett Bass
  - Coşku Baş
  - Niklas Behrens
  - Andrew Belt

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ available for all supported compilers.
 See the [compilation guide](https://www.glfw.org/docs/latest/compile.html) for
 more information about how to compile GLFW yourself.
 
+Alternatively, you can `#include <GLFW/glfw3impl.h>` in exactly one compilation
+unit of a C or C++ project to compile the entire implementation directly into
+your application, avoiding the need to separately compile and link with GLFW.
+
 
 ## Using GLFW
 

--- a/include/GLFW/glfw3impl.h
+++ b/include/GLFW/glfw3impl.h
@@ -1,0 +1,101 @@
+/*************************************************************************
+ * GLFW 3.4 - www.glfw.org
+ * A library for OpenGL, window and input
+ *------------------------------------------------------------------------
+ * Copyright (c) 2002-2006 Marcus Geelnard
+ * Copyright (c) 2006-2019 Camilla Löwy <elmindreda@glfw.org>
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would
+ *    be appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not
+ *    be misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source
+ *    distribution.
+ *
+ *************************************************************************/
+
+#ifndef _glfw3impl_h_
+#define _glfw3impl_h_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(_WIN32)
+
+    #define _GLFW_WIN32
+    // -D_CRT_SECURE_NO_WARNINGS
+    // -lgdi32
+    // -lshell32
+    // -luser32
+
+#elif defined(__APPLE__)
+
+    #define _GLFW_COCOA
+    // -framework Cocoa
+    // -framework IOKit
+    // -framework QuartzCore
+    // -x objective-c
+    //    or
+    // -x objective-c++
+
+#endif
+
+#include "../../src/cocoa_init.m"
+#include "../../src/cocoa_joystick.m"
+#include "../../src/cocoa_monitor.m"
+#include "../../src/cocoa_time.c"
+#include "../../src/cocoa_window.m"
+#include "../../src/context.c"
+#include "../../src/egl_context.c"
+#include "../../src/glx_context.c"
+#include "../../src/init.c"
+#include "../../src/input.c"
+#include "../../src/linux_joystick.c"
+#include "../../src/monitor.c"
+#include "../../src/nsgl_context.m"
+#include "../../src/null_init.c"
+#include "../../src/null_joystick.c"
+#include "../../src/null_monitor.c"
+#include "../../src/null_window.c"
+#include "../../src/osmesa_context.c"
+#include "../../src/platform.c"
+#include "../../src/posix_module.c"
+#include "../../src/posix_poll.c"
+#include "../../src/posix_thread.c"
+#include "../../src/posix_time.c"
+#include "../../src/vulkan.c"
+#include "../../src/wgl_context.c"
+#include "../../src/win32_init.c"
+#include "../../src/win32_joystick.c"
+#include "../../src/win32_module.c"
+#include "../../src/win32_monitor.c"
+#include "../../src/win32_thread.c"
+#include "../../src/win32_time.c"
+#include "../../src/win32_window.c"
+#include "../../src/window.c"
+#include "../../src/wl_init.c"
+#include "../../src/wl_monitor.c"
+#include "../../src/wl_window.c"
+#include "../../src/x11_init.c"
+#include "../../src/x11_monitor.c"
+#include "../../src/x11_window.c"
+#include "../../src/xkb_unicode.c"
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* _glfw3impl_h_ */

--- a/src/cocoa_platform.h
+++ b/src/cocoa_platform.h
@@ -298,5 +298,4 @@ void _glfwTerminateNSGL(void);
 GLFWbool _glfwCreateContextNSGL(_GLFWwindow* window,
                                 const _GLFWctxconfig* ctxconfig,
                                 const _GLFWfbconfig* fbconfig);
-void _glfwDestroyContextNSGL(_GLFWwindow* window);
 

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -39,7 +39,7 @@
 
 // Returns whether the cursor is in the content area of the specified window
 //
-static GLFWbool cursorInContentArea(_GLFWwindow* window)
+static GLFWbool _glfwCursorInContentAreaCocoa(_GLFWwindow* window)
 {
     const NSPoint pos = [window->ns.object mouseLocationOutsideOfEventStream];
     return [window->ns.view mouse:pos inRect:[window->ns.view frame]];
@@ -47,7 +47,7 @@ static GLFWbool cursorInContentArea(_GLFWwindow* window)
 
 // Hides the cursor if not already hidden
 //
-static void hideCursor(_GLFWwindow* window)
+static void _glfwHideCursorCocoa(_GLFWwindow* window)
 {
     if (!_glfw.ns.cursorHidden)
     {
@@ -58,7 +58,7 @@ static void hideCursor(_GLFWwindow* window)
 
 // Shows the cursor if not already shown
 //
-static void showCursor(_GLFWwindow* window)
+static void _glfwShowCursorCocoa(_GLFWwindow* window)
 {
     if (_glfw.ns.cursorHidden)
     {
@@ -69,11 +69,11 @@ static void showCursor(_GLFWwindow* window)
 
 // Updates the cursor image according to its cursor mode
 //
-static void updateCursorImage(_GLFWwindow* window)
+static void _glfwUpdateCursorImageCocoa(_GLFWwindow* window)
 {
     if (window->cursorMode == GLFW_CURSOR_NORMAL)
     {
-        showCursor(window);
+        _glfwShowCursorCocoa(window);
 
         if (window->cursor)
             [(NSCursor*) window->cursor->ns.object set];
@@ -81,12 +81,12 @@ static void updateCursorImage(_GLFWwindow* window)
             [[NSCursor arrowCursor] set];
     }
     else
-        hideCursor(window);
+        _glfwHideCursorCocoa(window);
 }
 
 // Apply chosen cursor mode to a focused window
 //
-static void updateCursorMode(_GLFWwindow* window)
+static void _glfwUpdateCursorModeCocoa(_GLFWwindow* window)
 {
     if (window->cursorMode == GLFW_CURSOR_DISABLED)
     {
@@ -107,13 +107,13 @@ static void updateCursorMode(_GLFWwindow* window)
         //       made in _glfwSetCursorPosCocoa as part of a workaround
     }
 
-    if (cursorInContentArea(window))
-        updateCursorImage(window);
+    if (_glfwCursorInContentAreaCocoa(window))
+        _glfwUpdateCursorImageCocoa(window);
 }
 
 // Make the specified window and its video mode active on its monitor
 //
-static void acquireMonitor(_GLFWwindow* window)
+static void _glfwAcquireMonitorCocoa(_GLFWwindow* window)
 {
     _glfwSetVideoModeCocoa(window->monitor, &window->videoMode);
     const CGRect bounds = CGDisplayBounds(window->monitor->ns.displayID);
@@ -129,7 +129,7 @@ static void acquireMonitor(_GLFWwindow* window)
 
 // Remove the window and restore the original video mode
 //
-static void releaseMonitor(_GLFWwindow* window)
+static void _glfwReleaseMonitorCocoa(_GLFWwindow* window)
 {
     if (window->monitor->window != window)
         return;
@@ -140,7 +140,7 @@ static void releaseMonitor(_GLFWwindow* window)
 
 // Translates macOS key modifiers into GLFW ones
 //
-static int translateFlags(NSUInteger flags)
+static int _glfwTranslateFlagsCocoa(NSUInteger flags)
 {
     int mods = 0;
 
@@ -160,7 +160,7 @@ static int translateFlags(NSUInteger flags)
 
 // Translates a macOS keycode to a GLFW keycode
 //
-static int translateKey(unsigned int key)
+static int _glfwTranslateKeyCocoa(unsigned int key)
 {
     if (key >= sizeof(_glfw.ns.keycodes) / sizeof(_glfw.ns.keycodes[0]))
         return GLFW_KEY_UNKNOWN;
@@ -170,7 +170,7 @@ static int translateKey(unsigned int key)
 
 // Translate a GLFW keycode to a Cocoa modifier flag
 //
-static NSUInteger translateKeyToModifierFlag(int key)
+static NSUInteger _glfwTranslateKeyToModifierFlagCocoa(int key)
 {
     switch (key)
     {
@@ -195,7 +195,7 @@ static NSUInteger translateKeyToModifierFlag(int key)
 
 // Defines a constant for empty ranges in NSTextInputClient
 //
-static const NSRange kEmptyRange = { NSNotFound, 0 };
+static const NSRange _glfwKEmptyRangeCocoa = { NSNotFound, 0 };
 
 
 //------------------------------------------------------------------------
@@ -279,7 +279,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
 - (void)windowDidMiniaturize:(NSNotification *)notification
 {
     if (window->monitor)
-        releaseMonitor(window);
+        _glfwReleaseMonitorCocoa(window);
 
     _glfwInputWindowIconify(window, GLFW_TRUE);
 }
@@ -287,7 +287,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
 - (void)windowDidDeminiaturize:(NSNotification *)notification
 {
     if (window->monitor)
-        acquireMonitor(window);
+        _glfwAcquireMonitorCocoa(window);
 
     _glfwInputWindowIconify(window, GLFW_FALSE);
 }
@@ -298,7 +298,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
         _glfwCenterCursorInContentArea(window);
 
     _glfwInputWindowFocus(window, GLFW_TRUE);
-    updateCursorMode(window);
+    _glfwUpdateCursorModeCocoa(window);
 }
 
 - (void)windowDidResignKey:(NSNotification *)notification
@@ -395,7 +395,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
 
 - (void)cursorUpdate:(NSEvent *)event
 {
-    updateCursorImage(window);
+    _glfwUpdateCursorImageCocoa(window);
 }
 
 - (BOOL)acceptsFirstMouse:(NSEvent *)event
@@ -408,7 +408,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
     _glfwInputMouseClick(window,
                          GLFW_MOUSE_BUTTON_LEFT,
                          GLFW_PRESS,
-                         translateFlags([event modifierFlags]));
+                         _glfwTranslateFlagsCocoa([event modifierFlags]));
 }
 
 - (void)mouseDragged:(NSEvent *)event
@@ -421,7 +421,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
     _glfwInputMouseClick(window,
                          GLFW_MOUSE_BUTTON_LEFT,
                          GLFW_RELEASE,
-                         translateFlags([event modifierFlags]));
+                         _glfwTranslateFlagsCocoa([event modifierFlags]));
 }
 
 - (void)mouseMoved:(NSEvent *)event
@@ -453,7 +453,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
     _glfwInputMouseClick(window,
                          GLFW_MOUSE_BUTTON_RIGHT,
                          GLFW_PRESS,
-                         translateFlags([event modifierFlags]));
+                         _glfwTranslateFlagsCocoa([event modifierFlags]));
 }
 
 - (void)rightMouseDragged:(NSEvent *)event
@@ -466,7 +466,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
     _glfwInputMouseClick(window,
                          GLFW_MOUSE_BUTTON_RIGHT,
                          GLFW_RELEASE,
-                         translateFlags([event modifierFlags]));
+                         _glfwTranslateFlagsCocoa([event modifierFlags]));
 }
 
 - (void)otherMouseDown:(NSEvent *)event
@@ -474,7 +474,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
     _glfwInputMouseClick(window,
                          (int) [event buttonNumber],
                          GLFW_PRESS,
-                         translateFlags([event modifierFlags]));
+                         _glfwTranslateFlagsCocoa([event modifierFlags]));
 }
 
 - (void)otherMouseDragged:(NSEvent *)event
@@ -487,13 +487,13 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
     _glfwInputMouseClick(window,
                          (int) [event buttonNumber],
                          GLFW_RELEASE,
-                         translateFlags([event modifierFlags]));
+                         _glfwTranslateFlagsCocoa([event modifierFlags]));
 }
 
 - (void)mouseExited:(NSEvent *)event
 {
     if (window->cursorMode == GLFW_CURSOR_HIDDEN)
-        showCursor(window);
+        _glfwShowCursorCocoa(window);
 
     _glfwInputCursorEnter(window, GLFW_FALSE);
 }
@@ -501,7 +501,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
 - (void)mouseEntered:(NSEvent *)event
 {
     if (window->cursorMode == GLFW_CURSOR_HIDDEN)
-        hideCursor(window);
+        _glfwHideCursorCocoa(window);
 
     _glfwInputCursorEnter(window, GLFW_TRUE);
 }
@@ -563,8 +563,8 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
 
 - (void)keyDown:(NSEvent *)event
 {
-    const int key = translateKey([event keyCode]);
-    const int mods = translateFlags([event modifierFlags]);
+    const int key = _glfwTranslateKeyCocoa([event keyCode]);
+    const int mods = _glfwTranslateFlagsCocoa([event modifierFlags]);
 
     _glfwInputKey(window, key, [event keyCode], GLFW_PRESS, mods);
 
@@ -576,9 +576,9 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
     int action;
     const unsigned int modifierFlags =
         [event modifierFlags] & NSEventModifierFlagDeviceIndependentFlagsMask;
-    const int key = translateKey([event keyCode]);
-    const int mods = translateFlags(modifierFlags);
-    const NSUInteger keyFlag = translateKeyToModifierFlag(key);
+    const int key = _glfwTranslateKeyCocoa([event keyCode]);
+    const int mods = _glfwTranslateFlagsCocoa(modifierFlags);
+    const NSUInteger keyFlag = _glfwTranslateKeyToModifierFlagCocoa(key);
 
     if (keyFlag & modifierFlags)
     {
@@ -595,8 +595,8 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
 
 - (void)keyUp:(NSEvent *)event
 {
-    const int key = translateKey([event keyCode]);
-    const int mods = translateFlags([event modifierFlags]);
+    const int key = _glfwTranslateKeyCocoa([event keyCode]);
+    const int mods = _glfwTranslateFlagsCocoa([event modifierFlags]);
     _glfwInputKey(window, key, [event keyCode], GLFW_RELEASE, mods);
 }
 
@@ -636,7 +636,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
     const NSUInteger count = [urls count];
     if (count)
     {
-        char** paths = _glfw_calloc(count, sizeof(char*));
+        char** paths = (char**) _glfw_calloc(count, sizeof(char*));
 
         for (NSUInteger i = 0;  i < count;  i++)
             paths[i] = _glfw_strdup([urls[i] fileSystemRepresentation]);
@@ -661,12 +661,12 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
     if ([markedText length] > 0)
         return NSMakeRange(0, [markedText length] - 1);
     else
-        return kEmptyRange;
+        return _glfwKEmptyRangeCocoa;
 }
 
 - (NSRange)selectedRange
 {
-    return kEmptyRange;
+    return _glfwKEmptyRangeCocoa;
 }
 
 - (void)setMarkedText:(id)string
@@ -712,7 +712,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
 {
     NSString* characters;
     NSEvent* event = [NSApp currentEvent];
-    const int mods = translateFlags([event modifierFlags]);
+    const int mods = _glfwTranslateFlagsCocoa([event modifierFlags]);
     const int plain = !(mods & GLFW_MOD_SUPER);
 
     if ([string isKindOfClass:[NSAttributedString class]])
@@ -773,9 +773,9 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
 
 // Create the Cocoa window
 //
-static GLFWbool createNativeWindow(_GLFWwindow* window,
-                                   const _GLFWwndconfig* wndconfig,
-                                   const _GLFWfbconfig* fbconfig)
+static GLFWbool _glfwCreateNativeWindowCocoa(_GLFWwindow* window,
+                                        const _GLFWwndconfig* wndconfig,
+                                        const _GLFWfbconfig* fbconfig)
 {
     window->ns.delegate = [[GLFWWindowDelegate alloc] initWithGlfwWindow:window];
     if (window->ns.delegate == nil)
@@ -925,7 +925,7 @@ GLFWbool _glfwCreateWindowCocoa(_GLFWwindow* window,
 {
     @autoreleasepool {
 
-    if (!createNativeWindow(window, wndconfig, fbconfig))
+    if (!_glfwCreateNativeWindowCocoa(window, wndconfig, fbconfig))
         return GLFW_FALSE;
 
     if (ctxconfig->client != GLFW_NO_API)
@@ -968,7 +968,7 @@ GLFWbool _glfwCreateWindowCocoa(_GLFWwindow* window,
     {
         _glfwShowWindowCocoa(window);
         _glfwFocusWindowCocoa(window);
-        acquireMonitor(window);
+        _glfwAcquireMonitorCocoa(window);
 
         if (wndconfig->centerCursor)
             _glfwCenterCursorInContentArea(window);
@@ -998,7 +998,7 @@ void _glfwDestroyWindowCocoa(_GLFWwindow* window)
     [window->ns.object orderOut:nil];
 
     if (window->monitor)
-        releaseMonitor(window);
+        _glfwReleaseMonitorCocoa(window);
 
     if (window->context.destroy)
         window->context.destroy(window);
@@ -1085,7 +1085,7 @@ void _glfwSetWindowSizeCocoa(_GLFWwindow* window, int width, int height)
     if (window->monitor)
     {
         if (window->monitor->window == window)
-            acquireMonitor(window);
+            _glfwAcquireMonitorCocoa(window);
     }
     else
     {
@@ -1254,7 +1254,7 @@ void _glfwSetWindowMonitorCocoa(_GLFWwindow* window,
         if (monitor)
         {
             if (monitor->window == window)
-                acquireMonitor(window);
+                _glfwAcquireMonitorCocoa(window);
         }
         else
         {
@@ -1272,7 +1272,7 @@ void _glfwSetWindowMonitorCocoa(_GLFWwindow* window,
     }
 
     if (window->monitor)
-        releaseMonitor(window);
+        _glfwReleaseMonitorCocoa(window);
 
     _glfwInputWindowMonitor(window, monitor);
 
@@ -1310,7 +1310,7 @@ void _glfwSetWindowMonitorCocoa(_GLFWwindow* window,
         [window->ns.object setLevel:NSMainMenuWindowLevel + 1];
         [window->ns.object setHasShadow:NO];
 
-        acquireMonitor(window);
+        _glfwAcquireMonitorCocoa(window);
     }
     else
     {
@@ -1607,7 +1607,7 @@ void _glfwSetCursorPosCocoa(_GLFWwindow* window, double x, double y)
 {
     @autoreleasepool {
 
-    updateCursorImage(window);
+    _glfwUpdateCursorImageCocoa(window);
 
     const NSRect contentRect = [window->ns.view frame];
     // NOTE: The returned location uses base 0,1 not 0,0
@@ -1650,7 +1650,7 @@ void _glfwSetCursorModeCocoa(_GLFWwindow* window, int mode)
     }
 
     if (_glfwWindowFocusedCocoa(window))
-        updateCursorMode(window);
+        _glfwUpdateCursorModeCocoa(window);
 
     } // autoreleasepool
 }
@@ -1672,7 +1672,8 @@ const char* _glfwGetScancodeNameCocoa(int scancode)
     UniChar characters[4];
     UniCharCount characterCount = 0;
 
-    if (UCKeyTranslate([(NSData*) _glfw.ns.unicodeData bytes],
+    if (UCKeyTranslate((const UCKeyboardLayout *)
+                       [(NSData*) _glfw.ns.unicodeData bytes],
                        scancode,
                        kUCKeyActionDisplay,
                        0,
@@ -1838,8 +1839,8 @@ void _glfwDestroyCursorCocoa(_GLFWcursor* cursor)
 void _glfwSetCursorCocoa(_GLFWwindow* window, _GLFWcursor* cursor)
 {
     @autoreleasepool {
-    if (cursorInContentArea(window))
-        updateCursorImage(window);
+    if (_glfwCursorInContentAreaCocoa(window))
+        _glfwUpdateCursorImageCocoa(window);
     } // autoreleasepool
 }
 
@@ -1901,7 +1902,7 @@ EGLenum _glfwGetEGLPlatformCocoa(EGLint** attribs)
 
         if (type)
         {
-            *attribs = _glfw_calloc(3, sizeof(EGLint));
+            *attribs = (EGLint*) _glfw_calloc(3, sizeof(EGLint));
             (*attribs)[0] = EGL_PLATFORM_ANGLE_TYPE_ANGLE;
             (*attribs)[1] = type;
             (*attribs)[2] = EGL_NONE;
@@ -1926,13 +1927,13 @@ void _glfwGetRequiredInstanceExtensionsCocoa(char** extensions)
 {
     if (_glfw.vk.KHR_surface && _glfw.vk.EXT_metal_surface)
     {
-        extensions[0] = "VK_KHR_surface";
-        extensions[1] = "VK_EXT_metal_surface";
+        extensions[0] = (char*) "VK_KHR_surface";
+        extensions[1] = (char*) "VK_EXT_metal_surface";
     }
     else if (_glfw.vk.KHR_surface && _glfw.vk.MVK_macos_surface)
     {
-        extensions[0] = "VK_KHR_surface";
-        extensions[1] = "VK_MVK_macos_surface";
+        extensions[0] = (char*) "VK_KHR_surface";
+        extensions[1] = (char*) "VK_MVK_macos_surface";
     }
 }
 

--- a/src/context.c
+++ b/src/context.c
@@ -361,7 +361,7 @@ GLFWbool _glfwRefreshContextAttribs(_GLFWwindow* window,
     window->context.source = ctxconfig->source;
     window->context.client = GLFW_OPENGL_API;
 
-    previous = _glfwPlatformGetTls(&_glfw.contextSlot);
+    previous = (_GLFWwindow*) _glfwPlatformGetTls(&_glfw.contextSlot);
     glfwMakeContextCurrent((GLFWwindow*) window);
     if (_glfwPlatformGetTls(&_glfw.contextSlot) != window)
         return GLFW_FALSE;
@@ -622,7 +622,7 @@ GLFWAPI void glfwMakeContextCurrent(GLFWwindow* handle)
 
     _GLFW_REQUIRE_INIT();
 
-    previous = _glfwPlatformGetTls(&_glfw.contextSlot);
+    previous = (_GLFWwindow*) _glfwPlatformGetTls(&_glfw.contextSlot);
 
     if (window && window->context.client == GLFW_NO_API)
     {
@@ -644,7 +644,7 @@ GLFWAPI void glfwMakeContextCurrent(GLFWwindow* handle)
 GLFWAPI GLFWwindow* glfwGetCurrentContext(void)
 {
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
-    return _glfwPlatformGetTls(&_glfw.contextSlot);
+    return (GLFWwindow*) _glfwPlatformGetTls(&_glfw.contextSlot);
 }
 
 GLFWAPI void glfwSwapBuffers(GLFWwindow* handle)
@@ -670,7 +670,7 @@ GLFWAPI void glfwSwapInterval(int interval)
 
     _GLFW_REQUIRE_INIT();
 
-    window = _glfwPlatformGetTls(&_glfw.contextSlot);
+    window = (_GLFWwindow*) _glfwPlatformGetTls(&_glfw.contextSlot);
     if (!window)
     {
         _glfwInputError(GLFW_NO_CURRENT_CONTEXT,
@@ -688,7 +688,7 @@ GLFWAPI int glfwExtensionSupported(const char* extension)
 
     _GLFW_REQUIRE_INIT_OR_RETURN(GLFW_FALSE);
 
-    window = _glfwPlatformGetTls(&_glfw.contextSlot);
+    window = (_GLFWwindow*) _glfwPlatformGetTls(&_glfw.contextSlot);
     if (!window)
     {
         _glfwInputError(GLFW_NO_CURRENT_CONTEXT,
@@ -754,7 +754,7 @@ GLFWAPI GLFWglproc glfwGetProcAddress(const char* procname)
 
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
 
-    window = _glfwPlatformGetTls(&_glfw.contextSlot);
+    window = (_GLFWwindow*) _glfwPlatformGetTls(&_glfw.contextSlot);
     if (!window)
     {
         _glfwInputError(GLFW_NO_CURRENT_CONTEXT,

--- a/src/glx_context.c
+++ b/src/glx_context.c
@@ -42,7 +42,7 @@
 
 // Returns the specified attribute of the specified GLXFBConfig
 //
-static int getGLXFBConfigAttrib(GLXFBConfig fbconfig, int attrib)
+static int _glfwGetConfigAttribGLX(GLXFBConfig fbconfig, int attrib)
 {
     int value;
     glXGetFBConfigAttrib(_glfw.x11.display, fbconfig, attrib, &value);
@@ -51,7 +51,7 @@ static int getGLXFBConfigAttrib(GLXFBConfig fbconfig, int attrib)
 
 // Return the GLXFBConfig most closely matching the specified hints
 //
-static GLFWbool chooseGLXFBConfig(const _GLFWfbconfig* desired,
+static GLFWbool _glfwChooseConfigGLX(const _GLFWfbconfig* desired,
                                   GLXFBConfig* result)
 {
     GLXFBConfig* nativeConfigs;
@@ -84,17 +84,17 @@ static GLFWbool chooseGLXFBConfig(const _GLFWfbconfig* desired,
         _GLFWfbconfig* u = usableConfigs + usableCount;
 
         // Only consider RGBA GLXFBConfigs
-        if (!(getGLXFBConfigAttrib(n, GLX_RENDER_TYPE) & GLX_RGBA_BIT))
+        if (!(_glfwGetConfigAttribGLX(n, GLX_RENDER_TYPE) & GLX_RGBA_BIT))
             continue;
 
         // Only consider window GLXFBConfigs
-        if (!(getGLXFBConfigAttrib(n, GLX_DRAWABLE_TYPE) & GLX_WINDOW_BIT))
+        if (!(_glfwGetConfigAttribGLX(n, GLX_DRAWABLE_TYPE) & GLX_WINDOW_BIT))
         {
             if (trustWindowBit)
                 continue;
         }
 
-        if (getGLXFBConfigAttrib(n, GLX_DOUBLEBUFFER) != desired->doublebuffer)
+        if (_glfwGetConfigAttribGLX(n, GLX_DOUBLEBUFFER) != desired->doublebuffer)
             continue;
 
         if (desired->transparent)
@@ -107,29 +107,29 @@ static GLFWbool chooseGLXFBConfig(const _GLFWfbconfig* desired,
             }
         }
 
-        u->redBits = getGLXFBConfigAttrib(n, GLX_RED_SIZE);
-        u->greenBits = getGLXFBConfigAttrib(n, GLX_GREEN_SIZE);
-        u->blueBits = getGLXFBConfigAttrib(n, GLX_BLUE_SIZE);
+        u->redBits = _glfwGetConfigAttribGLX(n, GLX_RED_SIZE);
+        u->greenBits = _glfwGetConfigAttribGLX(n, GLX_GREEN_SIZE);
+        u->blueBits = _glfwGetConfigAttribGLX(n, GLX_BLUE_SIZE);
 
-        u->alphaBits = getGLXFBConfigAttrib(n, GLX_ALPHA_SIZE);
-        u->depthBits = getGLXFBConfigAttrib(n, GLX_DEPTH_SIZE);
-        u->stencilBits = getGLXFBConfigAttrib(n, GLX_STENCIL_SIZE);
+        u->alphaBits = _glfwGetConfigAttribGLX(n, GLX_ALPHA_SIZE);
+        u->depthBits = _glfwGetConfigAttribGLX(n, GLX_DEPTH_SIZE);
+        u->stencilBits = _glfwGetConfigAttribGLX(n, GLX_STENCIL_SIZE);
 
-        u->accumRedBits = getGLXFBConfigAttrib(n, GLX_ACCUM_RED_SIZE);
-        u->accumGreenBits = getGLXFBConfigAttrib(n, GLX_ACCUM_GREEN_SIZE);
-        u->accumBlueBits = getGLXFBConfigAttrib(n, GLX_ACCUM_BLUE_SIZE);
-        u->accumAlphaBits = getGLXFBConfigAttrib(n, GLX_ACCUM_ALPHA_SIZE);
+        u->accumRedBits = _glfwGetConfigAttribGLX(n, GLX_ACCUM_RED_SIZE);
+        u->accumGreenBits = _glfwGetConfigAttribGLX(n, GLX_ACCUM_GREEN_SIZE);
+        u->accumBlueBits = _glfwGetConfigAttribGLX(n, GLX_ACCUM_BLUE_SIZE);
+        u->accumAlphaBits = _glfwGetConfigAttribGLX(n, GLX_ACCUM_ALPHA_SIZE);
 
-        u->auxBuffers = getGLXFBConfigAttrib(n, GLX_AUX_BUFFERS);
+        u->auxBuffers = _glfwGetConfigAttribGLX(n, GLX_AUX_BUFFERS);
 
-        if (getGLXFBConfigAttrib(n, GLX_STEREO))
+        if (_glfwGetConfigAttribGLX(n, GLX_STEREO))
             u->stereo = GLFW_TRUE;
 
         if (_glfw.glx.ARB_multisample)
-            u->samples = getGLXFBConfigAttrib(n, GLX_SAMPLES);
+            u->samples = _glfwGetConfigAttribGLX(n, GLX_SAMPLES);
 
         if (_glfw.glx.ARB_framebuffer_sRGB || _glfw.glx.EXT_framebuffer_sRGB)
-            u->sRGB = getGLXFBConfigAttrib(n, GLX_FRAMEBUFFER_SRGB_CAPABLE_ARB);
+            u->sRGB = _glfwGetConfigAttribGLX(n, GLX_FRAMEBUFFER_SRGB_CAPABLE_ARB);
 
         u->handle = (uintptr_t) n;
         usableCount++;
@@ -147,7 +147,7 @@ static GLFWbool chooseGLXFBConfig(const _GLFWfbconfig* desired,
 
 // Create the OpenGL context using legacy API
 //
-static GLXContext createLegacyContextGLX(_GLFWwindow* window,
+static GLXContext _glfwCreateLegacyContextGLX(_GLFWwindow* window,
                                          GLXFBConfig fbconfig,
                                          GLXContext share)
 {
@@ -158,7 +158,7 @@ static GLXContext createLegacyContextGLX(_GLFWwindow* window,
                                True);
 }
 
-static void makeContextCurrentGLX(_GLFWwindow* window)
+static void _glfwMakeContextCurrentGLX(_GLFWwindow* window)
 {
     if (window)
     {
@@ -184,12 +184,12 @@ static void makeContextCurrentGLX(_GLFWwindow* window)
     _glfwPlatformSetTls(&_glfw.contextSlot, window);
 }
 
-static void swapBuffersGLX(_GLFWwindow* window)
+static void _glfwSwapBuffersGLX(_GLFWwindow* window)
 {
     glXSwapBuffers(_glfw.x11.display, window->context.glx.window);
 }
 
-static void swapIntervalGLX(int interval)
+static void _glfwSwapIntervalGLX(int interval)
 {
     _GLFWwindow* window = _glfwPlatformGetTls(&_glfw.contextSlot);
     assert(window != NULL);
@@ -209,7 +209,7 @@ static void swapIntervalGLX(int interval)
     }
 }
 
-static int extensionSupportedGLX(const char* extension)
+static int _glfwExtensionSupportedGLX(const char* extension)
 {
     const char* extensions =
         glXQueryExtensionsString(_glfw.x11.display, _glfw.x11.screen);
@@ -222,7 +222,7 @@ static int extensionSupportedGLX(const char* extension)
     return GLFW_FALSE;
 }
 
-static GLFWglproc getProcAddressGLX(const char* procname)
+static GLFWglproc _glfwGetProcAddressGLX(const char* procname)
 {
     if (_glfw.glx.GetProcAddress)
         return _glfw.glx.GetProcAddress((const GLubyte*) procname);
@@ -235,7 +235,7 @@ static GLFWglproc getProcAddressGLX(const char* procname)
     }
 }
 
-static void destroyContextGLX(_GLFWwindow* window)
+static void _glfwDestroyContextGLX(_GLFWwindow* window)
 {
     if (window->context.glx.window)
     {
@@ -365,64 +365,64 @@ GLFWbool _glfwInitGLX(void)
         return GLFW_FALSE;
     }
 
-    if (extensionSupportedGLX("GLX_EXT_swap_control"))
+    if (_glfwExtensionSupportedGLX("GLX_EXT_swap_control"))
     {
         _glfw.glx.SwapIntervalEXT = (PFNGLXSWAPINTERVALEXTPROC)
-            getProcAddressGLX("glXSwapIntervalEXT");
+            _glfwGetProcAddressGLX("glXSwapIntervalEXT");
 
         if (_glfw.glx.SwapIntervalEXT)
             _glfw.glx.EXT_swap_control = GLFW_TRUE;
     }
 
-    if (extensionSupportedGLX("GLX_SGI_swap_control"))
+    if (_glfwExtensionSupportedGLX("GLX_SGI_swap_control"))
     {
         _glfw.glx.SwapIntervalSGI = (PFNGLXSWAPINTERVALSGIPROC)
-            getProcAddressGLX("glXSwapIntervalSGI");
+            _glfwGetProcAddressGLX("glXSwapIntervalSGI");
 
         if (_glfw.glx.SwapIntervalSGI)
             _glfw.glx.SGI_swap_control = GLFW_TRUE;
     }
 
-    if (extensionSupportedGLX("GLX_MESA_swap_control"))
+    if (_glfwExtensionSupportedGLX("GLX_MESA_swap_control"))
     {
         _glfw.glx.SwapIntervalMESA = (PFNGLXSWAPINTERVALMESAPROC)
-            getProcAddressGLX("glXSwapIntervalMESA");
+            _glfwGetProcAddressGLX("glXSwapIntervalMESA");
 
         if (_glfw.glx.SwapIntervalMESA)
             _glfw.glx.MESA_swap_control = GLFW_TRUE;
     }
 
-    if (extensionSupportedGLX("GLX_ARB_multisample"))
+    if (_glfwExtensionSupportedGLX("GLX_ARB_multisample"))
         _glfw.glx.ARB_multisample = GLFW_TRUE;
 
-    if (extensionSupportedGLX("GLX_ARB_framebuffer_sRGB"))
+    if (_glfwExtensionSupportedGLX("GLX_ARB_framebuffer_sRGB"))
         _glfw.glx.ARB_framebuffer_sRGB = GLFW_TRUE;
 
-    if (extensionSupportedGLX("GLX_EXT_framebuffer_sRGB"))
+    if (_glfwExtensionSupportedGLX("GLX_EXT_framebuffer_sRGB"))
         _glfw.glx.EXT_framebuffer_sRGB = GLFW_TRUE;
 
-    if (extensionSupportedGLX("GLX_ARB_create_context"))
+    if (_glfwExtensionSupportedGLX("GLX_ARB_create_context"))
     {
         _glfw.glx.CreateContextAttribsARB = (PFNGLXCREATECONTEXTATTRIBSARBPROC)
-            getProcAddressGLX("glXCreateContextAttribsARB");
+            _glfwGetProcAddressGLX("glXCreateContextAttribsARB");
 
         if (_glfw.glx.CreateContextAttribsARB)
             _glfw.glx.ARB_create_context = GLFW_TRUE;
     }
 
-    if (extensionSupportedGLX("GLX_ARB_create_context_robustness"))
+    if (_glfwExtensionSupportedGLX("GLX_ARB_create_context_robustness"))
         _glfw.glx.ARB_create_context_robustness = GLFW_TRUE;
 
-    if (extensionSupportedGLX("GLX_ARB_create_context_profile"))
+    if (_glfwExtensionSupportedGLX("GLX_ARB_create_context_profile"))
         _glfw.glx.ARB_create_context_profile = GLFW_TRUE;
 
-    if (extensionSupportedGLX("GLX_EXT_create_context_es2_profile"))
+    if (_glfwExtensionSupportedGLX("GLX_EXT_create_context_es2_profile"))
         _glfw.glx.EXT_create_context_es2_profile = GLFW_TRUE;
 
-    if (extensionSupportedGLX("GLX_ARB_create_context_no_error"))
+    if (_glfwExtensionSupportedGLX("GLX_ARB_create_context_no_error"))
         _glfw.glx.ARB_create_context_no_error = GLFW_TRUE;
 
-    if (extensionSupportedGLX("GLX_ARB_context_flush_control"))
+    if (_glfwExtensionSupportedGLX("GLX_ARB_context_flush_control"))
         _glfw.glx.ARB_context_flush_control = GLFW_TRUE;
 
     return GLFW_TRUE;
@@ -462,7 +462,7 @@ GLFWbool _glfwCreateContextGLX(_GLFWwindow* window,
     if (ctxconfig->share)
         share = ctxconfig->share->context.glx.handle;
 
-    if (!chooseGLXFBConfig(fbconfig, &native))
+    if (!_glfwChooseConfigGLX(fbconfig, &native))
     {
         _glfwInputError(GLFW_FORMAT_UNAVAILABLE,
                         "GLX: Failed to find a suitable GLXFBConfig");
@@ -602,14 +602,14 @@ GLFWbool _glfwCreateContextGLX(_GLFWwindow* window,
                 ctxconfig->forward == GLFW_FALSE)
             {
                 window->context.glx.handle =
-                    createLegacyContextGLX(window, native, share);
+                    _glfwCreateLegacyContextGLX(window, native, share);
             }
         }
     }
     else
     {
         window->context.glx.handle =
-            createLegacyContextGLX(window, native, share);
+            _glfwCreateLegacyContextGLX(window, native, share);
     }
 
     _glfwReleaseErrorHandlerX11();
@@ -628,12 +628,12 @@ GLFWbool _glfwCreateContextGLX(_GLFWwindow* window,
         return GLFW_FALSE;
     }
 
-    window->context.makeCurrent = makeContextCurrentGLX;
-    window->context.swapBuffers = swapBuffersGLX;
-    window->context.swapInterval = swapIntervalGLX;
-    window->context.extensionSupported = extensionSupportedGLX;
-    window->context.getProcAddress = getProcAddressGLX;
-    window->context.destroy = destroyContextGLX;
+    window->context.makeCurrent = _glfwMakeContextCurrentGLX;
+    window->context.swapBuffers = _glfwSwapBuffersGLX;
+    window->context.swapInterval = _glfwSwapIntervalGLX;
+    window->context.extensionSupported = _glfwExtensionSupportedGLX;
+    window->context.getProcAddress = _glfwGetProcAddressGLX;
+    window->context.destroy = _glfwDestroyContextGLX;
 
     return GLFW_TRUE;
 }
@@ -650,7 +650,7 @@ GLFWbool _glfwChooseVisualGLX(const _GLFWwndconfig* wndconfig,
     GLXFBConfig native;
     XVisualInfo* result;
 
-    if (!chooseGLXFBConfig(fbconfig, &native))
+    if (!_glfwChooseConfigGLX(fbconfig, &native))
     {
         _glfwInputError(GLFW_FORMAT_UNAVAILABLE,
                         "GLX: Failed to find a suitable GLXFBConfig");

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -39,10 +39,10 @@
 
 // Lexically compare video modes, used by qsort
 //
-static int compareVideoModes(const void* fp, const void* sp)
+static int _glfwQsortCompareVideoModes(const void* fp, const void* sp)
 {
-    const GLFWvidmode* fm = fp;
-    const GLFWvidmode* sm = sp;
+    const GLFWvidmode* fm = (const GLFWvidmode*) fp;
+    const GLFWvidmode* sm = (const GLFWvidmode*) sp;
     const int fbpp = fm->redBits + fm->greenBits + fm->blueBits;
     const int sbpp = sm->redBits + sm->greenBits + sm->blueBits;
     const int farea = fm->width * fm->height;
@@ -66,7 +66,7 @@ static int compareVideoModes(const void* fp, const void* sp)
 
 // Retrieves the available modes for the specified monitor
 //
-static GLFWbool refreshVideoModes(_GLFWmonitor* monitor)
+static GLFWbool _glfwRefreshVideoModes(_GLFWmonitor* monitor)
 {
     int modeCount;
     GLFWvidmode* modes;
@@ -78,7 +78,7 @@ static GLFWbool refreshVideoModes(_GLFWmonitor* monitor)
     if (!modes)
         return GLFW_FALSE;
 
-    qsort(modes, modeCount, sizeof(GLFWvidmode), compareVideoModes);
+    qsort(modes, modeCount, sizeof(GLFWvidmode), _glfwQsortCompareVideoModes);
 
     _glfw_free(monitor->modes);
     monitor->modes = modes;
@@ -104,6 +104,7 @@ void _glfwInputMonitor(_GLFWmonitor* monitor, int action, int placement)
     {
         _glfw.monitorCount++;
         _glfw.monitors =
+            (_GLFWmonitor**)
             _glfw_realloc(_glfw.monitors,
                           sizeof(_GLFWmonitor*) * _glfw.monitorCount);
 
@@ -172,7 +173,7 @@ void _glfwInputMonitorWindow(_GLFWmonitor* monitor, _GLFWwindow* window)
 //
 _GLFWmonitor* _glfwAllocMonitor(const char* name, int widthMM, int heightMM)
 {
-    _GLFWmonitor* monitor = _glfw_calloc(1, sizeof(_GLFWmonitor));
+    _GLFWmonitor* monitor = (_GLFWmonitor*) _glfw_calloc(1, sizeof(_GLFWmonitor));
     monitor->widthMM = widthMM;
     monitor->heightMM = heightMM;
 
@@ -201,9 +202,9 @@ void _glfwFreeMonitor(_GLFWmonitor* monitor)
 //
 void _glfwAllocGammaArrays(GLFWgammaramp* ramp, unsigned int size)
 {
-    ramp->red = _glfw_calloc(size, sizeof(unsigned short));
-    ramp->green = _glfw_calloc(size, sizeof(unsigned short));
-    ramp->blue = _glfw_calloc(size, sizeof(unsigned short));
+    ramp->red = (unsigned short*) _glfw_calloc(size, sizeof(unsigned short));
+    ramp->green = (unsigned short*) _glfw_calloc(size, sizeof(unsigned short));
+    ramp->blue = (unsigned short*) _glfw_calloc(size, sizeof(unsigned short));
     ramp->size = size;
 }
 
@@ -230,7 +231,7 @@ const GLFWvidmode* _glfwChooseVideoMode(_GLFWmonitor* monitor,
     const GLFWvidmode* current;
     const GLFWvidmode* closest = NULL;
 
-    if (!refreshVideoModes(monitor))
+    if (!_glfwRefreshVideoModes(monitor))
         return NULL;
 
     for (i = 0;  i < monitor->modeCount;  i++)
@@ -274,7 +275,7 @@ const GLFWvidmode* _glfwChooseVideoMode(_GLFWmonitor* monitor,
 //
 int _glfwCompareVideoModes(const GLFWvidmode* fm, const GLFWvidmode* sm)
 {
-    return compareVideoModes(fm, sm);
+    return _glfwQsortCompareVideoModes(fm, sm);
 }
 
 // Splits a color depth into red, green and blue bit depths
@@ -438,7 +439,7 @@ GLFWAPI const GLFWvidmode* glfwGetVideoModes(GLFWmonitor* handle, int* count)
 
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
 
-    if (!refreshVideoModes(monitor))
+    if (!_glfwRefreshVideoModes(monitor))
         return NULL;
 
     *count = monitor->modeCount;
@@ -478,7 +479,7 @@ GLFWAPI void glfwSetGamma(GLFWmonitor* handle, float gamma)
     if (!original)
         return;
 
-    values = _glfw_calloc(original->size, sizeof(unsigned short));
+    values = (unsigned short*) _glfw_calloc(original->size, sizeof(unsigned short));
 
     for (i = 0;  i < original->size;  i++)
     {

--- a/src/nsgl_context.m
+++ b/src/nsgl_context.m
@@ -33,7 +33,7 @@
 #include <unistd.h>
 #include <math.h>
 
-static void makeContextCurrentNSGL(_GLFWwindow* window)
+static void _glfwMakeContextCurrentNSGL(_GLFWwindow* window)
 {
     @autoreleasepool {
 
@@ -47,7 +47,7 @@ static void makeContextCurrentNSGL(_GLFWwindow* window)
     } // autoreleasepool
 }
 
-static void swapBuffersNSGL(_GLFWwindow* window)
+static void _glfwSwapBuffersNSGL(_GLFWwindow* window)
 {
     @autoreleasepool {
 
@@ -78,11 +78,11 @@ static void swapBuffersNSGL(_GLFWwindow* window)
     } // autoreleasepool
 }
 
-static void swapIntervalNSGL(int interval)
+static void _glfwSwapIntervalNSGL(int interval)
 {
     @autoreleasepool {
 
-    _GLFWwindow* window = _glfwPlatformGetTls(&_glfw.contextSlot);
+    _GLFWwindow* window = (_GLFWwindow*) _glfwPlatformGetTls(&_glfw.contextSlot);
     assert(window != NULL);
 
     [window->context.nsgl.object setValues:&interval
@@ -91,19 +91,19 @@ static void swapIntervalNSGL(int interval)
     } // autoreleasepool
 }
 
-static int extensionSupportedNSGL(const char* extension)
+static int _glfwExtensionSupportedNSGL(const char* extension)
 {
     // There are no NSGL extensions
     return GLFW_FALSE;
 }
 
-static GLFWglproc getProcAddressNSGL(const char* procname)
+static GLFWglproc _glfwGetProcAddressNSGL(const char* procname)
 {
     CFStringRef symbolName = CFStringCreateWithCString(kCFAllocatorDefault,
                                                        procname,
                                                        kCFStringEncodingASCII);
 
-    GLFWglproc symbol = CFBundleGetFunctionPointerForName(_glfw.nsgl.framework,
+    GLFWglproc symbol = (GLFWglproc) CFBundleGetFunctionPointerForName(_glfw.nsgl.framework,
                                                           symbolName);
 
     CFRelease(symbolName);
@@ -111,7 +111,7 @@ static GLFWglproc getProcAddressNSGL(const char* procname)
     return symbol;
 }
 
-static void destroyContextNSGL(_GLFWwindow* window)
+static void _glfwDestroyContextNSGL(_GLFWwindow* window)
 {
     @autoreleasepool {
 
@@ -339,12 +339,12 @@ GLFWbool _glfwCreateContextNSGL(_GLFWwindow* window,
 
     [window->context.nsgl.object setView:window->ns.view];
 
-    window->context.makeCurrent = makeContextCurrentNSGL;
-    window->context.swapBuffers = swapBuffersNSGL;
-    window->context.swapInterval = swapIntervalNSGL;
-    window->context.extensionSupported = extensionSupportedNSGL;
-    window->context.getProcAddress = getProcAddressNSGL;
-    window->context.destroy = destroyContextNSGL;
+    window->context.makeCurrent = _glfwMakeContextCurrentNSGL;
+    window->context.swapBuffers = _glfwSwapBuffersNSGL;
+    window->context.swapInterval = _glfwSwapIntervalNSGL;
+    window->context.extensionSupported = _glfwExtensionSupportedNSGL;
+    window->context.getProcAddress = _glfwGetProcAddressNSGL;
+    window->context.destroy = _glfwDestroyContextNSGL;
 
     return GLFW_TRUE;
 }

--- a/src/null_monitor.c
+++ b/src/null_monitor.c
@@ -35,7 +35,7 @@
 
 // The the sole (fake) video mode of our (sole) fake monitor
 //
-static GLFWvidmode getVideoMode(void)
+static GLFWvidmode _glfwGetDefaultVideoModeNull(void)
 {
     GLFWvidmode mode;
     mode.width = 1920;
@@ -54,7 +54,7 @@ static GLFWvidmode getVideoMode(void)
 void _glfwPollMonitorsNull(void)
 {
     const float dpi = 141.f;
-    const GLFWvidmode mode = getVideoMode();
+    const GLFWvidmode mode = _glfwGetDefaultVideoModeNull();
     _GLFWmonitor* monitor = _glfwAllocMonitor("Null SuperNoop 0",
                                               (int) (mode.width * 25.4f / dpi),
                                               (int) (mode.height * 25.4f / dpi));
@@ -91,7 +91,7 @@ void _glfwGetMonitorWorkareaNull(_GLFWmonitor* monitor,
                                  int* xpos, int* ypos,
                                  int* width, int* height)
 {
-    const GLFWvidmode mode = getVideoMode();
+    const GLFWvidmode mode = _glfwGetDefaultVideoModeNull();
 
     if (xpos)
         *xpos = 0;
@@ -105,15 +105,15 @@ void _glfwGetMonitorWorkareaNull(_GLFWmonitor* monitor,
 
 GLFWvidmode* _glfwGetVideoModesNull(_GLFWmonitor* monitor, int* found)
 {
-    GLFWvidmode* mode = _glfw_calloc(1, sizeof(GLFWvidmode));
-    *mode = getVideoMode();
+    GLFWvidmode* mode = (GLFWvidmode*) _glfw_calloc(1, sizeof(GLFWvidmode));
+    *mode = _glfwGetDefaultVideoModeNull();
     *found = 1;
     return mode;
 }
 
 void _glfwGetVideoModeNull(_GLFWmonitor* monitor, GLFWvidmode* mode)
 {
-    *mode = getVideoMode();
+    *mode = _glfwGetDefaultVideoModeNull();
 }
 
 GLFWbool _glfwGetGammaRampNull(_GLFWmonitor* monitor, GLFWgammaramp* ramp)

--- a/src/null_window.c
+++ b/src/null_window.c
@@ -31,7 +31,7 @@
 
 #include <stdlib.h>
 
-static void applySizeLimits(_GLFWwindow* window, int* width, int* height)
+static void _glfwApplySizeLimitsNull(_GLFWwindow* window, int* width, int* height)
 {
     if (window->numer != GLFW_DONT_CARE && window->denom != GLFW_DONT_CARE)
     {
@@ -50,7 +50,7 @@ static void applySizeLimits(_GLFWwindow* window, int* width, int* height)
         *height = _glfw_max(*height, window->maxheight);
 }
 
-static void fitToMonitor(_GLFWwindow* window)
+static void _glfwFitToMonitorNull(_GLFWwindow* window)
 {
     GLFWvidmode mode;
     _glfwGetVideoModeNull(window->monitor, &mode);
@@ -61,12 +61,12 @@ static void fitToMonitor(_GLFWwindow* window)
     window->null.height = mode.height;
 }
 
-static void acquireMonitor(_GLFWwindow* window)
+static void _glfwAcquireMonitorNull(_GLFWwindow* window)
 {
     _glfwInputMonitorWindow(window->monitor, window);
 }
 
-static void releaseMonitor(_GLFWwindow* window)
+static void _glfwReleaseMonitorNull(_GLFWwindow* window)
 {
     if (window->monitor->window != window)
         return;
@@ -74,12 +74,12 @@ static void releaseMonitor(_GLFWwindow* window)
     _glfwInputMonitorWindow(window->monitor, NULL);
 }
 
-static int createNativeWindow(_GLFWwindow* window,
-                              const _GLFWwndconfig* wndconfig,
-                              const _GLFWfbconfig* fbconfig)
+static int _glfwCreateNativeWindowNull(_GLFWwindow* window,
+                                       const _GLFWwndconfig* wndconfig,
+                                       const _GLFWfbconfig* fbconfig)
 {
     if (window->monitor)
-        fitToMonitor(window);
+        _glfwFitToMonitorNull(window);
     else
     {
         if (wndconfig->xpos == GLFW_ANY_POSITION && wndconfig->ypos == GLFW_ANY_POSITION)
@@ -117,7 +117,7 @@ GLFWbool _glfwCreateWindowNull(_GLFWwindow* window,
                                const _GLFWctxconfig* ctxconfig,
                                const _GLFWfbconfig* fbconfig)
 {
-    if (!createNativeWindow(window, wndconfig, fbconfig))
+    if (!_glfwCreateNativeWindowNull(window, wndconfig, fbconfig))
         return GLFW_FALSE;
 
     if (ctxconfig->client != GLFW_NO_API)
@@ -149,7 +149,7 @@ GLFWbool _glfwCreateWindowNull(_GLFWwindow* window,
     {
         _glfwShowWindowNull(window);
         _glfwFocusWindowNull(window);
-        acquireMonitor(window);
+        _glfwAcquireMonitorNull(window);
 
         if (wndconfig->centerCursor)
             _glfwCenterCursorInContentArea(window);
@@ -170,7 +170,7 @@ GLFWbool _glfwCreateWindowNull(_GLFWwindow* window,
 void _glfwDestroyWindowNull(_GLFWwindow* window)
 {
     if (window->monitor)
-        releaseMonitor(window);
+        _glfwReleaseMonitorNull(window);
 
     if (_glfw.null.focusedWindow == window)
         _glfw.null.focusedWindow = NULL;
@@ -205,15 +205,15 @@ void _glfwSetWindowMonitorNull(_GLFWwindow* window,
     }
 
     if (window->monitor)
-        releaseMonitor(window);
+        _glfwReleaseMonitorNull(window);
 
     _glfwInputWindowMonitor(window, monitor);
 
     if (window->monitor)
     {
         window->null.visible = GLFW_TRUE;
-        acquireMonitor(window);
-        fitToMonitor(window);
+        _glfwAcquireMonitorNull(window);
+        _glfwFitToMonitorNull(window);
     }
     else
     {
@@ -271,7 +271,7 @@ void _glfwSetWindowSizeLimitsNull(_GLFWwindow* window,
 {
     int width = window->null.width;
     int height = window->null.height;
-    applySizeLimits(window, &width, &height);
+    _glfwApplySizeLimitsNull(window, &width, &height);
     _glfwSetWindowSizeNull(window, width, height);
 }
 
@@ -279,7 +279,7 @@ void _glfwSetWindowAspectRatioNull(_GLFWwindow* window, int n, int d)
 {
     int width = window->null.width;
     int height = window->null.height;
-    applySizeLimits(window, &width, &height);
+    _glfwApplySizeLimitsNull(window, &width, &height);
     _glfwSetWindowSizeNull(window, width, height);
 }
 
@@ -341,7 +341,7 @@ void _glfwIconifyWindowNull(_GLFWwindow* window)
         _glfwInputWindowIconify(window, GLFW_TRUE);
 
         if (window->monitor)
-            releaseMonitor(window);
+            _glfwReleaseMonitorNull(window);
     }
 }
 
@@ -353,7 +353,7 @@ void _glfwRestoreWindowNull(_GLFWwindow* window)
         _glfwInputWindowIconify(window, GLFW_FALSE);
 
         if (window->monitor)
-            acquireMonitor(window);
+            _glfwAcquireMonitorNull(window);
     }
     else if (window->null.maximized)
     {

--- a/src/osmesa_context.c
+++ b/src/osmesa_context.c
@@ -34,7 +34,7 @@
 #include "internal.h"
 
 
-static void makeContextCurrentOSMesa(_GLFWwindow* window)
+static void _glfwMakeContextCurrentOSMesa(_GLFWwindow* window)
 {
     if (window)
     {
@@ -68,12 +68,12 @@ static void makeContextCurrentOSMesa(_GLFWwindow* window)
     _glfwPlatformSetTls(&_glfw.contextSlot, window);
 }
 
-static GLFWglproc getProcAddressOSMesa(const char* procname)
+static GLFWglproc _glfwGetProcAddressOSMesa(const char* procname)
 {
     return (GLFWglproc) OSMesaGetProcAddress(procname);
 }
 
-static void destroyContextOSMesa(_GLFWwindow* window)
+static void _glfwDestroyContextOSMesa(_GLFWwindow* window)
 {
     if (window->context.osmesa.handle)
     {
@@ -89,17 +89,17 @@ static void destroyContextOSMesa(_GLFWwindow* window)
     }
 }
 
-static void swapBuffersOSMesa(_GLFWwindow* window)
+static void _glfwSwapBuffersOSMesa(_GLFWwindow* window)
 {
     // No double buffering on OSMesa
 }
 
-static void swapIntervalOSMesa(int interval)
+static void _glfwSwapIntervalOSMesa(int interval)
 {
     // No swap interval on OSMesa
 }
 
-static int extensionSupportedOSMesa(const char* extension)
+static int _glfwExtensionSupportedOSMesa(const char* extension)
 {
     // OSMesa does not have extensions
     return GLFW_FALSE;
@@ -277,12 +277,12 @@ GLFWbool _glfwCreateContextOSMesa(_GLFWwindow* window,
         return GLFW_FALSE;
     }
 
-    window->context.makeCurrent = makeContextCurrentOSMesa;
-    window->context.swapBuffers = swapBuffersOSMesa;
-    window->context.swapInterval = swapIntervalOSMesa;
-    window->context.extensionSupported = extensionSupportedOSMesa;
-    window->context.getProcAddress = getProcAddressOSMesa;
-    window->context.destroy = destroyContextOSMesa;
+    window->context.makeCurrent = _glfwMakeContextCurrentOSMesa;
+    window->context.swapBuffers = _glfwSwapBuffersOSMesa;
+    window->context.swapInterval = _glfwSwapIntervalOSMesa;
+    window->context.extensionSupported = _glfwExtensionSupportedOSMesa;
+    window->context.getProcAddress = _glfwGetProcAddressOSMesa;
+    window->context.destroy = _glfwDestroyContextOSMesa;
 
     return GLFW_TRUE;
 }

--- a/src/posix_module.c
+++ b/src/posix_module.c
@@ -48,7 +48,7 @@ void _glfwPlatformFreeModule(void* module)
 
 GLFWproc _glfwPlatformGetModuleSymbol(void* module, const char* name)
 {
-    return dlsym(module, name);
+    return (GLFWproc) dlsym(module, name);
 }
 
 #endif // GLFW_BUILD_POSIX_MODULE

--- a/src/vulkan.c
+++ b/src/vulkan.c
@@ -114,7 +114,7 @@ GLFWbool _glfwInitVulkan(int mode)
         return GLFW_FALSE;
     }
 
-    ep = _glfw_calloc(count, sizeof(VkExtensionProperties));
+    ep = (VkExtensionProperties*) _glfw_calloc(count, sizeof(VkExtensionProperties));
 
     err = vkEnumerateInstanceExtensionProperties(NULL, &count, ep);
     if (err)

--- a/src/wgl_context.c
+++ b/src/wgl_context.c
@@ -36,10 +36,10 @@
 
 // Return the value corresponding to the specified attribute
 //
-static int findPixelFormatAttribValueWGL(const int* attribs,
-                                         int attribCount,
-                                         const int* values,
-                                         int attrib)
+static int _glfwFindPixelFormatAttribValueWGL(const int* attribs,
+                                              int attribCount,
+                                              const int* values,
+                                              int attrib)
 {
     int i;
 
@@ -54,17 +54,17 @@ static int findPixelFormatAttribValueWGL(const int* attribs,
     return 0;
 }
 
-#define ADD_ATTRIB(a) \
+#define _GLFW_ADD_ATTRIB(a) \
 { \
     assert((size_t) attribCount < sizeof(attribs) / sizeof(attribs[0])); \
     attribs[attribCount++] = a; \
 }
-#define FIND_ATTRIB_VALUE(a) \
-    findPixelFormatAttribValueWGL(attribs, attribCount, values, a)
+#define _GLFW_FIND_ATTRIB_VALUE(a) \
+    _glfwFindPixelFormatAttribValueWGL(attribs, attribCount, values, a)
 
 // Return a list of available and usable framebuffer configs
 //
-static int choosePixelFormatWGL(_GLFWwindow* window,
+static int _glfwChoosePixelFormatWGL(_GLFWwindow* window,
                                 const _GLFWctxconfig* ctxconfig,
                                 const _GLFWfbconfig* fbconfig)
 {
@@ -81,45 +81,45 @@ static int choosePixelFormatWGL(_GLFWwindow* window,
 
     if (_glfw.wgl.ARB_pixel_format)
     {
-        ADD_ATTRIB(WGL_SUPPORT_OPENGL_ARB);
-        ADD_ATTRIB(WGL_DRAW_TO_WINDOW_ARB);
-        ADD_ATTRIB(WGL_PIXEL_TYPE_ARB);
-        ADD_ATTRIB(WGL_ACCELERATION_ARB);
-        ADD_ATTRIB(WGL_RED_BITS_ARB);
-        ADD_ATTRIB(WGL_RED_SHIFT_ARB);
-        ADD_ATTRIB(WGL_GREEN_BITS_ARB);
-        ADD_ATTRIB(WGL_GREEN_SHIFT_ARB);
-        ADD_ATTRIB(WGL_BLUE_BITS_ARB);
-        ADD_ATTRIB(WGL_BLUE_SHIFT_ARB);
-        ADD_ATTRIB(WGL_ALPHA_BITS_ARB);
-        ADD_ATTRIB(WGL_ALPHA_SHIFT_ARB);
-        ADD_ATTRIB(WGL_DEPTH_BITS_ARB);
-        ADD_ATTRIB(WGL_STENCIL_BITS_ARB);
-        ADD_ATTRIB(WGL_ACCUM_BITS_ARB);
-        ADD_ATTRIB(WGL_ACCUM_RED_BITS_ARB);
-        ADD_ATTRIB(WGL_ACCUM_GREEN_BITS_ARB);
-        ADD_ATTRIB(WGL_ACCUM_BLUE_BITS_ARB);
-        ADD_ATTRIB(WGL_ACCUM_ALPHA_BITS_ARB);
-        ADD_ATTRIB(WGL_AUX_BUFFERS_ARB);
-        ADD_ATTRIB(WGL_STEREO_ARB);
-        ADD_ATTRIB(WGL_DOUBLE_BUFFER_ARB);
+        _GLFW_ADD_ATTRIB(WGL_SUPPORT_OPENGL_ARB);
+        _GLFW_ADD_ATTRIB(WGL_DRAW_TO_WINDOW_ARB);
+        _GLFW_ADD_ATTRIB(WGL_PIXEL_TYPE_ARB);
+        _GLFW_ADD_ATTRIB(WGL_ACCELERATION_ARB);
+        _GLFW_ADD_ATTRIB(WGL_RED_BITS_ARB);
+        _GLFW_ADD_ATTRIB(WGL_RED_SHIFT_ARB);
+        _GLFW_ADD_ATTRIB(WGL_GREEN_BITS_ARB);
+        _GLFW_ADD_ATTRIB(WGL_GREEN_SHIFT_ARB);
+        _GLFW_ADD_ATTRIB(WGL_BLUE_BITS_ARB);
+        _GLFW_ADD_ATTRIB(WGL_BLUE_SHIFT_ARB);
+        _GLFW_ADD_ATTRIB(WGL_ALPHA_BITS_ARB);
+        _GLFW_ADD_ATTRIB(WGL_ALPHA_SHIFT_ARB);
+        _GLFW_ADD_ATTRIB(WGL_DEPTH_BITS_ARB);
+        _GLFW_ADD_ATTRIB(WGL_STENCIL_BITS_ARB);
+        _GLFW_ADD_ATTRIB(WGL_ACCUM_BITS_ARB);
+        _GLFW_ADD_ATTRIB(WGL_ACCUM_RED_BITS_ARB);
+        _GLFW_ADD_ATTRIB(WGL_ACCUM_GREEN_BITS_ARB);
+        _GLFW_ADD_ATTRIB(WGL_ACCUM_BLUE_BITS_ARB);
+        _GLFW_ADD_ATTRIB(WGL_ACCUM_ALPHA_BITS_ARB);
+        _GLFW_ADD_ATTRIB(WGL_AUX_BUFFERS_ARB);
+        _GLFW_ADD_ATTRIB(WGL_STEREO_ARB);
+        _GLFW_ADD_ATTRIB(WGL_DOUBLE_BUFFER_ARB);
 
         if (_glfw.wgl.ARB_multisample)
-            ADD_ATTRIB(WGL_SAMPLES_ARB);
+            _GLFW_ADD_ATTRIB(WGL_SAMPLES_ARB);
 
         if (ctxconfig->client == GLFW_OPENGL_API)
         {
             if (_glfw.wgl.ARB_framebuffer_sRGB || _glfw.wgl.EXT_framebuffer_sRGB)
-                ADD_ATTRIB(WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB);
+                _GLFW_ADD_ATTRIB(WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB);
         }
         else
         {
             if (_glfw.wgl.EXT_colorspace)
-                ADD_ATTRIB(WGL_COLORSPACE_EXT);
+                _GLFW_ADD_ATTRIB(WGL_COLORSPACE_EXT);
         }
     }
 
-    usableConfigs = _glfw_calloc(nativeCount, sizeof(_GLFWfbconfig));
+    usableConfigs = (_GLFWfbconfig*) _glfw_calloc(nativeCount, sizeof(_GLFWfbconfig));
 
     for (i = 0;  i < nativeCount;  i++)
     {
@@ -142,48 +142,48 @@ static int choosePixelFormatWGL(_GLFWwindow* window,
                 return 0;
             }
 
-            if (!FIND_ATTRIB_VALUE(WGL_SUPPORT_OPENGL_ARB) ||
-                !FIND_ATTRIB_VALUE(WGL_DRAW_TO_WINDOW_ARB))
+            if (!_GLFW_FIND_ATTRIB_VALUE(WGL_SUPPORT_OPENGL_ARB) ||
+                !_GLFW_FIND_ATTRIB_VALUE(WGL_DRAW_TO_WINDOW_ARB))
             {
                 continue;
             }
 
-            if (FIND_ATTRIB_VALUE(WGL_PIXEL_TYPE_ARB) != WGL_TYPE_RGBA_ARB)
+            if (_GLFW_FIND_ATTRIB_VALUE(WGL_PIXEL_TYPE_ARB) != WGL_TYPE_RGBA_ARB)
                 continue;
 
-            if (FIND_ATTRIB_VALUE(WGL_ACCELERATION_ARB) == WGL_NO_ACCELERATION_ARB)
+            if (_GLFW_FIND_ATTRIB_VALUE(WGL_ACCELERATION_ARB) == WGL_NO_ACCELERATION_ARB)
                 continue;
 
-            if (FIND_ATTRIB_VALUE(WGL_DOUBLE_BUFFER_ARB) != fbconfig->doublebuffer)
+            if (_GLFW_FIND_ATTRIB_VALUE(WGL_DOUBLE_BUFFER_ARB) != fbconfig->doublebuffer)
                 continue;
 
-            u->redBits = FIND_ATTRIB_VALUE(WGL_RED_BITS_ARB);
-            u->greenBits = FIND_ATTRIB_VALUE(WGL_GREEN_BITS_ARB);
-            u->blueBits = FIND_ATTRIB_VALUE(WGL_BLUE_BITS_ARB);
-            u->alphaBits = FIND_ATTRIB_VALUE(WGL_ALPHA_BITS_ARB);
+            u->redBits = _GLFW_FIND_ATTRIB_VALUE(WGL_RED_BITS_ARB);
+            u->greenBits = _GLFW_FIND_ATTRIB_VALUE(WGL_GREEN_BITS_ARB);
+            u->blueBits = _GLFW_FIND_ATTRIB_VALUE(WGL_BLUE_BITS_ARB);
+            u->alphaBits = _GLFW_FIND_ATTRIB_VALUE(WGL_ALPHA_BITS_ARB);
 
-            u->depthBits = FIND_ATTRIB_VALUE(WGL_DEPTH_BITS_ARB);
-            u->stencilBits = FIND_ATTRIB_VALUE(WGL_STENCIL_BITS_ARB);
+            u->depthBits = _GLFW_FIND_ATTRIB_VALUE(WGL_DEPTH_BITS_ARB);
+            u->stencilBits = _GLFW_FIND_ATTRIB_VALUE(WGL_STENCIL_BITS_ARB);
 
-            u->accumRedBits = FIND_ATTRIB_VALUE(WGL_ACCUM_RED_BITS_ARB);
-            u->accumGreenBits = FIND_ATTRIB_VALUE(WGL_ACCUM_GREEN_BITS_ARB);
-            u->accumBlueBits = FIND_ATTRIB_VALUE(WGL_ACCUM_BLUE_BITS_ARB);
-            u->accumAlphaBits = FIND_ATTRIB_VALUE(WGL_ACCUM_ALPHA_BITS_ARB);
+            u->accumRedBits = _GLFW_FIND_ATTRIB_VALUE(WGL_ACCUM_RED_BITS_ARB);
+            u->accumGreenBits = _GLFW_FIND_ATTRIB_VALUE(WGL_ACCUM_GREEN_BITS_ARB);
+            u->accumBlueBits = _GLFW_FIND_ATTRIB_VALUE(WGL_ACCUM_BLUE_BITS_ARB);
+            u->accumAlphaBits = _GLFW_FIND_ATTRIB_VALUE(WGL_ACCUM_ALPHA_BITS_ARB);
 
-            u->auxBuffers = FIND_ATTRIB_VALUE(WGL_AUX_BUFFERS_ARB);
+            u->auxBuffers = _GLFW_FIND_ATTRIB_VALUE(WGL_AUX_BUFFERS_ARB);
 
-            if (FIND_ATTRIB_VALUE(WGL_STEREO_ARB))
+            if (_GLFW_FIND_ATTRIB_VALUE(WGL_STEREO_ARB))
                 u->stereo = GLFW_TRUE;
 
             if (_glfw.wgl.ARB_multisample)
-                u->samples = FIND_ATTRIB_VALUE(WGL_SAMPLES_ARB);
+                u->samples = _GLFW_FIND_ATTRIB_VALUE(WGL_SAMPLES_ARB);
 
             if (ctxconfig->client == GLFW_OPENGL_API)
             {
                 if (_glfw.wgl.ARB_framebuffer_sRGB ||
                     _glfw.wgl.EXT_framebuffer_sRGB)
                 {
-                    if (FIND_ATTRIB_VALUE(WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB))
+                    if (_GLFW_FIND_ATTRIB_VALUE(WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB))
                         u->sRGB = GLFW_TRUE;
                 }
             }
@@ -191,7 +191,7 @@ static int choosePixelFormatWGL(_GLFWwindow* window,
             {
                 if (_glfw.wgl.EXT_colorspace)
                 {
-                    if (FIND_ATTRIB_VALUE(WGL_COLORSPACE_EXT) == WGL_COLORSPACE_SRGB_EXT)
+                    if (_GLFW_FIND_ATTRIB_VALUE(WGL_COLORSPACE_EXT) == WGL_COLORSPACE_SRGB_EXT)
                         u->sRGB = GLFW_TRUE;
                 }
             }
@@ -280,10 +280,10 @@ static int choosePixelFormatWGL(_GLFWwindow* window,
     return pixelFormat;
 }
 
-#undef ADD_ATTRIB
-#undef FIND_ATTRIB_VALUE
+#undef _GLFW_ADD_ATTRIB
+#undef _GLFW_FIND_ATTRIB_VALUE
 
-static void makeContextCurrentWGL(_GLFWwindow* window)
+static void _glfwMakeContextCurrentWGL(_GLFWwindow* window)
 {
     if (window)
     {
@@ -308,7 +308,7 @@ static void makeContextCurrentWGL(_GLFWwindow* window)
     }
 }
 
-static void swapBuffersWGL(_GLFWwindow* window)
+static void _glfwSwapBuffersWGL(_GLFWwindow* window)
 {
     if (!window->monitor)
     {
@@ -329,9 +329,9 @@ static void swapBuffersWGL(_GLFWwindow* window)
     SwapBuffers(window->context.wgl.dc);
 }
 
-static void swapIntervalWGL(int interval)
+static void _glfwSwapIntervalWGL(int interval)
 {
-    _GLFWwindow* window = _glfwPlatformGetTls(&_glfw.contextSlot);
+    _GLFWwindow* window = (_GLFWwindow*) _glfwPlatformGetTls(&_glfw.contextSlot);
     assert(window != NULL);
 
     window->context.wgl.interval = interval;
@@ -353,7 +353,7 @@ static void swapIntervalWGL(int interval)
         wglSwapIntervalEXT(interval);
 }
 
-static int extensionSupportedWGL(const char* extension)
+static int _glfwExtensionSupportedWGL(const char* extension)
 {
     const char* extensions = NULL;
 
@@ -368,7 +368,7 @@ static int extensionSupportedWGL(const char* extension)
     return _glfwStringInExtensionString(extension, extensions);
 }
 
-static GLFWglproc getProcAddressWGL(const char* procname)
+static GLFWglproc _glfwGetProcAddressWGL(const char* procname)
 {
     const GLFWglproc proc = (GLFWglproc) wglGetProcAddress(procname);
     if (proc)
@@ -377,7 +377,7 @@ static GLFWglproc getProcAddressWGL(const char* procname)
     return (GLFWglproc) _glfwPlatformGetModuleSymbol(_glfw.wgl.instance, procname);
 }
 
-static void destroyContextWGL(_GLFWwindow* window)
+static void _glfwDestroyContextWGL(_GLFWwindow* window)
 {
     if (window->context.wgl.handle)
     {
@@ -397,7 +397,7 @@ GLFWbool _glfwInitWGL(void)
     if (_glfw.wgl.instance)
         return GLFW_TRUE;
 
-    _glfw.wgl.instance = _glfwPlatformLoadModule("opengl32.dll");
+    _glfw.wgl.instance = (HINSTANCE) _glfwPlatformLoadModule("opengl32.dll");
     if (!_glfw.wgl.instance)
     {
         _glfwInputErrorWin32(GLFW_PLATFORM_ERROR,
@@ -477,29 +477,29 @@ GLFWbool _glfwInitWGL(void)
     // NOTE: WGL_ARB_extensions_string and WGL_EXT_extensions_string are not
     //       checked below as we are already using them
     _glfw.wgl.ARB_multisample =
-        extensionSupportedWGL("WGL_ARB_multisample");
+        _glfwExtensionSupportedWGL("WGL_ARB_multisample");
     _glfw.wgl.ARB_framebuffer_sRGB =
-        extensionSupportedWGL("WGL_ARB_framebuffer_sRGB");
+        _glfwExtensionSupportedWGL("WGL_ARB_framebuffer_sRGB");
     _glfw.wgl.EXT_framebuffer_sRGB =
-        extensionSupportedWGL("WGL_EXT_framebuffer_sRGB");
+        _glfwExtensionSupportedWGL("WGL_EXT_framebuffer_sRGB");
     _glfw.wgl.ARB_create_context =
-        extensionSupportedWGL("WGL_ARB_create_context");
+        _glfwExtensionSupportedWGL("WGL_ARB_create_context");
     _glfw.wgl.ARB_create_context_profile =
-        extensionSupportedWGL("WGL_ARB_create_context_profile");
+        _glfwExtensionSupportedWGL("WGL_ARB_create_context_profile");
     _glfw.wgl.EXT_create_context_es2_profile =
-        extensionSupportedWGL("WGL_EXT_create_context_es2_profile");
+        _glfwExtensionSupportedWGL("WGL_EXT_create_context_es2_profile");
     _glfw.wgl.ARB_create_context_robustness =
-        extensionSupportedWGL("WGL_ARB_create_context_robustness");
+        _glfwExtensionSupportedWGL("WGL_ARB_create_context_robustness");
     _glfw.wgl.ARB_create_context_no_error =
-        extensionSupportedWGL("WGL_ARB_create_context_no_error");
+        _glfwExtensionSupportedWGL("WGL_ARB_create_context_no_error");
     _glfw.wgl.EXT_swap_control =
-        extensionSupportedWGL("WGL_EXT_swap_control");
+        _glfwExtensionSupportedWGL("WGL_EXT_swap_control");
     _glfw.wgl.EXT_colorspace =
-        extensionSupportedWGL("WGL_EXT_colorspace");
+        _glfwExtensionSupportedWGL("WGL_EXT_colorspace");
     _glfw.wgl.ARB_pixel_format =
-        extensionSupportedWGL("WGL_ARB_pixel_format");
+        _glfwExtensionSupportedWGL("WGL_ARB_pixel_format");
     _glfw.wgl.ARB_context_flush_control =
-        extensionSupportedWGL("WGL_ARB_context_flush_control");
+        _glfwExtensionSupportedWGL("WGL_ARB_context_flush_control");
 
     wglMakeCurrent(pdc, prc);
     wglDeleteContext(rc);
@@ -543,7 +543,7 @@ GLFWbool _glfwCreateContextWGL(_GLFWwindow* window,
         return GLFW_FALSE;
     }
 
-    pixelFormat = choosePixelFormatWGL(window, ctxconfig, fbconfig);
+    pixelFormat = _glfwChoosePixelFormatWGL(window, ctxconfig, fbconfig);
     if (!pixelFormat)
         return GLFW_FALSE;
 
@@ -746,12 +746,12 @@ GLFWbool _glfwCreateContextWGL(_GLFWwindow* window,
         }
     }
 
-    window->context.makeCurrent = makeContextCurrentWGL;
-    window->context.swapBuffers = swapBuffersWGL;
-    window->context.swapInterval = swapIntervalWGL;
-    window->context.extensionSupported = extensionSupportedWGL;
-    window->context.getProcAddress = getProcAddressWGL;
-    window->context.destroy = destroyContextWGL;
+    window->context.makeCurrent = _glfwMakeContextCurrentWGL;
+    window->context.swapBuffers = _glfwSwapBuffersWGL;
+    window->context.swapInterval = _glfwSwapIntervalWGL;
+    window->context.extensionSupported = _glfwExtensionSupportedWGL;
+    window->context.getProcAddress = _glfwGetProcAddressWGL;
+    window->context.destroy = _glfwDestroyContextWGL;
 
     return GLFW_TRUE;
 }

--- a/src/win32_init.c
+++ b/src/win32_init.c
@@ -36,7 +36,7 @@
 static const GUID _glfw_GUID_DEVINTERFACE_HID =
     {0x4d1e55b2,0xf16f,0x11cf,{0x88,0xcb,0x00,0x11,0x11,0x00,0x00,0x30}};
 
-#define GUID_DEVINTERFACE_HID _glfw_GUID_DEVINTERFACE_HID
+#define _GLFW_GUID_DEVINTERFACE_HID _glfw_GUID_DEVINTERFACE_HID
 
 #if defined(_GLFW_USE_HYBRID_HPG) || defined(_GLFW_USE_OPTIMUS_HPG)
 
@@ -71,7 +71,7 @@ BOOL WINAPI DllMain(HINSTANCE instance, DWORD reason, LPVOID reserved)
 
 // Load necessary libraries (DLLs)
 //
-static GLFWbool loadLibraries(void)
+static GLFWbool _glfwLoadLibrariesWin32(void)
 {
     if (!GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
                                 GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
@@ -83,7 +83,7 @@ static GLFWbool loadLibraries(void)
         return GLFW_FALSE;
     }
 
-    _glfw.win32.user32.instance = _glfwPlatformLoadModule("user32.dll");
+    _glfw.win32.user32.instance = (HINSTANCE) _glfwPlatformLoadModule("user32.dll");
     if (!_glfw.win32.user32.instance)
     {
         _glfwInputErrorWin32(GLFW_PLATFORM_ERROR,
@@ -106,7 +106,7 @@ static GLFWbool loadLibraries(void)
     _glfw.win32.user32.GetSystemMetricsForDpi_ = (PFN_GetSystemMetricsForDpi)
         _glfwPlatformGetModuleSymbol(_glfw.win32.user32.instance, "GetSystemMetricsForDpi");
 
-    _glfw.win32.dinput8.instance = _glfwPlatformLoadModule("dinput8.dll");
+    _glfw.win32.dinput8.instance = (HINSTANCE) _glfwPlatformLoadModule("dinput8.dll");
     if (_glfw.win32.dinput8.instance)
     {
         _glfw.win32.dinput8.Create = (PFN_DirectInput8Create)
@@ -127,7 +127,7 @@ static GLFWbool loadLibraries(void)
 
         for (i = 0;  names[i];  i++)
         {
-            _glfw.win32.xinput.instance = _glfwPlatformLoadModule(names[i]);
+            _glfw.win32.xinput.instance = (HINSTANCE) _glfwPlatformLoadModule(names[i]);
             if (_glfw.win32.xinput.instance)
             {
                 _glfw.win32.xinput.GetCapabilities = (PFN_XInputGetCapabilities)
@@ -140,7 +140,7 @@ static GLFWbool loadLibraries(void)
         }
     }
 
-    _glfw.win32.dwmapi.instance = _glfwPlatformLoadModule("dwmapi.dll");
+    _glfw.win32.dwmapi.instance = (HINSTANCE) _glfwPlatformLoadModule("dwmapi.dll");
     if (_glfw.win32.dwmapi.instance)
     {
         _glfw.win32.dwmapi.IsCompositionEnabled = (PFN_DwmIsCompositionEnabled)
@@ -153,7 +153,7 @@ static GLFWbool loadLibraries(void)
             _glfwPlatformGetModuleSymbol(_glfw.win32.dwmapi.instance, "DwmGetColorizationColor");
     }
 
-    _glfw.win32.shcore.instance = _glfwPlatformLoadModule("shcore.dll");
+    _glfw.win32.shcore.instance = (HINSTANCE) _glfwPlatformLoadModule("shcore.dll");
     if (_glfw.win32.shcore.instance)
     {
         _glfw.win32.shcore.SetProcessDpiAwareness_ = (PFN_SetProcessDpiAwareness)
@@ -162,7 +162,7 @@ static GLFWbool loadLibraries(void)
             _glfwPlatformGetModuleSymbol(_glfw.win32.shcore.instance, "GetDpiForMonitor");
     }
 
-    _glfw.win32.ntdll.instance = _glfwPlatformLoadModule("ntdll.dll");
+    _glfw.win32.ntdll.instance = (HINSTANCE) _glfwPlatformLoadModule("ntdll.dll");
     if (_glfw.win32.ntdll.instance)
     {
         _glfw.win32.ntdll.RtlVerifyVersionInfo_ = (PFN_RtlVerifyVersionInfo)
@@ -174,7 +174,7 @@ static GLFWbool loadLibraries(void)
 
 // Unload used libraries (DLLs)
 //
-static void freeLibraries(void)
+static void _glfwFreeLibrariesWin32(void)
 {
     if (_glfw.win32.xinput.instance)
         _glfwPlatformFreeModule(_glfw.win32.xinput.instance);
@@ -197,7 +197,7 @@ static void freeLibraries(void)
 
 // Create key code translation tables
 //
-static void createKeyTables(void)
+static void _glfwCreateKeyTablesWin32(void)
 {
     int scancode;
 
@@ -335,7 +335,7 @@ static void createKeyTables(void)
 
 // Window procedure for the hidden helper window
 //
-static LRESULT CALLBACK helperWindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+static LRESULT CALLBACK _glfwHelperWindowProcWin32(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     switch (uMsg)
     {
@@ -370,13 +370,13 @@ static LRESULT CALLBACK helperWindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LP
 
 // Creates a dummy window for behind-the-scenes work
 //
-static GLFWbool createHelperWindow(void)
+static GLFWbool _glfwCreateHelperWindowWin32(void)
 {
     MSG msg;
     WNDCLASSEXW wc = { sizeof(wc) };
 
     wc.style         = CS_OWNDC;
-    wc.lpfnWndProc   = (WNDPROC) helperWindowProc;
+    wc.lpfnWndProc   = (WNDPROC) _glfwHelperWindowProcWin32;
     wc.hInstance     = _glfw.win32.instance;
     wc.lpszClassName = L"GLFW3 Helper";
 
@@ -415,7 +415,7 @@ static GLFWbool createHelperWindow(void)
         ZeroMemory(&dbi, sizeof(dbi));
         dbi.dbcc_size = sizeof(dbi);
         dbi.dbcc_devicetype = DBT_DEVTYP_DEVICEINTERFACE;
-        dbi.dbcc_classguid = GUID_DEVINTERFACE_HID;
+        dbi.dbcc_classguid = _GLFW_GUID_DEVINTERFACE_HID;
 
         _glfw.win32.deviceNotificationHandle =
             RegisterDeviceNotificationW(_glfw.win32.helperWindowHandle,
@@ -452,7 +452,7 @@ WCHAR* _glfwCreateWideStringFromUTF8Win32(const char* source)
         return NULL;
     }
 
-    target = _glfw_calloc(count, sizeof(WCHAR));
+    target = (WCHAR*) _glfw_calloc(count, sizeof(WCHAR));
 
     if (!MultiByteToWideChar(CP_UTF8, 0, source, -1, target, count))
     {
@@ -480,7 +480,7 @@ char* _glfwCreateUTF8FromWideStringWin32(const WCHAR* source)
         return NULL;
     }
 
-    target = _glfw_calloc(size, 1);
+    target = (char*) _glfw_calloc(size, 1);
 
     if (!WideCharToMultiByte(CP_UTF8, 0, source, -1, target, size, NULL, NULL))
     {
@@ -685,10 +685,10 @@ GLFWbool _glfwConnectWin32(int platformID, _GLFWplatform* platform)
 
 int _glfwInitWin32(void)
 {
-    if (!loadLibraries())
+    if (!_glfwLoadLibrariesWin32())
         return GLFW_FALSE;
 
-    createKeyTables();
+    _glfwCreateKeyTablesWin32();
     _glfwUpdateKeyNamesWin32();
 
     if (_glfwIsWindows10Version1703OrGreaterWin32())
@@ -698,7 +698,7 @@ int _glfwInitWin32(void)
     else if (IsWindowsVistaOrGreater())
         SetProcessDPIAware();
 
-    if (!createHelperWindow())
+    if (!_glfwCreateHelperWindowWin32())
         return GLFW_FALSE;
 
     _glfwPollMonitorsWin32();
@@ -724,7 +724,7 @@ void _glfwTerminateWin32(void)
     _glfwTerminateEGL();
     _glfwTerminateOSMesa();
 
-    freeLibraries();
+    _glfwFreeLibrariesWin32();
 }
 
 #endif // _GLFW_WIN32

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -39,7 +39,7 @@
 
 // Returns the window style for the specified window
 //
-static DWORD getWindowStyle(const _GLFWwindow* window)
+static DWORD _glfwGetWindowStyleWin32(const _GLFWwindow* window)
 {
     DWORD style = WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
 
@@ -65,7 +65,7 @@ static DWORD getWindowStyle(const _GLFWwindow* window)
 
 // Returns the extended window style for the specified window
 //
-static DWORD getWindowExStyle(const _GLFWwindow* window)
+static DWORD _glfwGetWindowExStyleWin32(const _GLFWwindow* window)
 {
     DWORD style = WS_EX_APPWINDOW;
 
@@ -77,7 +77,7 @@ static DWORD getWindowExStyle(const _GLFWwindow* window)
 
 // Returns the image whose area most closely matches the desired one
 //
-static const GLFWimage* chooseImage(int count, const GLFWimage* images,
+static const GLFWimage* _glfwChooseImageWin32(int count, const GLFWimage* images,
                                     int width, int height)
 {
     int i, leastDiff = INT_MAX;
@@ -99,7 +99,7 @@ static const GLFWimage* chooseImage(int count, const GLFWimage* images,
 
 // Creates an RGBA icon or cursor
 //
-static HICON createIcon(const GLFWimage* image, int xhot, int yhot, GLFWbool icon)
+static HICON _glfwCreateIconWin32(const GLFWimage* image, int xhot, int yhot, GLFWbool icon)
 {
     int i;
     HDC dc;
@@ -188,12 +188,12 @@ static HICON createIcon(const GLFWimage* image, int xhot, int yhot, GLFWbool ico
 
 // Enforce the content area aspect ratio based on which edge is being dragged
 //
-static void applyAspectRatio(_GLFWwindow* window, int edge, RECT* area)
+static void _glfwApplyAspectRatioWin32(_GLFWwindow* window, int edge, RECT* area)
 {
     RECT frame = {0};
     const float ratio = (float) window->numer / (float) window->denom;
-    const DWORD style = getWindowStyle(window);
-    const DWORD exStyle = getWindowExStyle(window);
+    const DWORD style = _glfwGetWindowStyleWin32(window);
+    const DWORD exStyle = _glfwGetWindowExStyleWin32(window);
 
     if (_glfwIsWindows10Version1607OrGreaterWin32())
     {
@@ -223,7 +223,7 @@ static void applyAspectRatio(_GLFWwindow* window, int edge, RECT* area)
 
 // Updates the cursor image according to its cursor mode
 //
-static void updateCursorImage(_GLFWwindow* window)
+static void _glfwUpdateCursorImageWin32(_GLFWwindow* window)
 {
     if (window->cursorMode == GLFW_CURSOR_NORMAL ||
         window->cursorMode == GLFW_CURSOR_CAPTURED)
@@ -239,7 +239,7 @@ static void updateCursorImage(_GLFWwindow* window)
 
 // Sets the cursor clip rect to the window content area
 //
-static void captureCursor(_GLFWwindow* window)
+static void _glfwCaptureCursorWin32(_GLFWwindow* window)
 {
     RECT clipRect;
     GetClientRect(window->win32.handle, &clipRect);
@@ -251,7 +251,7 @@ static void captureCursor(_GLFWwindow* window)
 
 // Disabled clip cursor
 //
-static void releaseCursor(void)
+static void _glfwReleaseCursorWin32(void)
 {
     ClipCursor(NULL);
     _glfw.win32.capturedCursorWindow = NULL;
@@ -259,7 +259,7 @@ static void releaseCursor(void)
 
 // Enables WM_INPUT messages for the mouse for the specified window
 //
-static void enableRawMouseMotion(_GLFWwindow* window)
+static void _glfwEnableRawMouseMotionWin32(_GLFWwindow* window)
 {
     const RAWINPUTDEVICE rid = { 0x01, 0x02, 0, window->win32.handle };
 
@@ -272,7 +272,7 @@ static void enableRawMouseMotion(_GLFWwindow* window)
 
 // Disables WM_INPUT messages for the mouse
 //
-static void disableRawMouseMotion(_GLFWwindow* window)
+static void _glfwDisableRawMouseMotionWin32(_GLFWwindow* window)
 {
     const RAWINPUTDEVICE rid = { 0x01, 0x02, RIDEV_REMOVE, NULL };
 
@@ -285,38 +285,38 @@ static void disableRawMouseMotion(_GLFWwindow* window)
 
 // Apply disabled cursor mode to a focused window
 //
-static void disableCursor(_GLFWwindow* window)
+static void _glfwDisableCursorWin32(_GLFWwindow* window)
 {
     _glfw.win32.disabledCursorWindow = window;
     _glfwGetCursorPosWin32(window,
                            &_glfw.win32.restoreCursorPosX,
                            &_glfw.win32.restoreCursorPosY);
-    updateCursorImage(window);
+    _glfwUpdateCursorImageWin32(window);
     _glfwCenterCursorInContentArea(window);
-    captureCursor(window);
+    _glfwCaptureCursorWin32(window);
 
     if (window->rawMouseMotion)
-        enableRawMouseMotion(window);
+        _glfwEnableRawMouseMotionWin32(window);
 }
 
 // Exit disabled cursor mode for the specified window
 //
-static void enableCursor(_GLFWwindow* window)
+static void _glfwEnableCursorWin32(_GLFWwindow* window)
 {
     if (window->rawMouseMotion)
-        disableRawMouseMotion(window);
+        _glfwDisableRawMouseMotionWin32(window);
 
     _glfw.win32.disabledCursorWindow = NULL;
-    releaseCursor();
+    _glfwReleaseCursorWin32();
     _glfwSetCursorPosWin32(window,
                            _glfw.win32.restoreCursorPosX,
                            _glfw.win32.restoreCursorPosY);
-    updateCursorImage(window);
+    _glfwUpdateCursorImageWin32(window);
 }
 
 // Returns whether the cursor is in the content area of the specified window
 //
-static GLFWbool cursorInContentArea(_GLFWwindow* window)
+static GLFWbool _glfwCursorInContentAreaWin32(_GLFWwindow* window)
 {
     RECT area;
     POINT pos;
@@ -336,23 +336,23 @@ static GLFWbool cursorInContentArea(_GLFWwindow* window)
 
 // Update native window styles to match attributes
 //
-static void updateWindowStyles(const _GLFWwindow* window)
+static void _glfwUpdateWindowStylesWin32(const _GLFWwindow* window)
 {
     RECT rect;
     DWORD style = GetWindowLongW(window->win32.handle, GWL_STYLE);
     style &= ~(WS_OVERLAPPEDWINDOW | WS_POPUP);
-    style |= getWindowStyle(window);
+    style |= _glfwGetWindowStyleWin32(window);
 
     GetClientRect(window->win32.handle, &rect);
 
     if (_glfwIsWindows10Version1607OrGreaterWin32())
     {
         AdjustWindowRectExForDpi(&rect, style, FALSE,
-                                 getWindowExStyle(window),
+                                 _glfwGetWindowExStyleWin32(window),
                                  GetDpiForWindow(window->win32.handle));
     }
     else
-        AdjustWindowRectEx(&rect, style, FALSE, getWindowExStyle(window));
+        AdjustWindowRectEx(&rect, style, FALSE, _glfwGetWindowExStyleWin32(window));
 
     ClientToScreen(window->win32.handle, (POINT*) &rect.left);
     ClientToScreen(window->win32.handle, (POINT*) &rect.right);
@@ -365,7 +365,7 @@ static void updateWindowStyles(const _GLFWwindow* window)
 
 // Update window framebuffer transparency
 //
-static void updateFramebufferTransparency(const _GLFWwindow* window)
+static void _glfwUpdateFramebufferTransparencyWin32(const _GLFWwindow* window)
 {
     BOOL composition, opaque;
     DWORD color;
@@ -402,7 +402,7 @@ static void updateFramebufferTransparency(const _GLFWwindow* window)
 
 // Retrieves and translates modifier keys
 //
-static int getKeyMods(void)
+static int _glfwGetKeyModsWin32(void)
 {
     int mods = 0;
 
@@ -422,7 +422,7 @@ static int getKeyMods(void)
     return mods;
 }
 
-static void fitToMonitor(_GLFWwindow* window)
+static void _glfwFitToMonitorWin32(_GLFWwindow* window)
 {
     MONITORINFO mi = { sizeof(mi) };
     GetMonitorInfoW(window->monitor->win32.handle, &mi);
@@ -436,7 +436,7 @@ static void fitToMonitor(_GLFWwindow* window)
 
 // Make the specified window and its video mode active on its monitor
 //
-static void acquireMonitor(_GLFWwindow* window)
+static void _glfwAcquireMonitorWin32(_GLFWwindow* window)
 {
     if (!_glfw.win32.acquiredMonitorCount)
     {
@@ -457,7 +457,7 @@ static void acquireMonitor(_GLFWwindow* window)
 
 // Remove the window and restore the original video mode
 //
-static void releaseMonitor(_GLFWwindow* window)
+static void _glfwReleaseMonitorWin32(_GLFWwindow* window)
 {
     if (window->monitor->window != window)
         return;
@@ -467,7 +467,7 @@ static void releaseMonitor(_GLFWwindow* window)
     {
         SetThreadExecutionState(ES_CONTINUOUS);
 
-        // HACK: Restore mouse trail length saved in acquireMonitor
+        // HACK: Restore mouse trail length saved in _glfwAcquireMonitorWin32
         SystemParametersInfoW(SPI_SETMOUSETRAILS, _glfw.win32.mouseTrailSize, 0, 0);
     }
 
@@ -477,7 +477,7 @@ static void releaseMonitor(_GLFWwindow* window)
 
 // Manually maximize the window, for when SW_MAXIMIZE cannot be used
 //
-static void maximizeWindowManually(_GLFWwindow* window)
+static void _glfwMaximizeWindowManuallyWin32(_GLFWwindow* window)
 {
     RECT rect;
     DWORD style;
@@ -527,9 +527,9 @@ static void maximizeWindowManually(_GLFWwindow* window)
 
 // Window procedure for user-created windows
 //
-static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+static LRESULT CALLBACK _glfwWindowProcWin32(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-    _GLFWwindow* window = GetPropW(hWnd, L"GLFW");
+    _GLFWwindow* window = (_GLFWwindow*) GetPropW(hWnd, L"GLFW");
     if (!window)
     {
         if (uMsg == WM_NCCREATE)
@@ -537,7 +537,7 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
             if (_glfwIsWindows10Version1607OrGreaterWin32())
             {
                 const CREATESTRUCTW* cs = (const CREATESTRUCTW*) lParam;
-                const _GLFWwndconfig* wndconfig = cs->lpCreateParams;
+                const _GLFWwndconfig* wndconfig = (const _GLFWwndconfig*) cs->lpCreateParams;
 
                 // On per-monitor DPI aware V1 systems, only enable
                 // non-client scaling for windows that scale the client area
@@ -573,9 +573,9 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
             if (lParam == 0 && window->win32.frameAction)
             {
                 if (window->cursorMode == GLFW_CURSOR_DISABLED)
-                    disableCursor(window);
+                    _glfwDisableCursorWin32(window);
                 else if (window->cursorMode == GLFW_CURSOR_CAPTURED)
-                    captureCursor(window);
+                    _glfwCaptureCursorWin32(window);
 
                 window->win32.frameAction = GLFW_FALSE;
             }
@@ -593,9 +593,9 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
                 break;
 
             if (window->cursorMode == GLFW_CURSOR_DISABLED)
-                disableCursor(window);
+                _glfwDisableCursorWin32(window);
             else if (window->cursorMode == GLFW_CURSOR_CAPTURED)
-                captureCursor(window);
+                _glfwCaptureCursorWin32(window);
 
             return 0;
         }
@@ -603,9 +603,9 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
         case WM_KILLFOCUS:
         {
             if (window->cursorMode == GLFW_CURSOR_DISABLED)
-                enableCursor(window);
+                _glfwEnableCursorWin32(window);
             else if (window->cursorMode == GLFW_CURSOR_CAPTURED)
-                releaseCursor();
+                _glfwReleaseCursorWin32();
 
             if (window->monitor && window->autoIconify)
                 _glfwIconifyWindowWin32(window);
@@ -677,7 +677,7 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
                     codepoint = (WCHAR) wParam;
 
                 window->win32.highSurrogate = 0;
-                _glfwInputChar(window, codepoint, getKeyMods(), uMsg != WM_SYSCHAR);
+                _glfwInputChar(window, codepoint, _glfwGetKeyModsWin32(), uMsg != WM_SYSCHAR);
             }
 
             if (uMsg == WM_SYSCHAR && window->win32.keymenu)
@@ -696,7 +696,7 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
                 return TRUE;
             }
 
-            _glfwInputChar(window, (uint32_t) wParam, getKeyMods(), GLFW_TRUE);
+            _glfwInputChar(window, (uint32_t) wParam, _glfwGetKeyModsWin32(), GLFW_TRUE);
             return 0;
         }
 
@@ -707,7 +707,7 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
         {
             int key, scancode;
             const int action = (HIWORD(lParam) & KF_UP) ? GLFW_RELEASE : GLFW_PRESS;
-            const int mods = getKeyMods();
+            const int mods = _glfwGetKeyModsWin32();
 
             scancode = (HIWORD(lParam) & (KF_EXTENDED | 0xff));
             if (!scancode)
@@ -835,7 +835,7 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
             if (i > GLFW_MOUSE_BUTTON_LAST)
                 SetCapture(hWnd);
 
-            _glfwInputMouseClick(window, button, action, getKeyMods());
+            _glfwInputMouseClick(window, button, action, _glfwGetKeyModsWin32());
 
             for (i = 0;  i <= GLFW_MOUSE_BUTTON_LAST;  i++)
             {
@@ -909,7 +909,7 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
             if (size > (UINT) _glfw.win32.rawInputSize)
             {
                 _glfw_free(_glfw.win32.rawInput);
-                _glfw.win32.rawInput = _glfw_calloc(size, 1);
+                _glfw.win32.rawInput = (RAWINPUT *) _glfw_calloc(size, 1);
                 _glfw.win32.rawInputSize = size;
             }
 
@@ -974,9 +974,9 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
             // HACK: Enable the cursor while the user is moving or
             //       resizing the window or using the window menu
             if (window->cursorMode == GLFW_CURSOR_DISABLED)
-                enableCursor(window);
+                _glfwEnableCursorWin32(window);
             else if (window->cursorMode == GLFW_CURSOR_CAPTURED)
-                releaseCursor();
+                _glfwReleaseCursorWin32();
 
             break;
         }
@@ -990,9 +990,9 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
             // HACK: Disable the cursor once the user is done moving or
             //       resizing the window or using the menu
             if (window->cursorMode == GLFW_CURSOR_DISABLED)
-                disableCursor(window);
+                _glfwDisableCursorWin32(window);
             else if (window->cursorMode == GLFW_CURSOR_CAPTURED)
-                captureCursor(window);
+                _glfwCaptureCursorWin32(window);
 
             break;
         }
@@ -1007,7 +1007,7 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
                                         wParam != SIZE_RESTORED);
 
             if (_glfw.win32.capturedCursorWindow == window)
-                captureCursor(window);
+                _glfwCaptureCursorWin32(window);
 
             if (window->win32.iconified != iconified)
                 _glfwInputWindowIconify(window, iconified);
@@ -1027,11 +1027,11 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
             if (window->monitor && window->win32.iconified != iconified)
             {
                 if (iconified)
-                    releaseMonitor(window);
+                    _glfwReleaseMonitorWin32(window);
                 else
                 {
-                    acquireMonitor(window);
-                    fitToMonitor(window);
+                    _glfwAcquireMonitorWin32(window);
+                    _glfwFitToMonitorWin32(window);
                 }
             }
 
@@ -1043,7 +1043,7 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
         case WM_MOVE:
         {
             if (_glfw.win32.capturedCursorWindow == window)
-                captureCursor(window);
+                _glfwCaptureCursorWin32(window);
 
             // NOTE: This cannot use LOWORD/HIWORD recommended by MSDN, as
             // those macros do not handle negative window positions correctly
@@ -1061,7 +1061,7 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
                 break;
             }
 
-            applyAspectRatio(window, (int) wParam, (RECT*) lParam);
+            _glfwApplyAspectRatioWin32(window, (int) wParam, (RECT*) lParam);
             return TRUE;
         }
 
@@ -1069,8 +1069,8 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
         {
             RECT frame = {0};
             MINMAXINFO* mmi = (MINMAXINFO*) lParam;
-            const DWORD style = getWindowStyle(window);
-            const DWORD exStyle = getWindowExStyle(window);
+            const DWORD style = _glfwGetWindowStyleWin32(window);
+            const DWORD exStyle = _glfwGetWindowExStyleWin32(window);
 
             if (window->monitor)
                 break;
@@ -1142,7 +1142,7 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
         case WM_DWMCOLORIZATIONCOLORCHANGED:
         {
             if (window->win32.transparent)
-                updateFramebufferTransparency(window);
+                _glfwUpdateFramebufferTransparencyWin32(window);
             return 0;
         }
 
@@ -1157,11 +1157,11 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
                 RECT source = {0}, target = {0};
                 SIZE* size = (SIZE*) lParam;
 
-                AdjustWindowRectExForDpi(&source, getWindowStyle(window),
-                                         FALSE, getWindowExStyle(window),
+                AdjustWindowRectExForDpi(&source, _glfwGetWindowStyleWin32(window),
+                                         FALSE, _glfwGetWindowExStyleWin32(window),
                                          GetDpiForWindow(window->win32.handle));
-                AdjustWindowRectExForDpi(&target, getWindowStyle(window),
-                                         FALSE, getWindowExStyle(window),
+                AdjustWindowRectExForDpi(&target, _glfwGetWindowStyleWin32(window),
+                                         FALSE, _glfwGetWindowExStyleWin32(window),
                                          LOWORD(wParam));
 
                 size->cx += (target.right - target.left) -
@@ -1202,7 +1202,7 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
         {
             if (LOWORD(lParam) == HTCLIENT)
             {
-                updateCursorImage(window);
+                _glfwUpdateCursorImageWin32(window);
                 return TRUE;
             }
 
@@ -1216,7 +1216,7 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
             int i;
 
             const int count = DragQueryFileW(drop, 0xffffffff, NULL, 0);
-            char** paths = _glfw_calloc(count, sizeof(char*));
+            char** paths = (char**) _glfw_calloc(count, sizeof(char*));
 
             // Move the mouse to the position of the drop
             DragQueryPoint(drop, &pt);
@@ -1225,7 +1225,7 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
             for (i = 0;  i < count;  i++)
             {
                 const UINT length = DragQueryFileW(drop, i, NULL, 0);
-                WCHAR* buffer = _glfw_calloc((size_t) length + 1, sizeof(WCHAR));
+                WCHAR* buffer = (WCHAR*) _glfw_calloc((size_t) length + 1, sizeof(WCHAR));
 
                 DragQueryFileW(drop, i, buffer, length + 1);
                 paths[i] = _glfwCreateUTF8FromWideStringWin32(buffer);
@@ -1249,20 +1249,20 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
 
 // Creates the GLFW window
 //
-static int createNativeWindow(_GLFWwindow* window,
-                              const _GLFWwndconfig* wndconfig,
-                              const _GLFWfbconfig* fbconfig)
+static int _glfwCreateNativeWindowWin32(_GLFWwindow* window,
+                                   const _GLFWwndconfig* wndconfig,
+                                   const _GLFWfbconfig* fbconfig)
 {
     int frameX, frameY, frameWidth, frameHeight;
     WCHAR* wideTitle;
-    DWORD style = getWindowStyle(window);
-    DWORD exStyle = getWindowExStyle(window);
+    DWORD style = _glfwGetWindowStyleWin32(window);
+    DWORD exStyle = _glfwGetWindowExStyleWin32(window);
 
     if (!_glfw.win32.mainWindowClass)
     {
         WNDCLASSEXW wc = { sizeof(wc) };
         wc.style         = CS_HREDRAW | CS_VREDRAW | CS_OWNDC;
-        wc.lpfnWndProc   = windowProc;
+        wc.lpfnWndProc   = _glfwWindowProcWin32;
         wc.hInstance     = _glfw.win32.instance;
         wc.hCursor       = LoadCursorW(NULL, IDC_ARROW);
 #if defined(_GLFW_WNDCLASSNAME)
@@ -1271,15 +1271,15 @@ static int createNativeWindow(_GLFWwindow* window,
         wc.lpszClassName = L"GLFW30";
 #endif
         // Load user-provided icon if available
-        wc.hIcon = LoadImageW(GetModuleHandleW(NULL),
-                              L"GLFW_ICON", IMAGE_ICON,
-                              0, 0, LR_DEFAULTSIZE | LR_SHARED);
+        wc.hIcon = (HICON) LoadImageW(GetModuleHandleW(NULL),
+                                      L"GLFW_ICON", IMAGE_ICON,
+                                      0, 0, LR_DEFAULTSIZE | LR_SHARED);
         if (!wc.hIcon)
         {
             // No user-provided icon found, load default icon
-            wc.hIcon = LoadImageW(NULL,
-                                  IDI_APPLICATION, IMAGE_ICON,
-                                  0, 0, LR_DEFAULTSIZE | LR_SHARED);
+            wc.hIcon = (HICON) LoadImageW(NULL,
+                                          IDI_APPLICATION, IMAGE_ICON,
+                                          0, 0, LR_DEFAULTSIZE | LR_SHARED);
         }
 
         _glfw.win32.mainWindowClass = RegisterClassExW(&wc);
@@ -1430,7 +1430,7 @@ static int createNativeWindow(_GLFWwindow* window,
 
     if (fbconfig->transparent)
     {
-        updateFramebufferTransparency(window);
+        _glfwUpdateFramebufferTransparencyWin32(window);
         window->win32.transparent = GLFW_TRUE;
     }
 
@@ -1444,7 +1444,7 @@ GLFWbool _glfwCreateWindowWin32(_GLFWwindow* window,
                                 const _GLFWctxconfig* ctxconfig,
                                 const _GLFWfbconfig* fbconfig)
 {
-    if (!createNativeWindow(window, wndconfig, fbconfig))
+    if (!_glfwCreateNativeWindowWin32(window, wndconfig, fbconfig))
         return GLFW_FALSE;
 
     if (ctxconfig->client != GLFW_NO_API)
@@ -1482,8 +1482,8 @@ GLFWbool _glfwCreateWindowWin32(_GLFWwindow* window,
     {
         _glfwShowWindowWin32(window);
         _glfwFocusWindowWin32(window);
-        acquireMonitor(window);
-        fitToMonitor(window);
+        _glfwAcquireMonitorWin32(window);
+        _glfwFitToMonitorWin32(window);
 
         if (wndconfig->centerCursor)
             _glfwCenterCursorInContentArea(window);
@@ -1504,16 +1504,16 @@ GLFWbool _glfwCreateWindowWin32(_GLFWwindow* window,
 void _glfwDestroyWindowWin32(_GLFWwindow* window)
 {
     if (window->monitor)
-        releaseMonitor(window);
+        _glfwReleaseMonitorWin32(window);
 
     if (window->context.destroy)
         window->context.destroy(window);
 
     if (_glfw.win32.disabledCursorWindow == window)
-        enableCursor(window);
+        _glfwEnableCursorWin32(window);
 
     if (_glfw.win32.capturedCursorWindow == window)
-        releaseCursor();
+        _glfwReleaseCursorWin32();
 
     if (window->win32.handle)
     {
@@ -1545,15 +1545,15 @@ void _glfwSetWindowIconWin32(_GLFWwindow* window, int count, const GLFWimage* im
 
     if (count)
     {
-        const GLFWimage* bigImage = chooseImage(count, images,
+        const GLFWimage* bigImage = _glfwChooseImageWin32(count, images,
                                                 GetSystemMetrics(SM_CXICON),
                                                 GetSystemMetrics(SM_CYICON));
-        const GLFWimage* smallImage = chooseImage(count, images,
+        const GLFWimage* smallImage = _glfwChooseImageWin32(count, images,
                                                   GetSystemMetrics(SM_CXSMICON),
                                                   GetSystemMetrics(SM_CYSMICON));
 
-        bigIcon = createIcon(bigImage, 0, 0, GLFW_TRUE);
-        smallIcon = createIcon(smallImage, 0, 0, GLFW_TRUE);
+        bigIcon = _glfwCreateIconWin32(bigImage, 0, 0, GLFW_TRUE);
+        smallIcon = _glfwCreateIconWin32(smallImage, 0, 0, GLFW_TRUE);
     }
     else
     {
@@ -1594,14 +1594,14 @@ void _glfwSetWindowPosWin32(_GLFWwindow* window, int xpos, int ypos)
 
     if (_glfwIsWindows10Version1607OrGreaterWin32())
     {
-        AdjustWindowRectExForDpi(&rect, getWindowStyle(window),
-                                 FALSE, getWindowExStyle(window),
+        AdjustWindowRectExForDpi(&rect, _glfwGetWindowStyleWin32(window),
+                                 FALSE, _glfwGetWindowExStyleWin32(window),
                                  GetDpiForWindow(window->win32.handle));
     }
     else
     {
-        AdjustWindowRectEx(&rect, getWindowStyle(window),
-                           FALSE, getWindowExStyle(window));
+        AdjustWindowRectEx(&rect, _glfwGetWindowStyleWin32(window),
+                           FALSE, _glfwGetWindowExStyleWin32(window));
     }
 
     SetWindowPos(window->win32.handle, NULL, rect.left, rect.top, 0, 0,
@@ -1625,8 +1625,8 @@ void _glfwSetWindowSizeWin32(_GLFWwindow* window, int width, int height)
     {
         if (window->monitor->window == window)
         {
-            acquireMonitor(window);
-            fitToMonitor(window);
+            _glfwAcquireMonitorWin32(window);
+            _glfwFitToMonitorWin32(window);
         }
     }
     else
@@ -1635,14 +1635,14 @@ void _glfwSetWindowSizeWin32(_GLFWwindow* window, int width, int height)
 
         if (_glfwIsWindows10Version1607OrGreaterWin32())
         {
-            AdjustWindowRectExForDpi(&rect, getWindowStyle(window),
-                                     FALSE, getWindowExStyle(window),
+            AdjustWindowRectExForDpi(&rect, _glfwGetWindowStyleWin32(window),
+                                     FALSE, _glfwGetWindowExStyleWin32(window),
                                      GetDpiForWindow(window->win32.handle));
         }
         else
         {
-            AdjustWindowRectEx(&rect, getWindowStyle(window),
-                               FALSE, getWindowExStyle(window));
+            AdjustWindowRectEx(&rect, _glfwGetWindowStyleWin32(window),
+                               FALSE, _glfwGetWindowExStyleWin32(window));
         }
 
         SetWindowPos(window->win32.handle, HWND_TOP,
@@ -1678,7 +1678,7 @@ void _glfwSetWindowAspectRatioWin32(_GLFWwindow* window, int numer, int denom)
         return;
 
     GetWindowRect(window->win32.handle, &area);
-    applyAspectRatio(window, WMSZ_BOTTOMRIGHT, &area);
+    _glfwApplyAspectRatioWin32(window, WMSZ_BOTTOMRIGHT, &area);
     MoveWindow(window->win32.handle,
                area.left, area.top,
                area.right - area.left,
@@ -1702,14 +1702,14 @@ void _glfwGetWindowFrameSizeWin32(_GLFWwindow* window,
 
     if (_glfwIsWindows10Version1607OrGreaterWin32())
     {
-        AdjustWindowRectExForDpi(&rect, getWindowStyle(window),
-                                 FALSE, getWindowExStyle(window),
+        AdjustWindowRectExForDpi(&rect, _glfwGetWindowStyleWin32(window),
+                                 FALSE, _glfwGetWindowExStyleWin32(window),
                                  GetDpiForWindow(window->win32.handle));
     }
     else
     {
-        AdjustWindowRectEx(&rect, getWindowStyle(window),
-                           FALSE, getWindowExStyle(window));
+        AdjustWindowRectEx(&rect, _glfwGetWindowStyleWin32(window),
+                           FALSE, _glfwGetWindowExStyleWin32(window));
     }
 
     if (left)
@@ -1726,7 +1726,7 @@ void _glfwGetWindowContentScaleWin32(_GLFWwindow* window, float* xscale, float* 
 {
     const HANDLE handle = MonitorFromWindow(window->win32.handle,
                                             MONITOR_DEFAULTTONEAREST);
-    _glfwGetHMONITORContentScaleWin32(handle, xscale, yscale);
+    _glfwGetHMONITORContentScaleWin32((HMONITOR) handle, xscale, yscale);
 }
 
 void _glfwIconifyWindowWin32(_GLFWwindow* window)
@@ -1744,7 +1744,7 @@ void _glfwMaximizeWindowWin32(_GLFWwindow* window)
     if (IsWindowVisible(window->win32.handle))
         ShowWindow(window->win32.handle, SW_MAXIMIZE);
     else
-        maximizeWindowManually(window);
+        _glfwMaximizeWindowManuallyWin32(window);
 }
 
 void _glfwShowWindowWin32(_GLFWwindow* window)
@@ -1781,8 +1781,8 @@ void _glfwSetWindowMonitorWin32(_GLFWwindow* window,
         {
             if (monitor->window == window)
             {
-                acquireMonitor(window);
-                fitToMonitor(window);
+                _glfwAcquireMonitorWin32(window);
+                _glfwFitToMonitorWin32(window);
             }
         }
         else
@@ -1791,14 +1791,14 @@ void _glfwSetWindowMonitorWin32(_GLFWwindow* window,
 
             if (_glfwIsWindows10Version1607OrGreaterWin32())
             {
-                AdjustWindowRectExForDpi(&rect, getWindowStyle(window),
-                                         FALSE, getWindowExStyle(window),
+                AdjustWindowRectExForDpi(&rect, _glfwGetWindowStyleWin32(window),
+                                         FALSE, _glfwGetWindowExStyleWin32(window),
                                          GetDpiForWindow(window->win32.handle));
             }
             else
             {
-                AdjustWindowRectEx(&rect, getWindowStyle(window),
-                                   FALSE, getWindowExStyle(window));
+                AdjustWindowRectEx(&rect, _glfwGetWindowStyleWin32(window),
+                                   FALSE, _glfwGetWindowExStyleWin32(window));
             }
 
             SetWindowPos(window->win32.handle, HWND_TOP,
@@ -1811,7 +1811,7 @@ void _glfwSetWindowMonitorWin32(_GLFWwindow* window,
     }
 
     if (window->monitor)
-        releaseMonitor(window);
+        _glfwReleaseMonitorWin32(window);
 
     _glfwInputWindowMonitor(window, monitor);
 
@@ -1824,12 +1824,12 @@ void _glfwSetWindowMonitorWin32(_GLFWwindow* window,
         {
             DWORD style = GetWindowLongW(window->win32.handle, GWL_STYLE);
             style &= ~WS_OVERLAPPEDWINDOW;
-            style |= getWindowStyle(window);
+            style |= _glfwGetWindowStyleWin32(window);
             SetWindowLongW(window->win32.handle, GWL_STYLE, style);
             flags |= SWP_FRAMECHANGED;
         }
 
-        acquireMonitor(window);
+        _glfwAcquireMonitorWin32(window);
 
         GetMonitorInfoW(window->monitor->win32.handle, &mi);
         SetWindowPos(window->win32.handle, HWND_TOPMOST,
@@ -1849,7 +1849,7 @@ void _glfwSetWindowMonitorWin32(_GLFWwindow* window,
         if (window->decorated)
         {
             style &= ~WS_POPUP;
-            style |= getWindowStyle(window);
+            style |= _glfwGetWindowStyleWin32(window);
             SetWindowLongW(window->win32.handle, GWL_STYLE, style);
 
             flags |= SWP_FRAMECHANGED;
@@ -1862,14 +1862,14 @@ void _glfwSetWindowMonitorWin32(_GLFWwindow* window,
 
         if (_glfwIsWindows10Version1607OrGreaterWin32())
         {
-            AdjustWindowRectExForDpi(&rect, getWindowStyle(window),
-                                     FALSE, getWindowExStyle(window),
+            AdjustWindowRectExForDpi(&rect, _glfwGetWindowStyleWin32(window),
+                                     FALSE, _glfwGetWindowExStyleWin32(window),
                                      GetDpiForWindow(window->win32.handle));
         }
         else
         {
-            AdjustWindowRectEx(&rect, getWindowStyle(window),
-                               FALSE, getWindowExStyle(window));
+            AdjustWindowRectEx(&rect, _glfwGetWindowStyleWin32(window),
+                               FALSE, _glfwGetWindowExStyleWin32(window));
         }
 
         SetWindowPos(window->win32.handle, after,
@@ -1901,7 +1901,7 @@ GLFWbool _glfwWindowMaximizedWin32(_GLFWwindow* window)
 
 GLFWbool _glfwWindowHoveredWin32(_GLFWwindow* window)
 {
-    return cursorInContentArea(window);
+    return _glfwCursorInContentAreaWin32(window);
 }
 
 GLFWbool _glfwFramebufferTransparentWin32(_GLFWwindow* window)
@@ -1933,12 +1933,12 @@ GLFWbool _glfwFramebufferTransparentWin32(_GLFWwindow* window)
 
 void _glfwSetWindowResizableWin32(_GLFWwindow* window, GLFWbool enabled)
 {
-    updateWindowStyles(window);
+    _glfwUpdateWindowStylesWin32(window);
 }
 
 void _glfwSetWindowDecoratedWin32(_GLFWwindow* window, GLFWbool enabled)
 {
-    updateWindowStyles(window);
+    _glfwUpdateWindowStylesWin32(window);
 }
 
 void _glfwSetWindowFloatingWin32(_GLFWwindow* window, GLFWbool enabled)
@@ -2020,9 +2020,9 @@ void _glfwSetRawMouseMotionWin32(_GLFWwindow *window, GLFWbool enabled)
         return;
 
     if (enabled)
-        enableRawMouseMotion(window);
+        _glfwEnableRawMouseMotionWin32(window);
     else
-        disableRawMouseMotion(window);
+        _glfwDisableRawMouseMotionWin32(window);
 }
 
 GLFWbool _glfwRawMouseMotionSupportedWin32(void)
@@ -2064,11 +2064,11 @@ void _glfwPollEventsWin32(void)
     // NOTE: Windows key is not reported as released by the Win+V hotkey
     //       Other Win hotkeys are handled implicitly by _glfwInputWindowFocus
     //       because they change the input focus
-    // NOTE: The other half of this is in the WM_*KEY* handler in windowProc
+    // NOTE: The other half of this is in the WM_*KEY* handler in _glfwWindowProcWin32
     handle = GetActiveWindow();
     if (handle)
     {
-        window = GetPropW(handle, L"GLFW");
+        window = (_GLFWwindow*) GetPropW(handle, L"GLFW");
         if (window)
         {
             int i;
@@ -2091,7 +2091,7 @@ void _glfwPollEventsWin32(void)
                 if (window->keys[key] != GLFW_PRESS)
                     continue;
 
-                _glfwInputKey(window, key, scancode, GLFW_RELEASE, getKeyMods());
+                _glfwInputKey(window, key, scancode, GLFW_RELEASE, _glfwGetKeyModsWin32());
             }
         }
     }
@@ -2169,18 +2169,18 @@ void _glfwSetCursorModeWin32(_GLFWwindow* window, int mode)
                                    &_glfw.win32.restoreCursorPosY);
             _glfwCenterCursorInContentArea(window);
             if (window->rawMouseMotion)
-                enableRawMouseMotion(window);
+                _glfwEnableRawMouseMotionWin32(window);
         }
         else if (_glfw.win32.disabledCursorWindow == window)
         {
             if (window->rawMouseMotion)
-                disableRawMouseMotion(window);
+                _glfwDisableRawMouseMotionWin32(window);
         }
 
         if (mode == GLFW_CURSOR_DISABLED || mode == GLFW_CURSOR_CAPTURED)
-            captureCursor(window);
+            _glfwCaptureCursorWin32(window);
         else
-            releaseCursor();
+            _glfwReleaseCursorWin32();
 
         if (mode == GLFW_CURSOR_DISABLED)
             _glfw.win32.disabledCursorWindow = window;
@@ -2193,8 +2193,8 @@ void _glfwSetCursorModeWin32(_GLFWwindow* window, int mode)
         }
     }
 
-    if (cursorInContentArea(window))
-        updateCursorImage(window);
+    if (_glfwCursorInContentAreaWin32(window))
+        _glfwUpdateCursorImageWin32(window);
 }
 
 const char* _glfwGetScancodeNameWin32(int scancode)
@@ -2218,7 +2218,7 @@ GLFWbool _glfwCreateCursorWin32(_GLFWcursor* cursor,
                                 const GLFWimage* image,
                                 int xhot, int yhot)
 {
-    cursor->win32.handle = (HCURSOR) createIcon(image, xhot, yhot, GLFW_FALSE);
+    cursor->win32.handle = (HCURSOR) _glfwCreateIconWin32(image, xhot, yhot, GLFW_FALSE);
     if (!cursor->win32.handle)
         return GLFW_FALSE;
 
@@ -2266,9 +2266,9 @@ GLFWbool _glfwCreateStandardCursorWin32(_GLFWcursor* cursor, int shape)
             return GLFW_FALSE;
     }
 
-    cursor->win32.handle = LoadImageW(NULL,
-                                      MAKEINTRESOURCEW(id), IMAGE_CURSOR, 0, 0,
-                                      LR_DEFAULTSIZE | LR_SHARED);
+    cursor->win32.handle = (HCURSOR) LoadImageW(NULL,
+                                                MAKEINTRESOURCEW(id), IMAGE_CURSOR, 0, 0,
+                                                LR_DEFAULTSIZE | LR_SHARED);
     if (!cursor->win32.handle)
     {
         _glfwInputErrorWin32(GLFW_PLATFORM_ERROR,
@@ -2287,8 +2287,8 @@ void _glfwDestroyCursorWin32(_GLFWcursor* cursor)
 
 void _glfwSetCursorWin32(_GLFWwindow* window, _GLFWcursor* cursor)
 {
-    if (cursorInContentArea(window))
-        updateCursorImage(window);
+    if (_glfwCursorInContentAreaWin32(window))
+        _glfwUpdateCursorImageWin32(window);
 }
 
 void _glfwSetClipboardStringWin32(const char* string)
@@ -2309,7 +2309,7 @@ void _glfwSetClipboardStringWin32(const char* string)
         return;
     }
 
-    buffer = GlobalLock(object);
+    buffer = (WCHAR*) GlobalLock(object);
     if (!buffer)
     {
         _glfwInputErrorWin32(GLFW_PLATFORM_ERROR,
@@ -2355,7 +2355,7 @@ const char* _glfwGetClipboardStringWin32(void)
         return NULL;
     }
 
-    buffer = GlobalLock(object);
+    buffer = (WCHAR*) GlobalLock(object);
     if (!buffer)
     {
         _glfwInputErrorWin32(GLFW_PLATFORM_ERROR,
@@ -2403,7 +2403,7 @@ EGLenum _glfwGetEGLPlatformWin32(EGLint** attribs)
 
         if (type)
         {
-            *attribs = _glfw_calloc(3, sizeof(EGLint));
+            *attribs = (EGLint*) _glfw_calloc(3, sizeof(EGLint));
             (*attribs)[0] = EGL_PLATFORM_ANGLE_TYPE_ANGLE;
             (*attribs)[1] = type;
             (*attribs)[2] = EGL_NONE;
@@ -2429,8 +2429,8 @@ void _glfwGetRequiredInstanceExtensionsWin32(char** extensions)
     if (!_glfw.vk.KHR_surface || !_glfw.vk.KHR_win32_surface)
         return;
 
-    extensions[0] = "VK_KHR_surface";
-    extensions[1] = "VK_KHR_win32_surface";
+    extensions[0] = (char*) "VK_KHR_surface";
+    extensions[1] = (char*) "VK_KHR_win32_surface";
 }
 
 GLFWbool _glfwGetPhysicalDevicePresentationSupportWin32(VkInstance instance,

--- a/src/window.c
+++ b/src/window.c
@@ -216,7 +216,7 @@ GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height,
     if (!_glfwIsValidContextConfig(&ctxconfig))
         return NULL;
 
-    window = _glfw_calloc(1, sizeof(_GLFWwindow));
+    window = (_GLFWwindow*) _glfw_calloc(1, sizeof(_GLFWwindow));
     window->next = _glfw.windowListHead;
     _glfw.windowListHead = window;
 

--- a/src/wl_monitor.c
+++ b/src/wl_monitor.c
@@ -39,16 +39,16 @@
 #include "wayland-client-protocol.h"
 
 
-static void outputHandleGeometry(void* userData,
-                                 struct wl_output* output,
-                                 int32_t x,
-                                 int32_t y,
-                                 int32_t physicalWidth,
-                                 int32_t physicalHeight,
-                                 int32_t subpixel,
-                                 const char* make,
-                                 const char* model,
-                                 int32_t transform)
+static void _glfwOutputHandleGeometryWayland(void* userData,
+                                             struct wl_output* output,
+                                             int32_t x,
+                                             int32_t y,
+                                             int32_t physicalWidth,
+                                             int32_t physicalHeight,
+                                             int32_t subpixel,
+                                             const char* make,
+                                             const char* model,
+                                             int32_t transform)
 {
     struct _GLFWmonitor* monitor = userData;
 
@@ -61,12 +61,12 @@ static void outputHandleGeometry(void* userData,
         snprintf(monitor->name, sizeof(monitor->name), "%s %s", make, model);
 }
 
-static void outputHandleMode(void* userData,
-                             struct wl_output* output,
-                             uint32_t flags,
-                             int32_t width,
-                             int32_t height,
-                             int32_t refresh)
+static void _glfwOutputHandleModeWayland(void* userData,
+                                         struct wl_output* output,
+                                         uint32_t flags,
+                                         int32_t width,
+                                         int32_t height,
+                                         int32_t refresh)
 {
     struct _GLFWmonitor* monitor = userData;
     GLFWvidmode mode;
@@ -87,7 +87,7 @@ static void outputHandleMode(void* userData,
         monitor->wl.currentMode = monitor->modeCount - 1;
 }
 
-static void outputHandleDone(void* userData, struct wl_output* output)
+static void _glfwOutputHandleDoneWayland(void* userData, struct wl_output* output)
 {
     struct _GLFWmonitor* monitor = userData;
 
@@ -108,9 +108,9 @@ static void outputHandleDone(void* userData, struct wl_output* output)
     _glfwInputMonitor(monitor, GLFW_CONNECTED, _GLFW_INSERT_LAST);
 }
 
-static void outputHandleScale(void* userData,
-                              struct wl_output* output,
-                              int32_t factor)
+static void _glfwOutputHandleScaleWayland(void* userData,
+                                          struct wl_output* output,
+                                          int32_t factor)
 {
     struct _GLFWmonitor* monitor = userData;
 
@@ -132,30 +132,30 @@ static void outputHandleScale(void* userData,
 
 #ifdef WL_OUTPUT_NAME_SINCE_VERSION
 
-void outputHandleName(void* userData, struct wl_output* wl_output, const char* name)
+static void _glfwOutputHandleNameWayland(void* userData, struct wl_output* wl_output, const char* name)
 {
     struct _GLFWmonitor* monitor = userData;
 
     strncpy(monitor->name, name, sizeof(monitor->name) - 1);
 }
 
-void outputHandleDescription(void* userData,
-                             struct wl_output* wl_output,
-                             const char* description)
+static void _glfwOutputHandleDescriptionWayland(void* userData,
+                                                struct wl_output* wl_output,
+                                                const char* description)
 {
 }
 
 #endif // WL_OUTPUT_NAME_SINCE_VERSION
 
-static const struct wl_output_listener outputListener =
+static const struct wl_output_listener _glfwOutputListenerWayland =
 {
-    outputHandleGeometry,
-    outputHandleMode,
-    outputHandleDone,
-    outputHandleScale,
+    _glfwOutputHandleGeometryWayland,
+    _glfwOutputHandleModeWayland,
+    _glfwOutputHandleDoneWayland,
+    _glfwOutputHandleScaleWayland,
 #ifdef WL_OUTPUT_NAME_SINCE_VERSION
-    outputHandleName,
-    outputHandleDescription,
+    _glfwOutputHandleNameWayland,
+    _glfwOutputHandleDescriptionWayland,
 #endif
 };
 
@@ -193,7 +193,7 @@ void _glfwAddOutputWayland(uint32_t name, uint32_t version)
     monitor->wl.name = name;
 
     wl_proxy_set_tag((struct wl_proxy*) output, &_glfw.wl.tag);
-    wl_output_add_listener(output, &outputListener, monitor);
+    wl_output_add_listener(output, &_glfwOutputListenerWayland, monitor);
 }
 
 

--- a/src/x11_init.c
+++ b/src/x11_init.c
@@ -46,7 +46,7 @@
 // NOTE: This is only used as a fallback, in case the XKB method fails
 //       It is layout-dependent and will fail partially on most non-US layouts
 //
-static int translateKeySyms(const KeySym* keysyms, int width)
+static int _glfwTranslateKeySymsX11(const KeySym* keysyms, int width)
 {
     if (width > 1)
     {
@@ -212,7 +212,7 @@ static int translateKeySyms(const KeySym* keysyms, int width)
 
 // Create key code translation tables
 //
-static void createKeyTables(void)
+static void _glfwCreateKeyTablesX11(void)
 {
     int scancodeMin, scancodeMax;
 
@@ -426,7 +426,7 @@ static void createKeyTables(void)
         if (_glfw.x11.keycodes[scancode] < 0)
         {
             const size_t base = (scancode - scancodeMin) * width;
-            _glfw.x11.keycodes[scancode] = translateKeySyms(&keysyms[base], width);
+            _glfw.x11.keycodes[scancode] = _glfwTranslateKeySymsX11(&keysyms[base], width);
         }
 
         // Store the reverse translation for faster key name lookup
@@ -439,7 +439,7 @@ static void createKeyTables(void)
 
 // Check whether the IM has a usable style
 //
-static GLFWbool hasUsableInputMethodStyle(void)
+static GLFWbool _glfwHasUsableInputMethodStyleX11(void)
 {
     GLFWbool found = GLFW_FALSE;
     XIMStyles* styles = NULL;
@@ -460,14 +460,14 @@ static GLFWbool hasUsableInputMethodStyle(void)
     return found;
 }
 
-static void inputMethodDestroyCallback(XIM im, XPointer clientData, XPointer callData)
+static void _glfwInputMethodDestroyCallbackX11(XIM im, XPointer clientData, XPointer callData)
 {
     _glfw.x11.im = NULL;
 }
 
-static void inputMethodInstantiateCallback(Display* display,
-                                           XPointer clientData,
-                                           XPointer callData)
+static void _glfwInputMethodInstantiateCallbackX11(Display* display,
+                                                   XPointer clientData,
+                                                   XPointer callData)
 {
     if (_glfw.x11.im)
         return;
@@ -475,7 +475,7 @@ static void inputMethodInstantiateCallback(Display* display,
     _glfw.x11.im = XOpenIM(_glfw.x11.display, 0, NULL, NULL);
     if (_glfw.x11.im)
     {
-        if (!hasUsableInputMethodStyle())
+        if (!_glfwHasUsableInputMethodStyleX11())
         {
             XCloseIM(_glfw.x11.im);
             _glfw.x11.im = NULL;
@@ -485,7 +485,7 @@ static void inputMethodInstantiateCallback(Display* display,
     if (_glfw.x11.im)
     {
         XIMCallback callback;
-        callback.callback = (XIMProc) inputMethodDestroyCallback;
+        callback.callback = (XIMProc) _glfwInputMethodDestroyCallbackX11;
         callback.client_data = NULL;
         XSetIMValues(_glfw.x11.im, XNDestroyCallback, &callback, NULL);
 
@@ -496,7 +496,7 @@ static void inputMethodInstantiateCallback(Display* display,
 
 // Return the atom ID only if it is listed in the specified array
 //
-static Atom getAtomIfSupported(Atom* supportedAtoms,
+static Atom _glfwGetAtomIfSupportedX11(Atom* supportedAtoms,
                                unsigned long atomCount,
                                const char* atomName)
 {
@@ -513,7 +513,7 @@ static Atom getAtomIfSupported(Atom* supportedAtoms,
 
 // Check whether the running window manager is EWMH-compliant
 //
-static void detectEWMH(void)
+static void _glfwdetectEWMHX11(void)
 {
     // First we read the _NET_SUPPORTING_WM_CHECK property on the root window
 
@@ -570,33 +570,33 @@ static void detectEWMH(void)
     // See which of the atoms we support that are supported by the WM
 
     _glfw.x11.NET_WM_STATE =
-        getAtomIfSupported(supportedAtoms, atomCount, "_NET_WM_STATE");
+        _glfwGetAtomIfSupportedX11(supportedAtoms, atomCount, "_NET_WM_STATE");
     _glfw.x11.NET_WM_STATE_ABOVE =
-        getAtomIfSupported(supportedAtoms, atomCount, "_NET_WM_STATE_ABOVE");
+        _glfwGetAtomIfSupportedX11(supportedAtoms, atomCount, "_NET_WM_STATE_ABOVE");
     _glfw.x11.NET_WM_STATE_FULLSCREEN =
-        getAtomIfSupported(supportedAtoms, atomCount, "_NET_WM_STATE_FULLSCREEN");
+        _glfwGetAtomIfSupportedX11(supportedAtoms, atomCount, "_NET_WM_STATE_FULLSCREEN");
     _glfw.x11.NET_WM_STATE_MAXIMIZED_VERT =
-        getAtomIfSupported(supportedAtoms, atomCount, "_NET_WM_STATE_MAXIMIZED_VERT");
+        _glfwGetAtomIfSupportedX11(supportedAtoms, atomCount, "_NET_WM_STATE_MAXIMIZED_VERT");
     _glfw.x11.NET_WM_STATE_MAXIMIZED_HORZ =
-        getAtomIfSupported(supportedAtoms, atomCount, "_NET_WM_STATE_MAXIMIZED_HORZ");
+        _glfwGetAtomIfSupportedX11(supportedAtoms, atomCount, "_NET_WM_STATE_MAXIMIZED_HORZ");
     _glfw.x11.NET_WM_STATE_DEMANDS_ATTENTION =
-        getAtomIfSupported(supportedAtoms, atomCount, "_NET_WM_STATE_DEMANDS_ATTENTION");
+        _glfwGetAtomIfSupportedX11(supportedAtoms, atomCount, "_NET_WM_STATE_DEMANDS_ATTENTION");
     _glfw.x11.NET_WM_FULLSCREEN_MONITORS =
-        getAtomIfSupported(supportedAtoms, atomCount, "_NET_WM_FULLSCREEN_MONITORS");
+        _glfwGetAtomIfSupportedX11(supportedAtoms, atomCount, "_NET_WM_FULLSCREEN_MONITORS");
     _glfw.x11.NET_WM_WINDOW_TYPE =
-        getAtomIfSupported(supportedAtoms, atomCount, "_NET_WM_WINDOW_TYPE");
+        _glfwGetAtomIfSupportedX11(supportedAtoms, atomCount, "_NET_WM_WINDOW_TYPE");
     _glfw.x11.NET_WM_WINDOW_TYPE_NORMAL =
-        getAtomIfSupported(supportedAtoms, atomCount, "_NET_WM_WINDOW_TYPE_NORMAL");
+        _glfwGetAtomIfSupportedX11(supportedAtoms, atomCount, "_NET_WM_WINDOW_TYPE_NORMAL");
     _glfw.x11.NET_WORKAREA =
-        getAtomIfSupported(supportedAtoms, atomCount, "_NET_WORKAREA");
+        _glfwGetAtomIfSupportedX11(supportedAtoms, atomCount, "_NET_WORKAREA");
     _glfw.x11.NET_CURRENT_DESKTOP =
-        getAtomIfSupported(supportedAtoms, atomCount, "_NET_CURRENT_DESKTOP");
+        _glfwGetAtomIfSupportedX11(supportedAtoms, atomCount, "_NET_CURRENT_DESKTOP");
     _glfw.x11.NET_ACTIVE_WINDOW =
-        getAtomIfSupported(supportedAtoms, atomCount, "_NET_ACTIVE_WINDOW");
+        _glfwGetAtomIfSupportedX11(supportedAtoms, atomCount, "_NET_ACTIVE_WINDOW");
     _glfw.x11.NET_FRAME_EXTENTS =
-        getAtomIfSupported(supportedAtoms, atomCount, "_NET_FRAME_EXTENTS");
+        _glfwGetAtomIfSupportedX11(supportedAtoms, atomCount, "_NET_FRAME_EXTENTS");
     _glfw.x11.NET_REQUEST_FRAME_EXTENTS =
-        getAtomIfSupported(supportedAtoms, atomCount, "_NET_REQUEST_FRAME_EXTENTS");
+        _glfwGetAtomIfSupportedX11(supportedAtoms, atomCount, "_NET_REQUEST_FRAME_EXTENTS");
 
     if (supportedAtoms)
         XFree(supportedAtoms);
@@ -604,7 +604,7 @@ static void detectEWMH(void)
 
 // Look for and initialize supported X11 extensions
 //
-static GLFWbool initExtensions(void)
+static GLFWbool _glfwInitExtensionsX11(void)
 {
 #if defined(__OpenBSD__) || defined(__NetBSD__)
     _glfw.x11.vidmode.handle = _glfwPlatformLoadModule("libXxf86vm.so");
@@ -910,7 +910,7 @@ static GLFWbool initExtensions(void)
     // Update the key code LUT
     // FIXME: We should listen to XkbMapNotify events to track changes to
     // the keyboard mapping.
-    createKeyTables();
+    _glfwCreateKeyTablesX11();
 
     // String format atoms
     _glfw.x11.NULL_ = XInternAtom(_glfw.x11.display, "NULL", False);
@@ -948,7 +948,7 @@ static GLFWbool initExtensions(void)
 
     // ICCCM, EWMH and Motif window property atoms
     // These can be set safely even without WM support
-    // The EWMH atoms that require WM support are handled in detectEWMH
+    // The EWMH atoms that require WM support are handled in _glfwdetectEWMHX11
     _glfw.x11.WM_PROTOCOLS =
         XInternAtom(_glfw.x11.display, "WM_PROTOCOLS", False);
     _glfw.x11.WM_STATE =
@@ -984,14 +984,14 @@ static GLFWbool initExtensions(void)
     }
 
     // Detect whether an EWMH-conformant window manager is running
-    detectEWMH();
+    _glfwdetectEWMHX11();
 
     return GLFW_TRUE;
 }
 
 // Retrieve system content scale via folklore heuristics
 //
-static void getSystemContentScale(float* xscale, float* yscale)
+static void _glfwGetSystemContentScaleX11(float* xscale, float* yscale)
 {
     // Start by assuming the default X11 DPI
     // NOTE: Some desktop environments (KDE) may remove the Xft.dpi field when it
@@ -1026,7 +1026,7 @@ static void getSystemContentScale(float* xscale, float* yscale)
 
 // Create a blank cursor for hidden and disabled cursor modes
 //
-static Cursor createHiddenCursor(void)
+static Cursor _glfwCreateHiddenCursorX11(void)
 {
     unsigned char pixels[16 * 16 * 4] = { 0 };
     GLFWimage image = { 16, 16, pixels };
@@ -1035,7 +1035,7 @@ static Cursor createHiddenCursor(void)
 
 // Create a helper window for IPC
 //
-static Window createHelperWindow(void)
+static Window _glfwCreateHelperWindowX11(void)
 {
     XSetWindowAttributes wa;
     wa.event_mask = PropertyChangeMask;
@@ -1049,7 +1049,7 @@ static Window createHelperWindow(void)
 
 // Create the pipe for empty events without assumuing the OS has pipe2(2)
 //
-static GLFWbool createEmptyEventPipe(void)
+static GLFWbool _glfwCreateEmptyEventPipeX11(void)
 {
     if (pipe(_glfw.x11.emptyEventPipe) != 0)
     {
@@ -1080,7 +1080,7 @@ static GLFWbool createEmptyEventPipe(void)
 
 // X error handler
 //
-static int errorHandler(Display *display, XErrorEvent* event)
+static int _glfwErrorHandlerX11(Display *display, XErrorEvent* event)
 {
     if (_glfw.x11.display != display)
         return 0;
@@ -1100,7 +1100,7 @@ void _glfwGrabErrorHandlerX11(void)
 {
     assert(_glfw.x11.errorHandler == NULL);
     _glfw.x11.errorCode = Success;
-    _glfw.x11.errorHandler = XSetErrorHandler(errorHandler);
+    _glfw.x11.errorHandler = XSetErrorHandler(_glfwErrorHandlerX11);
 }
 
 // Clears the X error handler callback
@@ -1527,16 +1527,16 @@ int _glfwInitX11(void)
     _glfw.x11.root = RootWindow(_glfw.x11.display, _glfw.x11.screen);
     _glfw.x11.context = XUniqueContext();
 
-    getSystemContentScale(&_glfw.x11.contentScaleX, &_glfw.x11.contentScaleY);
+    _glfwGetSystemContentScaleX11(&_glfw.x11.contentScaleX, &_glfw.x11.contentScaleY);
 
-    if (!createEmptyEventPipe())
+    if (!_glfwCreateEmptyEventPipeX11())
         return GLFW_FALSE;
 
-    if (!initExtensions())
+    if (!_glfwInitExtensionsX11())
         return GLFW_FALSE;
 
-    _glfw.x11.helperWindowHandle = createHelperWindow();
-    _glfw.x11.hiddenCursorHandle = createHiddenCursor();
+    _glfw.x11.helperWindowHandle = _glfwCreateHelperWindowX11();
+    _glfw.x11.hiddenCursorHandle = _glfwCreateHiddenCursorX11();
 
     if (XSupportsLocale() && _glfw.x11.xlib.utf8)
     {
@@ -1545,7 +1545,7 @@ int _glfwInitX11(void)
         // If an IM is already present our callback will be called right away
         XRegisterIMInstantiateCallback(_glfw.x11.display,
                                        NULL, NULL, NULL,
-                                       inputMethodInstantiateCallback,
+                                       _glfwInputMethodInstantiateCallbackX11,
                                        NULL);
     }
 
@@ -1578,7 +1578,7 @@ void _glfwTerminateX11(void)
 
     XUnregisterIMInstantiateCallback(_glfw.x11.display,
                                      NULL, NULL, NULL,
-                                     inputMethodInstantiateCallback,
+                                     _glfwInputMethodInstantiateCallbackX11,
                                      NULL);
 
     if (_glfw.x11.im)

--- a/src/x11_monitor.c
+++ b/src/x11_monitor.c
@@ -39,14 +39,14 @@
 
 // Check whether the display mode should be included in enumeration
 //
-static GLFWbool modeIsGood(const XRRModeInfo* mi)
+static GLFWbool _glfwModeIsGoodX11(const XRRModeInfo* mi)
 {
     return (mi->modeFlags & RR_Interlace) == 0;
 }
 
 // Calculates the refresh rate, in Hz, from the specified RandR mode info
 //
-static int calculateRefreshRate(const XRRModeInfo* mi)
+static int _glfwCalculateRefreshRateX11(const XRRModeInfo* mi)
 {
     if (mi->hTotal && mi->vTotal)
         return (int) round((double) mi->dotClock / ((double) mi->hTotal * (double) mi->vTotal));
@@ -56,7 +56,7 @@ static int calculateRefreshRate(const XRRModeInfo* mi)
 
 // Returns the mode info for a RandR mode XID
 //
-static const XRRModeInfo* getModeInfo(const XRRScreenResources* sr, RRMode id)
+static const XRRModeInfo* _glfwGetModeInfoX11(const XRRScreenResources* sr, RRMode id)
 {
     for (int i = 0;  i < sr->nmode;  i++)
     {
@@ -69,8 +69,8 @@ static const XRRModeInfo* getModeInfo(const XRRScreenResources* sr, RRMode id)
 
 // Convert RandR mode info to GLFW video mode
 //
-static GLFWvidmode vidmodeFromModeInfo(const XRRModeInfo* mi,
-                                       const XRRCrtcInfo* ci)
+static GLFWvidmode _glfwVidmodeFromModeInfoX11(const XRRModeInfo* mi,
+                                               const XRRCrtcInfo* ci)
 {
     GLFWvidmode mode;
 
@@ -85,7 +85,7 @@ static GLFWvidmode vidmodeFromModeInfo(const XRRModeInfo* mi,
         mode.height = mi->height;
     }
 
-    mode.refreshRate = calculateRefreshRate(mi);
+    mode.refreshRate = _glfwCalculateRefreshRateX11(mi);
 
     _glfwSplitBPP(DefaultDepth(_glfw.x11.display, _glfw.x11.screen),
                   &mode.redBits, &mode.greenBits, &mode.blueBits);
@@ -245,11 +245,11 @@ void _glfwSetVideoModeX11(_GLFWmonitor* monitor, const GLFWvidmode* desired)
 
         for (int i = 0;  i < oi->nmode;  i++)
         {
-            const XRRModeInfo* mi = getModeInfo(sr, oi->modes[i]);
-            if (!modeIsGood(mi))
+            const XRRModeInfo* mi = _glfwGetModeInfoX11(sr, oi->modes[i]);
+            if (!_glfwModeIsGoodX11(mi))
                 continue;
 
-            const GLFWvidmode mode = vidmodeFromModeInfo(mi, ci);
+            const GLFWvidmode mode = _glfwVidmodeFromModeInfoX11(mi, ci);
             if (_glfwCompareVideoModes(best, &mode) == 0)
             {
                 native = mi->id;
@@ -362,7 +362,7 @@ void _glfwGetMonitorWorkareaX11(_GLFWmonitor* monitor,
         areaX = ci->x;
         areaY = ci->y;
 
-        const XRRModeInfo* mi = getModeInfo(sr, ci->mode);
+        const XRRModeInfo* mi = _glfwGetModeInfoX11(sr, ci->mode);
 
         if (ci->rotation == RR_Rotate_90 || ci->rotation == RR_Rotate_270)
         {
@@ -458,11 +458,11 @@ GLFWvidmode* _glfwGetVideoModesX11(_GLFWmonitor* monitor, int* count)
 
         for (int i = 0;  i < oi->nmode;  i++)
         {
-            const XRRModeInfo* mi = getModeInfo(sr, oi->modes[i]);
-            if (!modeIsGood(mi))
+            const XRRModeInfo* mi = _glfwGetModeInfoX11(sr, oi->modes[i]);
+            if (!_glfwModeIsGoodX11(mi))
                 continue;
 
-            const GLFWvidmode mode = vidmodeFromModeInfo(mi, ci);
+            const GLFWvidmode mode = _glfwVidmodeFromModeInfoX11(mi, ci);
             int j;
 
             for (j = 0;  j < *count;  j++)
@@ -503,9 +503,9 @@ void _glfwGetVideoModeX11(_GLFWmonitor* monitor, GLFWvidmode* mode)
 
         if (ci)
         {
-            const XRRModeInfo* mi = getModeInfo(sr, ci->mode);
+            const XRRModeInfo* mi = _glfwGetModeInfoX11(sr, ci->mode);
             if (mi)  // mi can be NULL if the monitor has been disconnected
-                *mode = vidmodeFromModeInfo(mi, ci);
+                *mode = _glfwVidmodeFromModeInfoX11(mi, ci);
 
             XRRFreeCrtcInfo(ci);
         }

--- a/src/x11_platform.h
+++ b/src/x11_platform.h
@@ -996,7 +996,6 @@ void _glfwTerminateGLX(void);
 GLFWbool _glfwCreateContextGLX(_GLFWwindow* window,
                                const _GLFWctxconfig* ctxconfig,
                                const _GLFWfbconfig* fbconfig);
-void _glfwDestroyContextGLX(_GLFWwindow* window);
 GLFWbool _glfwChooseVisualGLX(const _GLFWwndconfig* wndconfig,
                               const _GLFWctxconfig* ctxconfig,
                               const _GLFWfbconfig* fbconfig,

--- a/src/xkb_unicode.c
+++ b/src/xkb_unicode.c
@@ -67,7 +67,7 @@
 //****                KeySym to Unicode mapping table                 ****
 //************************************************************************
 
-static const struct codepair {
+static const struct _glfwCodepair {
   unsigned short keysym;
   unsigned short ucs;
 } keysymtab[] = {
@@ -911,7 +911,7 @@ static const struct codepair {
 uint32_t _glfwKeySym2Unicode(unsigned int keysym)
 {
     int min = 0;
-    int max = sizeof(keysymtab) / sizeof(struct codepair) - 1;
+    int max = sizeof(keysymtab) / sizeof(struct _glfwCodepair) - 1;
     int mid;
 
     // First check for Latin-1 characters (1:1 mapping)


### PR DESCRIPTION
- assigned `_glfw`-qualified private names to all `static` symbols to avoid naming conflicts when including `glfw3impl.h`

- added casts as needed to compile `glfw3impl.h` as C++

- replaced `sprintf` with `snprintf` to avoid warnings from `clang -Wall`, (except on win32, where this provokes an appveyor failure `'snprintf' undefined`) 

- Added a brief remark on `glfw3impl.h` to the `Compiling GLFW` section in `README.md`

- Added `Garett Bass` to `CONTRIBUTORS.md`

I understand I should additionally provide updates to `docs/news.dox`, an example, and some means of testing that header-only compilation for C or C++ is not broken by future changes, which I will add in an additional commit if this change is deemed technically acceptable.