### PR TITLE
Wayland: Fix key repeat

### DIFF
--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -1796,10 +1796,11 @@ static void keyboardHandleKey(void* userData,
 
             timer.it_value.tv_sec = _glfw.wl.keyRepeatDelay / 1000;
             timer.it_value.tv_nsec = (_glfw.wl.keyRepeatDelay % 1000) * 1000000;
+            timerfd_settime(_glfw.wl.keyRepeatTimerfd, 0, &timer, NULL);
         }
+    } else if (scancode == _glfw.wl.keyRepeatScancode) {
+        timerfd_settime(_glfw.wl.keyRepeatTimerfd, 0, &timer, NULL);
     }
-
-    timerfd_settime(_glfw.wl.keyRepeatTimerfd, 0, &timer, NULL);
 
     _glfwInputKey(window, key, scancode, action, _glfw.wl.xkb.modifiers);
 


### PR DESCRIPTION
Key repeat shoud only be interrupted when the repeating key is released, not when another key is released.

This matches the behavior on X11 (and also on win32 if my memory serves me right).