### PR TITLE
added missing GLFWAPI for glfwDefaultHints()

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -253,7 +253,7 @@ GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height,
     return (GLFWwindow*) window;
 }
 
-void glfwDefaultWindowHints(void)
+GLFWAPI void glfwDefaultWindowHints(void)
 {
     _GLFW_REQUIRE_INIT();
 


### PR DESCRIPTION
I saw that this macro was missing. It should not have much effect as it's probably added in by the declaration in the inclusion of the header above, but just for correctness it should be the same as the others.