### PR TITLE
Wayland: Partially implement `glfwSetCursorPos`

### DIFF
--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -371,6 +371,7 @@ typedef struct _GLFWwindowWayland
         GLFWbool                iconified;
         GLFWbool                activated;
         GLFWbool                fullscreen;
+        double                  cursorPosX, cursorPosY;
     } pending;
 
     struct {
@@ -386,6 +387,7 @@ typedef struct _GLFWwindowWayland
 
     _GLFWcursor*                currentCursor;
     double                      cursorPosX, cursorPosY;
+    GLFWbool                    pendingCursorPos;
 
     char*                       appId;
 

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -2667,8 +2667,34 @@ void _glfwGetCursorPosWayland(_GLFWwindow* window, double* xpos, double* ypos)
 
 void _glfwSetCursorPosWayland(_GLFWwindow* window, double x, double y)
 {
-    _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
-                    "Wayland: The platform does not support setting the cursor position");
+    if (!_glfw.wl.pointerConstraints)
+    {
+        _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
+                        "Wayland: The compositor does not support setting the cursor position");
+        return;
+    }
+
+    if (window->wl.lockedPointer) {
+        zwp_locked_pointer_v1_set_cursor_position_hint(window->wl.lockedPointer,
+                                                       wl_fixed_from_double(x),
+                                                       wl_fixed_from_double(y));
+    } else {
+        if (window->cursorMode != GLFW_CURSOR_DISABLED) {
+            _glfwInputError(GLFW_PLATFORM_ERROR,
+                            "Wayland: Delaying the cursor position update until "
+                            "the cursor mode is set to GLFW_CURSOR_DISABLED");
+        }
+
+        // The cursor is not currently locked, but it may be locked later. Either
+        // - the application has already set the cursor mode to GLFW_CURSOR_DISABLED,
+        //   but the cursor is currently outside of the window, or
+        // - the application has not yet set the cursor mode to GLFW_CURSOR_DISABLED,
+        //   but will do so soon.
+        // Defer setting the cursor position to _glfwSetCursorWayland.
+        window->wl.pending.cursorPosX = x;
+        window->wl.pending.cursorPosY = y;
+        window->wl.pendingCursorPos = GLFW_TRUE;
+    }
 }
 
 void _glfwSetCursorModeWayland(_GLFWwindow* window, int mode)
@@ -3009,6 +3035,13 @@ void _glfwSetCursorWayland(_GLFWwindow* window, _GLFWcursor* cursor)
             unconfinePointer(window);
         if (!window->wl.lockedPointer)
             lockPointer(window);
+
+        if (window->wl.pendingCursorPos == GLFW_TRUE) {
+            zwp_locked_pointer_v1_set_cursor_position_hint(window->wl.lockedPointer,
+                wl_fixed_from_double(window->wl.pending.cursorPosX),
+                wl_fixed_from_double(window->wl.pending.cursorPosY));
+            window->wl.pendingCursorPos = GLFW_FALSE;
+        }
     }
     else if (window->cursorMode == GLFW_CURSOR_CAPTURED)
     {


### PR DESCRIPTION
Wayland _does_ support setting the cursor position with [`set_cursor_position_hint`](https://wayland.app/protocols/pointer-constraints-unstable-v1#zwp_locked_pointer_v1:request:set_cursor_position_hint), but in order to call that function we need a [`zwp_locked_pointer_v1`](https://wayland.app/protocols/pointer-constraints-unstable-v1#zwp_locked_pointer_v1) object.

By "partially implement" I mean that calling `glfwSetCursorPos` while the cursor mode is not DISABLED will do nothing immediately. I implemented a mechanism that defers the call to `set_cursor_position_hint` until we have locked the pointer, if the pointer is not currently locked. This has an effect in these two situations:

1. The application has already set the cursor mode to DISABLED, but the cursor is currently outside of the window.
2. The application has not yet set the cursor mode to DISABLED, but will (hopefully) do so soon.

In situation two we input an error that notifies the application about this.

This is everything required to make the use of `glfwSetCursorPos` in Minecraft work. When closing an GUI in Minecraft, it first sets the cursor position to the center, then sets the cursor mode to DISABLED immediately after. Because of this, Minecraft inadvertently makes use of this "defer" mechanism. Situation two applies. This does mean that the log is hit with an GLFW error every time an GUI is closed, but I don't think there's much that can be done to avoid this.