### PR TITLE
fix: disable dinput8 to fix startup delay

### DIFF
--- a/src/win32_init.c
+++ b/src/win32_init.c
@@ -104,7 +104,6 @@ static GLFWbool loadLibraries(void)
     _glfw.win32.user32.GetSystemMetricsForDpi_ = (PFN_GetSystemMetricsForDpi)
         _glfwPlatformGetModuleSymbol(_glfw.win32.user32.instance, "GetSystemMetricsForDpi");
 
-    _glfw.win32.dinput8.instance = _glfwPlatformLoadModule("dinput8.dll");
     if (_glfw.win32.dinput8.instance)
     {
         _glfw.win32.dinput8.Create = (PFN_DirectInput8Create)


### PR DESCRIPTION
Some HID devices block DirectInput8 device enumeration for many seconds which adversely affects software that uses GLFW without needing joysticks at all.

This change vendors the build of GLFW3 with a patch that skips loading of the `dinput8` library and thus disables all functionality that checks for its availability.