### PR TITLE
X11: enable Apple support

### DIFF
--- a/src/egl_context.c
+++ b/src/egl_context.c
@@ -372,7 +372,7 @@ GLFWbool _glfwInitEGL(void)
 #elif defined(_GLFW_WIN32)
         "libEGL.dll",
         "EGL.dll",
-#elif defined(_GLFW_COCOA)
+#elif defined(__APPLE__)
         "libEGL.dylib",
 #elif defined(__CYGWIN__)
         "libEGL-1.so",
@@ -771,7 +771,7 @@ GLFWbool _glfwCreateContextEGL(_GLFWwindow* window,
 #elif defined(_GLFW_WIN32)
             "GLESv1_CM.dll",
             "libGLES_CM.dll",
-#elif defined(_GLFW_COCOA)
+#elif defined(__APPLE__)
             "libGLESv1_CM.dylib",
 #elif defined(__OpenBSD__) || defined(__NetBSD__)
             "libGLESv1_CM.so",
@@ -788,7 +788,7 @@ GLFWbool _glfwCreateContextEGL(_GLFWwindow* window,
 #elif defined(_GLFW_WIN32)
             "GLESv2.dll",
             "libGLESv2.dll",
-#elif defined(_GLFW_COCOA)
+#elif defined(__APPLE__)
             "libGLESv2.dylib",
 #elif defined(__CYGWIN__)
             "libGLESv2-2.so",
@@ -804,7 +804,8 @@ GLFWbool _glfwCreateContextEGL(_GLFWwindow* window,
 #if defined(_GLFW_OPENGL_LIBRARY)
             _GLFW_OPENGL_LIBRARY,
 #elif defined(_GLFW_WIN32)
-#elif defined(_GLFW_COCOA)
+#elif defined(__APPLE__)
+            "libGL.1.dylib",
 #elif defined(__OpenBSD__) || defined(__NetBSD__)
             "libGL.so",
 #else

--- a/src/glx_context.c
+++ b/src/glx_context.c
@@ -263,6 +263,8 @@ GLFWbool _glfwInitGLX(void)
         _GLFW_GLX_LIBRARY,
 #elif defined(__CYGWIN__)
         "libGL-1.so",
+#elif defined(__APPLE__)
+        "libGL.1.dylib",
 #elif defined(__OpenBSD__) || defined(__NetBSD__)
         "libGL.so",
 #else

--- a/src/vulkan.c
+++ b/src/vulkan.c
@@ -57,10 +57,12 @@ GLFWbool _glfwInitVulkan(int mode)
         _glfw.vk.handle = _glfwPlatformLoadModule(_GLFW_VULKAN_LIBRARY);
 #elif defined(_GLFW_WIN32)
         _glfw.vk.handle = _glfwPlatformLoadModule("vulkan-1.dll");
-#elif defined(_GLFW_COCOA)
+#elif defined(__APPLE__)
         _glfw.vk.handle = _glfwPlatformLoadModule("libvulkan.1.dylib");
+#if defined(_GLFW_COCOA)
         if (!_glfw.vk.handle)
             _glfw.vk.handle = _glfwLoadLocalVulkanLoaderCocoa();
+#endif
 #elif defined(__OpenBSD__) || defined(__NetBSD__)
         _glfw.vk.handle = _glfwPlatformLoadModule("libvulkan.so");
 #else

--- a/src/x11_init.c
+++ b/src/x11_init.c
@@ -606,6 +606,8 @@ static GLFWbool initExtensions(void)
 {
 #if defined(__OpenBSD__) || defined(__NetBSD__)
     _glfw.x11.vidmode.handle = _glfwPlatformLoadModule("libXxf86vm.so");
+#elif defined(__APPLE__)
+    _glfw.x11.vidmode.handle = _glfwPlatformLoadModule("libXxf86vm.1.dylib");
 #else
     _glfw.x11.vidmode.handle = _glfwPlatformLoadModule("libXxf86vm.so.1");
 #endif
@@ -630,6 +632,8 @@ static GLFWbool initExtensions(void)
     _glfw.x11.xi.handle = _glfwPlatformLoadModule("libXi-6.so");
 #elif defined(__OpenBSD__) || defined(__NetBSD__)
     _glfw.x11.xi.handle = _glfwPlatformLoadModule("libXi.so");
+#elif defined(__APPLE__)
+    _glfw.x11.xi.handle = _glfwPlatformLoadModule("libXi.6.dylib");
 #else
     _glfw.x11.xi.handle = _glfwPlatformLoadModule("libXi.so.6");
 #endif
@@ -662,6 +666,8 @@ static GLFWbool initExtensions(void)
     _glfw.x11.randr.handle = _glfwPlatformLoadModule("libXrandr-2.so");
 #elif defined(__OpenBSD__) || defined(__NetBSD__)
     _glfw.x11.randr.handle = _glfwPlatformLoadModule("libXrandr.so");
+#elif defined(__APPLE__)
+    _glfw.x11.randr.handle = _glfwPlatformLoadModule("libXrandr.2.dylib");
 #else
     _glfw.x11.randr.handle = _glfwPlatformLoadModule("libXrandr.so.2");
 #endif
@@ -756,6 +762,8 @@ static GLFWbool initExtensions(void)
     _glfw.x11.xcursor.handle = _glfwPlatformLoadModule("libXcursor-1.so");
 #elif defined(__OpenBSD__) || defined(__NetBSD__)
     _glfw.x11.xcursor.handle = _glfwPlatformLoadModule("libXcursor.so");
+#elif defined(__APPLE__)
+    _glfw.x11.xcursor.handle = _glfwPlatformLoadModule("libXcursor.1.dylib");
 #else
     _glfw.x11.xcursor.handle = _glfwPlatformLoadModule("libXcursor.so.1");
 #endif
@@ -779,6 +787,8 @@ static GLFWbool initExtensions(void)
     _glfw.x11.xinerama.handle = _glfwPlatformLoadModule("libXinerama-1.so");
 #elif defined(__OpenBSD__) || defined(__NetBSD__)
     _glfw.x11.xinerama.handle = _glfwPlatformLoadModule("libXinerama.so");
+#elif defined(__APPLE__)
+    _glfw.x11.xinerama.handle = _glfwPlatformLoadModule("libXinerama.1.dylib");
 #else
     _glfw.x11.xinerama.handle = _glfwPlatformLoadModule("libXinerama.so.1");
 #endif
@@ -834,6 +844,8 @@ static GLFWbool initExtensions(void)
         _glfw.x11.x11xcb.handle = _glfwPlatformLoadModule("libX11-xcb-1.so");
 #elif defined(__OpenBSD__) || defined(__NetBSD__)
         _glfw.x11.x11xcb.handle = _glfwPlatformLoadModule("libX11-xcb.so");
+#elif defined(__APPLE__)
+        _glfw.x11.x11xcb.handle = _glfwPlatformLoadModule("libX11-xcb.1.dylib");
 #else
         _glfw.x11.x11xcb.handle = _glfwPlatformLoadModule("libX11-xcb.so.1");
 #endif
@@ -849,6 +861,8 @@ static GLFWbool initExtensions(void)
     _glfw.x11.xrender.handle = _glfwPlatformLoadModule("libXrender-1.so");
 #elif defined(__OpenBSD__) || defined(__NetBSD__)
     _glfw.x11.xrender.handle = _glfwPlatformLoadModule("libXrender.so");
+#elif defined(__APPLE__)
+    _glfw.x11.xrender.handle = _glfwPlatformLoadModule("libXrender.1.dylib");
 #else
     _glfw.x11.xrender.handle = _glfwPlatformLoadModule("libXrender.so.1");
 #endif
@@ -878,6 +892,8 @@ static GLFWbool initExtensions(void)
     _glfw.x11.xshape.handle = _glfwPlatformLoadModule("libXext-6.so");
 #elif defined(__OpenBSD__) || defined(__NetBSD__)
     _glfw.x11.xshape.handle = _glfwPlatformLoadModule("libXext.so");
+#elif defined(__APPLE__)
+    _glfw.x11.xshape.handle = _glfwPlatformLoadModule("libXext.6.dylib");
 #else
     _glfw.x11.xshape.handle = _glfwPlatformLoadModule("libXext.so.6");
 #endif
@@ -1259,6 +1275,8 @@ GLFWbool _glfwConnectX11(int platformID, _GLFWplatform* platform)
     void* module = _glfwPlatformLoadModule("libX11-6.so");
 #elif defined(__OpenBSD__) || defined(__NetBSD__)
     void* module = _glfwPlatformLoadModule("libX11.so");
+#elif defined(__APPLE__)
+    void* module = _glfwPlatformLoadModule("libX11.6.dylib");
 #else
     void* module = _glfwPlatformLoadModule("libX11.so.6");
 #endif


### PR DESCRIPTION
Summary of changes:
* Replace instances of `_GLFW_COCOA` with `__APPLE__` where it makes more sense.
* Let X11 code dlopen `.dylib` files when building for Apple platforms.

These changes allow OpenGL 4.6/GLFW programs to run on XQuartz/LLVMpipe with a modified glad.c.