### PR TITLE
Added ability to override `canBecomeMain/KeyWindow`

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -929,6 +929,18 @@ extern "C" {
  */
 #define GLFW_MOUSE_PASSTHROUGH      0x0002000D
 
+/*! @brief Window can become the main window
+ *
+ * Only honored with Cocoa backend
+ */
+#define GLFW_CAN_BECOME_MAIN        0x00020010
+
+/*! @brief Window can receive key inputs
+ *
+ * Only honored with Cocoa backend
+ */
+#define GLFW_CAN_BECOME_KEY         0x00020011
+
 /*! @brief Initial position x-coordinate window hint.
  *
  *  Initial position x-coordinate [window hint](@ref GLFW_POSITION_X).

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -752,19 +752,19 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
 //------------------------------------------------------------------------
 
 @interface GLFWWindow : NSWindow {}
+@property _GLFWwindow* glfwWindow;
 @end
 
 @implementation GLFWWindow
 
 - (BOOL)canBecomeKeyWindow
 {
-    // Required for NSWindowStyleMaskBorderless windows
-    return YES;
+    return self.glfwWindow->canBecomeKey;
 }
 
 - (BOOL)canBecomeMainWindow
 {
-    return YES;
+    return self.glfwWindow->canBecomeMain;
 }
 
 @end
@@ -834,6 +834,8 @@ static GLFWbool createNativeWindow(_GLFWwindow* window,
         _glfwInputError(GLFW_PLATFORM_ERROR, "Cocoa: Failed to create window");
         return GLFW_FALSE;
     }
+
+    ((GLFWWindow*)window->ns.object).glfwWindow = window;
 
     if (window->monitor)
         [window->ns.object setLevel:NSMainMenuWindowLevel + 1];

--- a/src/internal.h
+++ b/src/internal.h
@@ -413,6 +413,8 @@ struct _GLFWwndconfig
     GLFWbool      centerCursor;
     GLFWbool      focusOnShow;
     GLFWbool      mousePassthrough;
+    GLFWbool      canBecomeMain;
+    GLFWbool      canBecomeKey;
     GLFWbool      scaleToMonitor;
     GLFWbool      scaleFramebuffer;
     struct {
@@ -538,6 +540,8 @@ struct _GLFWwindow
     GLFWbool            floating;
     GLFWbool            focusOnShow;
     GLFWbool            mousePassthrough;
+    GLFWbool            canBecomeMain;
+    GLFWbool            canBecomeKey;
     GLFWbool            shouldClose;
     void*               userPointer;
     GLFWbool            doublebuffer;

--- a/src/window.c
+++ b/src/window.c
@@ -232,6 +232,8 @@ GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height,
     window->floating         = wndconfig.floating;
     window->focusOnShow      = wndconfig.focusOnShow;
     window->mousePassthrough = wndconfig.mousePassthrough;
+    window->canBecomeMain    = wndconfig.canBecomeMain;
+    window->canBecomeKey     = wndconfig.canBecomeKey;
     window->cursorMode       = GLFW_CURSOR_NORMAL;
 
     window->doublebuffer = fbconfig.doublebuffer;
@@ -397,6 +399,12 @@ GLFWAPI void glfwWindowHint(int hint, int value)
             return;
         case GLFW_MOUSE_PASSTHROUGH:
             _glfw.hints.window.mousePassthrough = value ? GLFW_TRUE : GLFW_FALSE;
+            return;
+        case GLFW_CAN_BECOME_MAIN:
+            _glfw.hints.window.canBecomeMain = value ? GLFW_TRUE : GLFW_FALSE;
+            return;
+        case GLFW_CAN_BECOME_KEY:
+            _glfw.hints.window.canBecomeKey = value ? GLFW_TRUE : GLFW_FALSE;
             return;
         case GLFW_CLIENT_API:
             _glfw.hints.context.client = value;
@@ -900,6 +908,10 @@ GLFWAPI int glfwGetWindowAttrib(GLFWwindow* handle, int attrib)
             return window->focusOnShow;
         case GLFW_MOUSE_PASSTHROUGH:
             return window->mousePassthrough;
+        case GLFW_CAN_BECOME_MAIN:
+            return window->canBecomeMain;
+        case GLFW_CAN_BECOME_KEY:
+            return window->canBecomeKey;
         case GLFW_TRANSPARENT_FRAMEBUFFER:
             return _glfw.platform.framebufferTransparent(window);
         case GLFW_RESIZABLE:
@@ -980,6 +992,14 @@ GLFWAPI void glfwSetWindowAttrib(GLFWwindow* handle, int attrib, int value)
         case GLFW_MOUSE_PASSTHROUGH:
             window->mousePassthrough = value;
             _glfw.platform.setWindowMousePassthrough(window, value);
+            return;
+
+        case GLFW_CAN_BECOME_MAIN:
+            window->canBecomeMain = value;
+            return;
+
+        case GLFW_CAN_BECOME_KEY:
+            window->canBecomeKey = value;
             return;
     }
 


### PR DESCRIPTION
I need to override this for my application. Therefore I added these two options as window hints to the API. I'm not sure if this is what you want for the public API because it's quite backend specific, but I thought I'd propose it anyhow. If you like the idea but would prefer a different implementation just tell me I could do that.