### PR TITLE
Ability to get a window's title

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,6 +15,7 @@ video tutorials.
  - Keith Bauer
  - John Bartholomew
  - Coşku Baş
+ - Bayemite
  - Niklas Behrens
  - Andrew Belt
  - Nevyn Bengtsson

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ information on what to include when reporting a bug.
    (#279,#1307,#1497,#1574,#1928)
  - Added `GLFW_PKG_CONFIG_REQUIRES_PRIVATE` and `GLFW_PKG_CONFIG_LIBS_PRIVATE` CMake
    variables exposing pkg-config dependencies (#1307)
+ - Added `glfwGetWindowTitle` function for GLFWwindow for querying window titles (#1448,#1909)
  - Made joystick subsystem initialize at first use (#1284,#1646)
  - Made `GLFW_DOUBLEBUFFER` a read-only window attribute
  - Updated the minimum required CMake version to 3.1

--- a/docs/news.dox
+++ b/docs/news.dox
@@ -9,6 +9,13 @@
 
 @subsection features_34 New features in version 3.4
 
+
+@subsubsection features_34_get_window_title Ability to get a window's title
+
+GLFW now supports retrieving a window's title with the @ref glfwGetWindowTitle
+function.
+
+
 @subsubsection runtime_platform_34 Runtime platform selection
 
 GLFW now supports being compiled for multiple backends and selecting between
@@ -33,12 +40,6 @@ cursor is now referred to as @ref GLFW_POINTING_HAND_CURSOR.  The older names
 are still available.
 
 For more information see @ref cursor_standard.
-
-
-@subsubsection features_34_get_window_title Ability to get a window's title
-
-GLFW now supports retrieving a window's title with the @ref glfwGetWindowTitle
-function.
 
 
 @subsubsection mouse_passthrough_34 Mouse event passthrough

--- a/docs/news.dox
+++ b/docs/news.dox
@@ -35,6 +35,12 @@ are still available.
 For more information see @ref cursor_standard.
 
 
+@subsubsection features_34_get_window_title Ability to get a window's title
+
+GLFW now supports retrieving a window's title with the @ref glfwGetWindowTitle
+function.
+
+
 @subsubsection mouse_passthrough_34 Mouse event passthrough
 
 GLFW now provides the [GLFW_MOUSE_PASSTHROUGH](@ref GLFW_MOUSE_PASSTHROUGH_hint)
@@ -231,6 +237,7 @@ then GLFW will fail to initialize.
  - @ref glfwGetPlatform
  - @ref glfwPlatformSupported
  - @ref glfwInitVulkanLoader
+ - @ref glfwGetWindowTitle
 
 
 @subsubsection types_34 New types in version 3.4

--- a/docs/window.dox
+++ b/docs/window.dox
@@ -882,6 +882,15 @@ If you are using C++11 or C11, you can use a UTF-8 string literal.
 glfwSetWindowTitle(window, u8"This is always a UTF-8 string");
 @endcode
 
+The window title can be retrieved with @ref glfwGetWindowTitle.
+
+@code
+const char* title = glfwGetWindowTitle(window);
+@endcode
+
+The title returned is an internally managed copy of the title set
+by @ref glfwCreateWindow or @ref glfwSetWindowTitle. It does not
+include any additional text which may be appended by the platform.
 
 @subsection window_icon Window icon
 

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -3241,6 +3241,26 @@ GLFWAPI int glfwWindowShouldClose(GLFWwindow* window);
  */
 GLFWAPI void glfwSetWindowShouldClose(GLFWwindow* window, int value);
 
+/*! @brief Retrieves the title of the specified window.
+ *
+ *  This function gets the window title, encoded as UTF-8, of the specified
+ *  window.
+ *
+ *  @param[in] window The window to query.
+ *  @return A copy of the UTF-8 encoded window title, as set by glfwCreateWindow
+ *  or glfwSetWindowTitle, or NULL if there is an error.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_title
+ *  @sa @ref glfwSetWindowTitle
+ *
+ *  @ingroup window
+ */
+GLFWAPI const char* glfwGetWindowTitle(GLFWwindow* window);
+
 /*! @brief Sets the title of the specified window.
  *
  *  This function sets the window title, encoded as UTF-8, of the specified

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -3252,6 +3252,10 @@ GLFWAPI void glfwSetWindowShouldClose(GLFWwindow* window, int value);
  *
  *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED
  *
+ *  @pointer_lifetime The returned string is allocated and freed by GLFW.  You
+ *  should not free it yourself.  It is valid until the next call to @ref
+ *  glfwSetWindowTitle, or until the library is terminated.
+ *
  *  @thread_safety This function must only be called from the main thread.
  *
  *  @sa @ref window_title

--- a/src/internal.h
+++ b/src/internal.h
@@ -531,6 +531,7 @@ struct _GLFWwindow
     GLFWvidmode         videoMode;
     _GLFWmonitor*       monitor;
     _GLFWcursor*        cursor;
+    char*               title;
 
     int                 minwidth, minheight;
     int                 maxwidth, maxheight;

--- a/src/window.c
+++ b/src/window.c
@@ -173,15 +173,6 @@ void _glfwInputWindowMonitor(_GLFWwindow* window, _GLFWmonitor* monitor)
     window->monitor = monitor;
 }
 
-// Notifies shared code that a window has new title
-//
-void _glfwInputWindowTitle(_GLFWwindow* window, const char* title)
-{
-    size_t size = strlen( title ) + 1;
-    window->title = _glfw_realloc(window->title, size);
-    memcpy( window->title, title, size );
-}
-
 //////////////////////////////////////////////////////////////////////////
 //////                        GLFW public API                       //////
 //////////////////////////////////////////////////////////////////////////
@@ -251,7 +242,7 @@ GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height,
     window->maxheight   = GLFW_DONT_CARE;
     window->numer       = GLFW_DONT_CARE;
     window->denom       = GLFW_DONT_CARE;
-    _glfwInputWindowTitle(window, title);
+    window->title       = _glfw_strdup(title);
 
     if (!_glfw.platform.createWindow(window, &wndconfig, &ctxconfig, &fbconfig))
     {
@@ -541,7 +532,9 @@ GLFWAPI void glfwSetWindowTitle(GLFWwindow* handle, const char* title)
 
     _GLFW_REQUIRE_INIT();
 
-    _glfwInputWindowTitle(window, title);
+    _glfw_free(window->title);
+    window->title = _glfw_strdup(title);
+
     _glfw.platform.setWindowTitle(window, title);
 }
 

--- a/src/window.c
+++ b/src/window.c
@@ -534,9 +534,9 @@ GLFWAPI void glfwSetWindowTitle(GLFWwindow* handle, const char* title)
 
     char* prev = window->title;
     window->title = _glfw_strdup(title);
-    _glfw_free(prev);
 
     _glfw.platform.setWindowTitle(window, title);
+    _glfw_free(prev);
 }
 
 GLFWAPI void glfwSetWindowIcon(GLFWwindow* handle,

--- a/src/window.c
+++ b/src/window.c
@@ -532,8 +532,9 @@ GLFWAPI void glfwSetWindowTitle(GLFWwindow* handle, const char* title)
 
     _GLFW_REQUIRE_INIT();
 
-    _glfw_free(window->title);
+    char* prev = window->title;
     window->title = _glfw_strdup(title);
+    _glfw_free(prev);
 
     _glfw.platform.setWindowTitle(window, title);
 }

--- a/src/window.c
+++ b/src/window.c
@@ -173,6 +173,15 @@ void _glfwInputWindowMonitor(_GLFWwindow* window, _GLFWmonitor* monitor)
     window->monitor = monitor;
 }
 
+// Notifies shared code that a window has new title
+//
+void _glfwInputWindowTitle(_GLFWwindow* window, const char* title)
+{
+    size_t size = strlen( title ) + 1;
+    window->title = _glfw_realloc(window->title, size);
+    memcpy( window->title, title, size );
+}
+
 //////////////////////////////////////////////////////////////////////////
 //////                        GLFW public API                       //////
 //////////////////////////////////////////////////////////////////////////
@@ -242,6 +251,7 @@ GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height,
     window->maxheight   = GLFW_DONT_CARE;
     window->numer       = GLFW_DONT_CARE;
     window->denom       = GLFW_DONT_CARE;
+    _glfwInputWindowTitle(window, title);
 
     if (!_glfw.platform.createWindow(window, &wndconfig, &ctxconfig, &fbconfig))
     {
@@ -491,7 +501,7 @@ GLFWAPI void glfwDestroyWindow(GLFWwindow* handle)
 
         *prev = window->next;
     }
-
+    _glfw_free(window->title);
     _glfw_free(window);
 }
 
@@ -513,6 +523,16 @@ GLFWAPI void glfwSetWindowShouldClose(GLFWwindow* handle, int value)
     window->shouldClose = value;
 }
 
+GLFWAPI const char* glfwGetWindowTitle(GLFWwindow* handle)
+{
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    assert(window != NULL);
+
+    _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
+
+    return window->title;
+}
+
 GLFWAPI void glfwSetWindowTitle(GLFWwindow* handle, const char* title)
 {
     _GLFWwindow* window = (_GLFWwindow*) handle;
@@ -520,6 +540,8 @@ GLFWAPI void glfwSetWindowTitle(GLFWwindow* handle, const char* title)
     assert(title != NULL);
 
     _GLFW_REQUIRE_INIT();
+
+    _glfwInputWindowTitle(window, title);
     _glfw.platform.setWindowTitle(window, title);
 }
 

--- a/tests/window.c
+++ b/tests/window.c
@@ -62,6 +62,7 @@ int main(int argc, char** argv)
     char min_width_buffer[12] = "", min_height_buffer[12] = "";
     char max_width_buffer[12] = "", max_height_buffer[12] = "";
     int may_close = true;
+    char window_title[64] = "";
 
     if (!glfwInit())
         exit(EXIT_FAILURE);
@@ -108,6 +109,11 @@ int main(int argc, char** argv)
     struct nk_font_atlas* atlas;
     nk_glfw3_font_stash_begin(&atlas);
     nk_glfw3_font_stash_end();
+
+    // test setting title with result from glfwGetWindowTitle
+    glfwSetWindowTitle(window, glfwGetWindowTitle(window));
+
+    strncpy( window_title, glfwGetWindowTitle(window), sizeof(window_title));
 
     while (!(may_close && glfwWindowShouldClose(window)))
     {
@@ -170,14 +176,26 @@ int main(int argc, char** argv)
                     glfwSetWindowAttrib(window, GLFW_MOUSE_PASSTHROUGH, false);
             }
 
-            nk_labelf(nk, NK_TEXT_CENTERED, "Window Title: %s", glfwGetWindowTitle(window));
-
             nk_label(nk, "Press Enter in a text field to set value", NK_TEXT_CENTERED);
+
+
 
             nk_flags events;
             const nk_flags flags = NK_EDIT_FIELD |
                                    NK_EDIT_SIG_ENTER |
                                    NK_EDIT_GOTO_END_ON_ACTIVATE;
+
+            nk_layout_row_dynamic(nk, 30, 2);
+            nk_label(nk, "Window Title:", NK_TEXT_LEFT);
+
+            events = nk_edit_string_zero_terminated( nk, flags, window_title, sizeof(window_title), NULL );
+
+            if (events & NK_EDIT_COMMITED)
+            {
+                glfwSetWindowTitle(window, window_title);
+                // we do not need to call glfwGetWindowTitle as we already store the title, but using it here for testing purposes
+                strncpy( window_title, glfwGetWindowTitle(window), sizeof(window_title));
+            }
 
             if (position_supported)
             {

--- a/tests/window.c
+++ b/tests/window.c
@@ -71,7 +71,7 @@ int main(int argc, char** argv)
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
 
-    GLFWwindow* window = glfwCreateWindow(600, 600, "Window Features", NULL, NULL);
+    GLFWwindow* window = glfwCreateWindow(600, 630, "Window Features", NULL, NULL);
     if (!window)
     {
         glfwTerminate();
@@ -169,6 +169,8 @@ int main(int argc, char** argv)
                 if (glfwGetKey(window, GLFW_KEY_H))
                     glfwSetWindowAttrib(window, GLFW_MOUSE_PASSTHROUGH, false);
             }
+
+            nk_labelf(nk, NK_TEXT_CENTERED, "Window Title: %s", glfwGetWindowTitle(window));
 
             nk_label(nk, "Press Enter in a text field to set value", NK_TEXT_CENTERED);
 


### PR DESCRIPTION
This PR implements the feature requested by issue #1448, partially based on the implementation by #1909.

A design choice has been made to return the same title which was set, rather than the title which could be obtained from the platform. This reduces surface area of the code and is easier to reason about when making dynamic titles.