### PR TITLE
Fix compilation of Null-only library on Linux

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -316,10 +316,8 @@ if (MSVC90)
 endif()
 
 # Workaround for -std=c99 on Linux disabling _DEFAULT_SOURCE (POSIX 2008 and more)
-if (GLFW_BUILD_X11 OR GLFW_BUILD_WAYLAND)
-    if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-        target_compile_definitions(glfw PRIVATE _DEFAULT_SOURCE)
-    endif()
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_compile_definitions(glfw PRIVATE _DEFAULT_SOURCE)
 endif()
 
 if (GLFW_BUILD_SHARED_LIBRARY)

--- a/src/posix_time.h
+++ b/src/posix_time.h
@@ -29,6 +29,7 @@
 
 #include <stdint.h>
 #include <time.h>
+#include <sys/types.h>
 
 
 // POSIX-specific global timer data


### PR DESCRIPTION
In file news.dox it is mentioned that it should be possible to disable both X11 and Wayland backends to compile GLFW with only null platform.

This actually does not compile due to missing definintion of clockid_t and CLOCK_REALTIME. This commit fixes compilation errors.