### PR TITLE
X11: Free the error handle whern returing early in detectEWMH

### DIFF
--- a/src/x11_init.c
+++ b/src/x11_init.c
@@ -535,6 +535,7 @@ static void detectEWMH(void)
                                    XA_WINDOW,
                                    (unsigned char**) &windowFromChild))
     {
+        _glfwReleaseErrorHandlerX11();
         XFree(windowFromRoot);
         return;
     }


### PR DESCRIPTION
# What this PR does:
It frees the X11 error context when returning in `detectEWMH`.

# Background:
Recently, I've noticed that all programs using GLFW were crashing on my system. I tried tracing the error and found out it was being casued by the assertion [here](https://github.com/glfw/glfw/blob/b35641f4a3c62aa86a0b3c983d163bc0fe36026d/src/x11_init.c#L1099) failing. After some more digging, I found out that this was being casued by `detectEWMH` returning early without freeing the error context [here](https://github.com/glfw/glfw/blob/b35641f4a3c62aa86a0b3c983d163bc0fe36026d/src/x11_init.c#L539). I still don't know why this is only happening on my system, but I'm guessing this is an issue that should be fixed anyway.

## My system info:
I'm not sure if this is relevant, but here's my system info for the sake of completeness:
- OS: Arch Linux (kernel 6.6.36-1-lts)
- APU: AMD Ryzen 7 5700U with Radeon Graphics

