### PR TITLE
Wayland: let the compositor decide which screen to use for fullscreen operations

### DIFF
--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -503,12 +503,12 @@ static void acquireMonitor(_GLFWwindow* window)
     if (window->wl.libdecor.frame)
     {
         libdecor_frame_set_fullscreen(window->wl.libdecor.frame,
-                                      window->monitor->wl.output);
+                                      NULL);
     }
     else if (window->wl.xdg.toplevel)
     {
         xdg_toplevel_set_fullscreen(window->wl.xdg.toplevel,
-                                    window->monitor->wl.output);
+                                    NULL);
     }
 
     setIdleInhibitor(window, GLFW_TRUE);
@@ -849,7 +849,7 @@ static GLFWbool createLibdecorFrame(_GLFWwindow* window)
     if (window->monitor)
     {
         libdecor_frame_set_fullscreen(window->wl.libdecor.frame,
-                                      window->monitor->wl.output);
+                                      NULL);
         setIdleInhibitor(window, GLFW_TRUE);
     }
     else
@@ -942,7 +942,7 @@ static GLFWbool createXdgShellObjects(_GLFWwindow* window)
 
     if (window->monitor)
     {
-        xdg_toplevel_set_fullscreen(window->wl.xdg.toplevel, window->monitor->wl.output);
+        xdg_toplevel_set_fullscreen(window->wl.xdg.toplevel, NULL);
         setIdleInhibitor(window, GLFW_TRUE);
     }
     else


### PR DESCRIPTION
Wayland doesn't have a concept of primary/preferred display. By default, GLFW assuming that first reported wl_output is the primary screen, but that's [not](https://bugs.kde.org/show_bug.cgi?id=489135) [true](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/issues/179). I've made a simple workaround that unsets wl_output from `xdg_toplevel_set_fullscreen` requests. That'll make the compositor decide on which screen fullscreen application must go.