### PR TITLE
Fix out of bounds joystick read on Linux

### DIFF
--- a/src/linux_joystick.c
+++ b/src/linux_joystick.c
@@ -190,7 +190,10 @@ static GLFWbool openJoystickDevice(const char* path)
 
     int axisCount = 0, buttonCount = 0, hatCount = 0;
 
-    for (int code = BTN_MISC;  code < KEY_CNT;  code++)
+    // This loop should stop at KEY_CNT instead of KEY_MAX. However, we are
+    // terminating the loop one iteration early to maintain compatibility with
+    // the SDL gamepad mappings.
+    for (int code = BTN_JOYSTICK;  code < KEY_MAX;  code++)
     {
         if (!isBitSet(code, keyBits))
             continue;
@@ -199,7 +202,11 @@ static GLFWbool openJoystickDevice(const char* path)
         buttonCount++;
     }
 
-    for (int code = 0;  code < BTN_MISC;  code++)
+    // Originally, this range was not mapped, but some controllers now output
+    // these values. Appending them to the end of the list maintains both
+    // backwards compatibility with older versions of GLFW, and with the SDL
+    // gamepad mappings.
+    for (int code = 0;  code < BTN_JOYSTICK;  code++)
     {
         if (!isBitSet(code, keyBits))
             continue;

--- a/src/linux_joystick.c
+++ b/src/linux_joystick.c
@@ -49,9 +49,8 @@
 //
 static void handleKeyEvent(_GLFWjoystick* js, int code, int value)
 {
-    if (code < BTN_MISC || code >= KEY_CNT - BTN_MISC) return;
     _glfwInputJoystickButton(js,
-                             js->linjs.keyMap[code - BTN_MISC],
+                             js->linjs.keyMap[code],
                              value ? GLFW_PRESS : GLFW_RELEASE);
 }
 
@@ -59,7 +58,6 @@ static void handleKeyEvent(_GLFWjoystick* js, int code, int value)
 //
 static void handleAbsEvent(_GLFWjoystick* js, int code, int value)
 {
-    if (code >= ABS_CNT) return;
     const int index = js->linjs.absMap[code];
 
     if (code >= ABS_HAT0X && code <= ABS_HAT3Y)
@@ -197,7 +195,16 @@ static GLFWbool openJoystickDevice(const char* path)
         if (!isBitSet(code, keyBits))
             continue;
 
-        linjs.keyMap[code - BTN_MISC] = buttonCount;
+        linjs.keyMap[code] = buttonCount;
+        buttonCount++;
+    }
+
+    for (int code = 0;  code < BTN_MISC;  code++)
+    {
+        if (!isBitSet(code, keyBits))
+            continue;
+
+        linjs.keyMap[code] = buttonCount;
         buttonCount++;
     }
 

--- a/src/linux_joystick.c
+++ b/src/linux_joystick.c
@@ -49,6 +49,7 @@
 //
 static void handleKeyEvent(_GLFWjoystick* js, int code, int value)
 {
+    if (code < BTN_MISC || code >= KEY_CNT - BTN_MISC) return;
     _glfwInputJoystickButton(js,
                              js->linjs.keyMap[code - BTN_MISC],
                              value ? GLFW_PRESS : GLFW_RELEASE);
@@ -58,6 +59,7 @@ static void handleKeyEvent(_GLFWjoystick* js, int code, int value)
 //
 static void handleAbsEvent(_GLFWjoystick* js, int code, int value)
 {
+    if (code >= ABS_CNT) return;
     const int index = js->linjs.absMap[code];
 
     if (code >= ABS_HAT0X && code <= ABS_HAT3Y)

--- a/src/linux_joystick.h
+++ b/src/linux_joystick.h
@@ -37,7 +37,7 @@ typedef struct _GLFWjoystickLinux
 {
     int                     fd;
     char                    path[PATH_MAX];
-    int                     keyMap[KEY_CNT - BTN_MISC];
+    int                     keyMap[KEY_CNT];
     int                     absMap[ABS_CNT];
     struct input_absinfo    absInfo[ABS_CNT];
     int                     hats[4][2];


### PR DESCRIPTION
The Xbox Series X controller has a new button ("share") directly under the Xbox button. For whatever reason, it outputs a value lower than `BTN_MISC`, resulting in this index into `keyMap` being negative:

```c
_glfwInputJoystickButton(js,
                         js->linjs.keyMap[code - BTN_MISC],
                         value ? GLFW_PRESS : GLFW_RELEASE);
```

## Initial fix
My first commit just added a bounds check to prevent the undefined behavior. This resolved the UB, but didn't actually do anything to make the button usable.

In the second commit, I added the missing range to the *end* of the key map array. This allows us to report the button press, without changing the indices of any existing already working buttons.

## Possibly controversial adjustment
After making the above changes, it occurred to me--if GLFW is skipping a button at the beginning of the list, how is its numbering scheme compatible with the SDL game controller database?

I took a look at SDL's source, and it turns out they had to make almost exactly the same patch to address this.

However, in looking at SDL's source, I spotted two possible incompatibilities between their numbering scheme and GLFW's that would affect us if a device used very specific codes as buttons:
1. SDL's original iteration started at `BTN_JOYSTICK` (0x120), GLFW's started at `BTN_MISC` (0x100). I guess technically nobody was right since apparently we need to start at 0 now.
2. SDL ends iteration before reaching `KEY_MAX` instead of `KEY_CNT`. This is an off by one error on SDL's part, GLFW handles this correctly.

I imagine the most important use case for the joystick mappings is compatibility with the SDL game controller database. As such, this might be more controversial, but in the third commit I changed GLFW's iteration to be in line with SDL's (mistakes included.)

As a result:
* **No existing mappings in the controller database that worked previously with GLFW will be affected by this change**
* Joystick button codes between `BTN_JOYSTICK` (0x120) and `BTN_MISC` (0x100) will change indices
* The very final button code will no longer work (sad, but, it doesn't work in SDL either, if we map it here and it happens to be present it will offset the lower range breaking compat with SDL mappings)

## Thoughts

IMO it's worth merging the whole PR despite the listed downsides.

If you're hesitant though, you're welcome to merge only the first two commits instead. I don't feel strongly since all I personally care about are the controller mappings, and all the existing controller mappings will behave identically regardless.