### PR TITLE
bugfix glx driver get egl non-null

### DIFF
--- a/src/glx_context.c
+++ b/src/glx_context.c
@@ -222,6 +222,11 @@ static int extensionSupportedGLX(const char* extension)
 
 static GLFWglproc getProcAddressGLX(const char* procname)
 {
+    // Avoid calling glXGetProcAddress() for EGL procs.
+    // We don't expect it to ever succeed, but somtimes it returns non-null anyway.
+    if (0 == strncmp(procname, "egl", 3)) {
+        return NULL;
+    }
     if (_glfw.glx.GetProcAddress)
         return _glfw.glx.GetProcAddress((const GLubyte*) procname);
     else if (_glfw.glx.GetProcAddressARB)


### PR DESCRIPTION
When using the glx driver to dynamically obtain egl related functions by  glxGetProcAddress function, should return null. But, sometimes it may not return a null in some desktop computer, leading to abnormal judgment of subsequent related operations