### PR TITLE
EGL: GLFW_ANGLE_PLATFORM_TYPE_VULKAN on macOS

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -294,6 +294,7 @@ video tutorials.
  - Jonas Ådahl
  - Lasse Öörni
  - Leonard König
+ - nee-wom
  - All the unmentioned and anonymous contributors in the GLFW community, for bug
    reports, patches, feedback, testing and encouragement
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ information on what to include when reporting a bug.
  - [Null] Added EGL context creation on Mesa via `EGL_MESA_platform_surfaceless`
  - [EGL] Allowed native access on Wayland with `GLFW_CONTEXT_CREATION_API` set to
    `GLFW_NATIVE_CONTEXT_API` (#2518)
+ - [EGL] Enabled init hint parameter `GLFW_ANGLE_PLATFORM_TYPE_VULKAN` for macOS
 
 
 ## Contact

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -1899,6 +1899,12 @@ EGLenum _glfwGetEGLPlatformCocoa(EGLint** attribs)
                 type = EGL_PLATFORM_ANGLE_TYPE_METAL_ANGLE;
         }
 
+        if (_glfw.egl.ANGLE_platform_angle_vulkan)
+        {
+            if (_glfw.hints.init.angleType == GLFW_ANGLE_PLATFORM_TYPE_VULKAN)
+                type = EGL_PLATFORM_ANGLE_TYPE_VULKAN_ANGLE;
+        }
+
         if (type)
         {
             *attribs = _glfw_calloc(3, sizeof(EGLint));


### PR DESCRIPTION
ANGLE vulkan backend is available for macOS and supports OpenGL ES 3.1 (both metal and OpenGL backends are limited to ES 3.0)