### PR TITLE
macOS EGL: fixed initial layer contents scale

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -942,6 +942,8 @@ GLFWbool _glfwCreateWindowCocoa(_GLFWwindow* window,
             // need to get the layer for EGL window surface creation.
             [window->ns.view setWantsLayer:YES];
             window->ns.layer = [window->ns.view layer];
+            if (window->ns.scaleFramebuffer && window->ns.layer)
+                [window->ns.layer setContentsScale:[window->ns.object backingScaleFactor]];
 
             if (!_glfwInitEGL())
                 return GLFW_FALSE;


### PR DESCRIPTION
The initial event `viewDidChangeBackingProperties` arrives before the layer is attached to the view.
Hence the layer keeps its default scale, which is not always correct.