### PR TITLE
Fix resource leak (error handler)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -294,6 +294,7 @@ video tutorials.
  - Jonas Ådahl
  - Lasse Öörni
  - Leonard König
+ - Collin Bell
  - All the unmentioned and anonymous contributors in the GLFW community, for bug
    reports, patches, feedback, testing and encouragement
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ information on what to include when reporting a bug.
  - [Null] Added EGL context creation on Mesa via `EGL_MESA_platform_surfaceless`
  - [EGL] Allowed native access on Wayland with `GLFW_CONTEXT_CREATION_API` set to
    `GLFW_NATIVE_CONTEXT_API` (#2518)
+ - Patch resource leak of errorHandler in detectEWMH
 
 
 ## Contact

--- a/src/x11_init.c
+++ b/src/x11_init.c
@@ -535,6 +535,7 @@ static void detectEWMH(void)
                                    XA_WINDOW,
                                    (unsigned char**) &windowFromChild))
     {
+        _glfwReleaseErrorHandlerX11();
         XFree(windowFromRoot);
         return;
     }


### PR DESCRIPTION
See #2601. The early return in detectEWMH is leaking the error handler resource. This is a problem for window manager developers.