### PR TITLE
Fixing c99 warnings

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -1179,7 +1179,7 @@ extern "C" {
 #define GLFW_WAYLAND_PREFER_LIBDECOR    0x00038001
 #define GLFW_WAYLAND_DISABLE_LIBDECOR   0x00038002
 
-#define GLFW_ANY_POSITION           0x80000000
+#define GLFW_ANY_POSITION           0x7FFFFFFF
 
 /*! @defgroup shapes Standard cursor shapes
  *  @brief Standard system cursor shapes.

--- a/src/cocoa_platform.h
+++ b/src/cocoa_platform.h
@@ -272,7 +272,7 @@ EGLenum _glfwGetEGLPlatformCocoa(EGLint** attribs);
 EGLNativeDisplayType _glfwGetEGLNativeDisplayCocoa(void);
 EGLNativeWindowType _glfwGetEGLNativeWindowCocoa(_GLFWwindow* window);
 
-void _glfwGetRequiredInstanceExtensionsCocoa(char** extensions);
+void _glfwGetRequiredInstanceExtensionsCocoa(const char** extensions);
 GLFWbool _glfwGetPhysicalDevicePresentationSupportCocoa(VkInstance instance, VkPhysicalDevice device, uint32_t queuefamily);
 VkResult _glfwCreateWindowSurfaceCocoa(VkInstance instance, _GLFWwindow* window, const VkAllocationCallbacks* allocator, VkSurfaceKHR* surface);
 

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -1921,7 +1921,7 @@ EGLNativeWindowType _glfwGetEGLNativeWindowCocoa(_GLFWwindow* window)
     return window->ns.layer;
 }
 
-void _glfwGetRequiredInstanceExtensionsCocoa(char** extensions)
+void _glfwGetRequiredInstanceExtensionsCocoa(const char** extensions)
 {
     if (_glfw.vk.KHR_surface && _glfw.vk.EXT_metal_surface)
     {

--- a/src/input.c
+++ b/src/input.c
@@ -1271,7 +1271,7 @@ GLFWAPI int glfwUpdateGamepadMappings(const char* string)
             const size_t length = strcspn(c, "\r\n");
             if (length < sizeof(line))
             {
-                _GLFWmapping mapping = {{0}};
+                _GLFWmapping mapping = { .name = {0} };
 
                 memcpy(line, c, length);
                 line[length] = '\0';

--- a/src/internal.h
+++ b/src/internal.h
@@ -746,7 +746,7 @@ struct _GLFWplatform
     EGLNativeDisplayType (*getEGLNativeDisplay)(void);
     EGLNativeWindowType (*getEGLNativeWindow)(_GLFWwindow*);
     // vulkan
-    void (*getRequiredInstanceExtensions)(char**);
+    void (*getRequiredInstanceExtensions)(const char**);
     GLFWbool (*getPhysicalDevicePresentationSupport)(VkInstance,VkPhysicalDevice,uint32_t);
     VkResult (*createWindowSurface)(VkInstance,_GLFWwindow*,const VkAllocationCallbacks*,VkSurfaceKHR*);
 };
@@ -851,7 +851,7 @@ struct _GLFWlibrary
     struct {
         GLFWbool        available;
         void*           handle;
-        char*           extensions[2];
+        const char*     extensions[2];
         PFN_vkGetInstanceProcAddr GetInstanceProcAddr;
         GLFWbool        KHR_surface;
         GLFWbool        KHR_win32_surface;

--- a/src/null_platform.h
+++ b/src/null_platform.h
@@ -263,7 +263,7 @@ EGLenum _glfwGetEGLPlatformNull(EGLint** attribs);
 EGLNativeDisplayType _glfwGetEGLNativeDisplayNull(void);
 EGLNativeWindowType _glfwGetEGLNativeWindowNull(_GLFWwindow* window);
 
-void _glfwGetRequiredInstanceExtensionsNull(char** extensions);
+void _glfwGetRequiredInstanceExtensionsNull(const char** extensions);
 GLFWbool _glfwGetPhysicalDevicePresentationSupportNull(VkInstance instance, VkPhysicalDevice device, uint32_t queuefamily);
 VkResult _glfwCreateWindowSurfaceNull(VkInstance instance, _GLFWwindow* window, const VkAllocationCallbacks* allocator, VkSurfaceKHR* surface);
 

--- a/src/null_window.c
+++ b/src/null_window.c
@@ -697,7 +697,7 @@ int _glfwGetKeyScancodeNull(int key)
     return _glfw.null.scancodes[key];
 }
 
-void _glfwGetRequiredInstanceExtensionsNull(char** extensions)
+void _glfwGetRequiredInstanceExtensionsNull(const char** extensions)
 {
 }
 

--- a/src/vulkan.c
+++ b/src/vulkan.c
@@ -148,7 +148,7 @@ GLFWbool _glfwInitVulkan(int mode)
 
     _glfw.vk.available = GLFW_TRUE;
 
-    _glfw.platform.getRequiredInstanceExtensions(_glfw.vk.extensions);
+    _glfw.platform.getRequiredInstanceExtensions((const char **)_glfw.vk.extensions);
 
     return GLFW_TRUE;
 }

--- a/src/win32_platform.h
+++ b/src/win32_platform.h
@@ -600,7 +600,7 @@ EGLenum _glfwGetEGLPlatformWin32(EGLint** attribs);
 EGLNativeDisplayType _glfwGetEGLNativeDisplayWin32(void);
 EGLNativeWindowType _glfwGetEGLNativeWindowWin32(_GLFWwindow* window);
 
-void _glfwGetRequiredInstanceExtensionsWin32(char** extensions);
+void _glfwGetRequiredInstanceExtensionsWin32(const char** extensions);
 GLFWbool _glfwGetPhysicalDevicePresentationSupportWin32(VkInstance instance, VkPhysicalDevice device, uint32_t queuefamily);
 VkResult _glfwCreateWindowSurfaceWin32(VkInstance instance, _GLFWwindow* window, const VkAllocationCallbacks* allocator, VkSurfaceKHR* surface);
 

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -2513,7 +2513,7 @@ EGLNativeWindowType _glfwGetEGLNativeWindowWin32(_GLFWwindow* window)
     return window->win32.handle;
 }
 
-void _glfwGetRequiredInstanceExtensionsWin32(char** extensions)
+void _glfwGetRequiredInstanceExtensionsWin32(const char** extensions)
 {
     if (!_glfw.vk.KHR_surface || !_glfw.vk.KHR_win32_surface)
         return;

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -236,7 +236,7 @@ void libdecorHandleError(struct libdecor* context,
 
 static const struct libdecor_interface libdecorInterface =
 {
-    libdecorHandleError
+    .error = libdecorHandleError
 };
 
 static void libdecorReadyCallback(void* userData,

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -670,7 +670,7 @@ EGLenum _glfwGetEGLPlatformWayland(EGLint** attribs);
 EGLNativeDisplayType _glfwGetEGLNativeDisplayWayland(void);
 EGLNativeWindowType _glfwGetEGLNativeWindowWayland(_GLFWwindow* window);
 
-void _glfwGetRequiredInstanceExtensionsWayland(char** extensions);
+void _glfwGetRequiredInstanceExtensionsWayland(const char** extensions);
 GLFWbool _glfwGetPhysicalDevicePresentationSupportWayland(VkInstance instance, VkPhysicalDevice device, uint32_t queuefamily);
 VkResult _glfwCreateWindowSurfaceWayland(VkInstance instance, _GLFWwindow* window, const VkAllocationCallbacks* allocator, VkSurfaceKHR* surface);
 

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -3207,7 +3207,7 @@ EGLNativeWindowType _glfwGetEGLNativeWindowWayland(_GLFWwindow* window)
     return window->wl.egl.window;
 }
 
-void _glfwGetRequiredInstanceExtensionsWayland(char** extensions)
+void _glfwGetRequiredInstanceExtensionsWayland(const char** extensions)
 {
     if (!_glfw.vk.KHR_surface || !_glfw.vk.KHR_wayland_surface)
         return;

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -474,8 +474,8 @@ static void surfaceHandleLeave(void* userData,
 
 static const struct wl_surface_listener surfaceListener =
 {
-    surfaceHandleEnter,
-    surfaceHandleLeave
+    .enter = surfaceHandleEnter,
+    .leave = surfaceHandleLeave
 };
 
 static void setIdleInhibitor(_GLFWwindow* window, GLFWbool enable)
@@ -616,8 +616,8 @@ static void xdgToplevelHandleClose(void* userData,
 
 static const struct xdg_toplevel_listener xdgToplevelListener =
 {
-    xdgToplevelHandleConfigure,
-    xdgToplevelHandleClose
+    .configure = xdgToplevelHandleConfigure,
+    .close = xdgToplevelHandleClose
 };
 
 static void xdgSurfaceHandleConfigure(void* userData,
@@ -791,10 +791,10 @@ void libdecorFrameHandleDismissPopup(struct libdecor_frame* frame,
 
 static const struct libdecor_frame_interface libdecorFrameInterface =
 {
-    libdecorFrameHandleConfigure,
-    libdecorFrameHandleClose,
-    libdecorFrameHandleCommit,
-    libdecorFrameHandleDismissPopup
+    .configure = libdecorFrameHandleConfigure,
+    .close = libdecorFrameHandleClose,
+    .commit = libdecorFrameHandleCommit,
+    .dismiss_popup = libdecorFrameHandleDismissPopup
 };
 
 static GLFWbool createLibdecorFrame(_GLFWwindow* window)
@@ -1144,7 +1144,7 @@ static GLFWbool flushDisplay(void)
         if (errno != EAGAIN)
             return GLFW_FALSE;
 
-        struct pollfd fd = { wl_display_get_fd(_glfw.wl.display), POLLOUT };
+        struct pollfd fd = { .fd = wl_display_get_fd(_glfw.wl.display), POLLOUT };
 
         while (poll(&fd, 1, -1) == -1)
         {
@@ -1624,11 +1624,11 @@ static void pointerHandleAxis(void* userData,
 
 static const struct wl_pointer_listener pointerListener =
 {
-    pointerHandleEnter,
-    pointerHandleLeave,
-    pointerHandleMotion,
-    pointerHandleButton,
-    pointerHandleAxis,
+    .enter = pointerHandleEnter,
+    .leave = pointerHandleLeave,
+    .motion = pointerHandleMotion,
+    .button = pointerHandleButton,
+    .axis = pointerHandleAxis,
 };
 
 static void keyboardHandleKeymap(void* userData,
@@ -1936,7 +1936,7 @@ static void dataOfferHandleOffer(void* userData,
 
 static const struct wl_data_offer_listener dataOfferListener =
 {
-    dataOfferHandleOffer
+    .offer = dataOfferHandleOffer
 };
 
 static void dataDeviceHandleDataOffer(void* userData,
@@ -1955,7 +1955,7 @@ static void dataDeviceHandleDataOffer(void* userData,
     _glfw.wl.offers = offers;
     _glfw.wl.offerCount++;
 
-    _glfw.wl.offers[_glfw.wl.offerCount - 1] = (_GLFWofferWayland) { offer };
+    _glfw.wl.offers[_glfw.wl.offerCount - 1] = (_GLFWofferWayland) { .offer = offer };
     wl_data_offer_add_listener(offer, &dataOfferListener, NULL);
 }
 
@@ -3131,9 +3131,9 @@ static void dataSourceHandleCancelled(void* userData,
 
 static const struct wl_data_source_listener dataSourceListener =
 {
-    dataSourceHandleTarget,
-    dataSourceHandleSend,
-    dataSourceHandleCancelled,
+    .target = dataSourceHandleTarget,
+    .send = dataSourceHandleSend,
+    .cancelled = dataSourceHandleCancelled,
 };
 
 void _glfwSetClipboardStringWayland(const char* string)

--- a/src/x11_init.c
+++ b/src/x11_init.c
@@ -366,7 +366,7 @@ static void createKeyTables(void)
             // keyboard layout. Because function keys aren't mapped correctly
             // when using traditional KeySym translations, they are mapped
             // here instead.
-            for (int i = 0;  i < sizeof(keymap) / sizeof(keymap[0]);  i++)
+            for (size_t i = 0;  i < sizeof(keymap) / sizeof(keymap[0]);  i++)
             {
                 if (strncmp(desc->names->keys[scancode].name,
                             keymap[i].name,
@@ -390,7 +390,7 @@ static void createKeyTables(void)
                     continue;
                 }
 
-                for (int j = 0;  j < sizeof(keymap) / sizeof(keymap[0]);  j++)
+                for (size_t j = 0;  j < sizeof(keymap) / sizeof(keymap[0]);  j++)
                 {
                     if (strncmp(desc->names->key_aliases[i].alias,
                                 keymap[j].name,

--- a/src/x11_init.c
+++ b/src/x11_init.c
@@ -231,7 +231,7 @@ static void createKeyTables(void)
         const struct
         {
             int key;
-            char* name;
+            const char* name;
         } keymap[] =
         {
             { GLFW_KEY_GRAVE_ACCENT, "TLDE" },

--- a/src/x11_monitor.c
+++ b/src/x11_monitor.c
@@ -179,8 +179,8 @@ void _glfwPollMonitorsX11(void)
             {
                 if (screens[j].x_org == ci->x &&
                     screens[j].y_org == ci->y &&
-                    screens[j].width == ci->width &&
-                    screens[j].height == ci->height)
+                    screens[j].width == (int)ci->width &&
+                    screens[j].height == (int)ci->height)
                 {
                     monitor->x11.index = j;
                     break;
@@ -572,7 +572,7 @@ void _glfwSetGammaRampX11(_GLFWmonitor* monitor, const GLFWgammaramp* ramp)
 {
     if (_glfw.x11.randr.available && !_glfw.x11.randr.gammaBroken)
     {
-        if (XRRGetCrtcGammaSize(_glfw.x11.display, monitor->x11.crtc) != ramp->size)
+        if (XRRGetCrtcGammaSize(_glfw.x11.display, monitor->x11.crtc) != (int)ramp->size)
         {
             _glfwInputError(GLFW_PLATFORM_ERROR,
                             "X11: Gamma ramp size must match current ramp size");

--- a/src/x11_platform.h
+++ b/src/x11_platform.h
@@ -959,7 +959,7 @@ EGLenum _glfwGetEGLPlatformX11(EGLint** attribs);
 EGLNativeDisplayType _glfwGetEGLNativeDisplayX11(void);
 EGLNativeWindowType _glfwGetEGLNativeWindowX11(_GLFWwindow* window);
 
-void _glfwGetRequiredInstanceExtensionsX11(char** extensions);
+void _glfwGetRequiredInstanceExtensionsX11(const char** extensions);
 GLFWbool _glfwGetPhysicalDevicePresentationSupportX11(VkInstance instance, VkPhysicalDevice device, uint32_t queuefamily);
 VkResult _glfwCreateWindowSurfaceX11(VkInstance instance, _GLFWwindow* window, const VkAllocationCallbacks* allocator, VkSurfaceKHR* surface);
 

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -3133,7 +3133,7 @@ EGLNativeWindowType _glfwGetEGLNativeWindowX11(_GLFWwindow* window)
         return (EGLNativeWindowType) window->x11.handle;
 }
 
-void _glfwGetRequiredInstanceExtensionsX11(char** extensions)
+void _glfwGetRequiredInstanceExtensionsX11(const char** extensions)
 {
     if (!_glfw.vk.KHR_surface)
         return;

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -62,7 +62,7 @@
 //
 static GLFWbool waitForX11Event(double* timeout)
 {
-    struct pollfd fd = { ConnectionNumber(_glfw.x11.display), POLLIN };
+    struct pollfd fd = { .fd = ConnectionNumber(_glfw.x11.display), .events = POLLIN };
 
     while (!XPending(_glfw.x11.display))
     {

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -97,7 +97,7 @@ static GLFWbool waitForAnyEvent(double* timeout)
         if (!_glfwPollPOSIX(fds, sizeof(fds) / sizeof(fds[0]), timeout))
             return GLFW_FALSE;
 
-        for (int i = 1; i < sizeof(fds) / sizeof(fds[0]); i++)
+        for (size_t i = 1; i < sizeof(fds) / sizeof(fds[0]); i++)
         {
             if (fds[i].revents & POLLIN)
                 return GLFW_TRUE;
@@ -235,10 +235,10 @@ static int translateState(int state)
 
 // Translates an X11 key code to a GLFW key token
 //
-static int translateKey(int scancode)
+static int translateKey(unsigned int scancode)
 {
     // Use the pre-filled LUT (see createKeyTables() in x11_init.c)
-    if (scancode < 0 || scancode > 255)
+    if (scancode > 255)
         return GLFW_KEY_UNKNOWN;
 
     return _glfw.x11.keycodes[scancode];
@@ -1145,7 +1145,7 @@ static void releaseMonitor(_GLFWwindow* window)
 //
 static void processEvent(XEvent *event)
 {
-    int keycode = 0;
+    unsigned int keycode = 0;
     Bool filtered = False;
 
     // HACK: Save scancode as some IMs clear the field in XFilterEvent


### PR DESCRIPTION
I'm used to strict & pedantic warnings in my projects, and I really appreciate the work done with `v3.4`. However, some warnings are off with GCC. The aim of this pull-request is to fix the as much as possible (a couple are still missing).