### PR TITLE
Fix duplicate scroll events

### DIFF
--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -135,7 +135,7 @@ static void registryHandleGlobal(void* userData,
         {
             _glfw.wl.seat =
                 wl_registry_bind(registry, name, &wl_seat_interface,
-                                 _glfw_min(4, version));
+                                 _glfw_min(5, version));
             _glfwAddSeatListenerWayland(_glfw.wl.seat);
         }
     }

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -1622,6 +1622,31 @@ static void pointerHandleAxis(void* userData,
         _glfwInputScroll(window, 0.0, -wl_fixed_to_double(value) / 10.0);
 }
 
+static void pointerHandleFrame(void* userData,
+                               struct wl_pointer* pointer)
+{
+}
+
+static void pointerHandleAxisSource(void* userData,
+                                    struct wl_pointer* pointer,
+                                    uint32_t axis_source)
+{
+}
+
+static void pointerHandleAxisStop(void* userData,
+                                  struct wl_pointer* pointer,
+                                  uint32_t time,
+                                  uint32_t axis)
+{
+}
+
+static void pointerHandleAxisDiscrete(void* userData,
+                                      struct wl_pointer* pointer,
+                                      uint32_t axis,
+                                      int32_t discrete)
+{
+}
+
 static const struct wl_pointer_listener pointerListener =
 {
     pointerHandleEnter,
@@ -1629,6 +1654,10 @@ static const struct wl_pointer_listener pointerListener =
     pointerHandleMotion,
     pointerHandleButton,
     pointerHandleAxis,
+    pointerHandleFrame,
+    pointerHandleAxisSource,
+    pointerHandleAxisStop,
+    pointerHandleAxisDiscrete,
 };
 
 static void keyboardHandleKeymap(void* userData,


### PR DESCRIPTION
I'm not exactly sure why this works, but it seems to do so on my machine. I don't know what changed in the wayland protocol between those versions, and I don't really know how to look that up effectively. Should we do something within these new functions? I don't know what impact changing the interface version has on the rest of the codebase. That's why this is a draft PR until that gets figured out.

Fixes #2494