### PR TITLE
Pluggable clipboard functionality on X11

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -294,6 +294,7 @@ video tutorials.
  - Jonas Ådahl
  - Lasse Öörni
  - Leonard König
+ - Alex Sanchez-Stern
  - All the unmentioned and anonymous contributors in the GLFW community, for bug
    reports, patches, feedback, testing and encouragement
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,11 @@ information on what to include when reporting a bug.
  - [Null] Added EGL context creation on Mesa via `EGL_MESA_platform_surfaceless`
  - [EGL] Allowed native access on Wayland with `GLFW_CONTEXT_CREATION_API` set to
    `GLFW_NATIVE_CONTEXT_API` (#2518)
-
+ - [X11] Added `getSelectionRequestHandler`, `setSelectionRequestHander`,
+   `getGLFWDisplay`, and `getGLFWHelperWindow` functions. to allow
+   clients to implement more X clipboard functionality than is
+   built-in; with these primitives clients can add copy paste support
+   for files, images, colors, and other non-text data types.
 
 ## Contact
 
@@ -148,4 +152,3 @@ request, please file it in the
 
 Finally, if you're interested in helping out with the development of GLFW or
 porting it to your favorite platform, join us on the forum or GitHub.
-

--- a/docs/input.md
+++ b/docs/input.md
@@ -973,6 +973,53 @@ The contents of the system clipboard can be set to a UTF-8 encoded string with
 glfwSetClipboardString(NULL, "A string with words in it");
 ```
 
+\par Advanced Usage
+While GLFW does not directly support using other data types with the
+system clipboard, on many platforms this is possible using platform
+specific code. If you are primarily targetting a small set of
+platforms, this may be viable for your application.
+
+\par
+On Windows, you can do clipboard operations directly using <a
+href="https://learn.microsoft.com/en-us/windows/win32/api/winuser/">winuser.h</a>,
+allowing you to copy and paste datatypes other than text. On X11 you
+can also use the platform specific API to get this functionality, but
+you must hook into GLFW's X11 event handling code to allow copying
+<i>out</i> of your application. Example code for most of this functionality
+can be found in general X11 documentation like <a
+href="http://www.uninformativ.de/blog/postings/2017-04-02/0/POSTING-en.html">this
+page</a>; the GLFW-specific part is including
+
+\par
+@code
+#include <GLFW/glfw3.h>
+#include <X11/Xlib.h>
+#define GLFW_EXPOSE_NATIVE_X11
+#include <GLFW/glfw3native.h>
+@endcode
+
+\par
+At the top of your file (guarded by platform), and then running
+
+\par
+@code
+setSelectionRequestHandler(myHandler);
+@endcode
+
+\par
+on initialization. Your selection handler must have the signature:
+
+\par
+@code
+void myHandler(XEvent*);
+@endcode
+
+\par
+and it will receive all X Selection events. To ensure compatibility
+use `getGLFWDisplay()` to get a display object instead of
+`XOpenDisplay()` and use the result of `getGLFWHelperWindow()` as the
+target window for the selection.
+
 
 ## Path drop input {#path_drop}
 

--- a/docs/news.md
+++ b/docs/news.md
@@ -14,6 +14,25 @@ values over 8. For compatibility with older versions, the
 @ref GLFW_UNLIMITED_MOUSE_BUTTONS input mode needs to be set to make use of
 this.
 
+
+### Support for custom X11 clipboard functionality {#x11_custom_selection}
+
+This change allows clients to implement custom X11 clipboard
+functionality like the copying and pasting of files across
+applications.
+
+GLFW itself only allows plain text to be copied to the
+clipboard and back on all platforms. On some platforms, like Windows,
+you can use platform specific APIs to add extra clipboard
+functionality like copying of other data types. However, on X11, this
+was previously not fully possible due to the fact that GLFW internal
+code has full control over the X11 event queue.
+
+This change exposes several new symbols that allow you to get and set
+the handler for X11 selection events that GLFW will use. It also
+allows getting the internal display connection and selection helper
+window, for use in that kind of code.
+
 ## Caveats {#caveats}
 
 ## Deprecations {#deprecations}
@@ -23,6 +42,12 @@ this.
 ## New symbols {#new_symbols}
 
 ### New functions {#new_functions}
+
+#### X11-specific
+ - @ref getSelectionRequestHandler
+ - @ref setSelectionRequestHanddler
+ - @ref getGLFWDisplay
+ - @ref getGLFWHelperWindow
 
 ### New types {#new_types}
 

--- a/include/GLFW/glfw3native.h
+++ b/include/GLFW/glfw3native.h
@@ -442,6 +442,13 @@ GLFWAPI void glfwSetX11SelectionString(const char* string);
  *  @ingroup native
  */
 GLFWAPI const char* glfwGetX11SelectionString(void);
+
+#include <X11/Xlib.h>
+extern void (*handleSelectionRequest)(XEvent*);
+void (*getSelectionRequestHandler(void))(XEvent*);
+void setSelectionRequestHandler(void (*handler)(XEvent*));
+Display* getGLFWDisplay(void);
+
 #endif
 
 #if defined(GLFW_EXPOSE_NATIVE_GLX)

--- a/include/GLFW/glfw3native.h
+++ b/include/GLFW/glfw3native.h
@@ -448,6 +448,7 @@ extern void (*handleSelectionRequest)(XEvent*);
 void (*getSelectionRequestHandler(void))(XEvent*);
 void setSelectionRequestHandler(void (*handler)(XEvent*));
 Display* getGLFWDisplay(void);
+Window getGLFWHelperWindow(void);
 
 #endif
 

--- a/include/GLFW/glfw3native.h
+++ b/include/GLFW/glfw3native.h
@@ -444,7 +444,6 @@ GLFWAPI void glfwSetX11SelectionString(const char* string);
 GLFWAPI const char* glfwGetX11SelectionString(void);
 
 #include <X11/Xlib.h>
-extern void (*handleSelectionRequest)(XEvent*);
 void (*getSelectionRequestHandler(void))(XEvent*);
 void setSelectionRequestHandler(void (*handler)(XEvent*));
 Display* getGLFWDisplay(void);

--- a/src/x11_init.c
+++ b/src/x11_init.c
@@ -1314,6 +1314,8 @@ GLFWbool _glfwConnectX11(int platformID, _GLFWplatform* platform)
     _glfw.x11.xlib.handle = module;
 
     *platform = x11;
+
+    handleSelectionRequest = handleSelectionRequest_;
     return GLFW_TRUE;
 }
 

--- a/src/x11_platform.h
+++ b/src/x11_platform.h
@@ -896,6 +896,8 @@ typedef struct _GLFWcursorX11
     Cursor handle;
 } _GLFWcursorX11;
 
+extern void (*handleSelectionRequest)(XEvent*);
+void handleSelectionRequest_(XEvent* event);
 
 GLFWbool _glfwConnectX11(int platformID, _GLFWplatform* platform);
 int _glfwInitX11(void);

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -921,7 +921,8 @@ static Atom writeTargetToProperty(const XSelectionRequestEvent* request)
     return None;
 }
 
-static void handleSelectionRequest(XEvent* event)
+void (*handleSelectionRequest)(XEvent*);
+void handleSelectionRequest_(XEvent* event)
 {
     const XSelectionRequestEvent* request = &event->xselectionrequest;
 
@@ -3355,6 +3356,15 @@ GLFWAPI const char* glfwGetX11SelectionString(void)
     }
 
     return getSelectionString(_glfw.x11.PRIMARY);
+}
+void (*getSelectionRequestHandler(void))(XEvent*) {
+    return handleSelectionRequest;
+}
+void setSelectionRequestHandler(void (*handler)(XEvent*)) {
+    handleSelectionRequest = handler;
+}
+Display* getGLFWDisplay(void) {
+    return _glfw.x11.display;
 }
 
 #endif // _GLFW_X11

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -3367,5 +3367,8 @@ Display* getGLFWDisplay(void) {
     return _glfw.x11.display;
 }
 
-#endif // _GLFW_X11
+Window getGLFWHelperWindow(void) {
+    return _glfw.x11.helperWindowHandle;
+}
 
+#endif // _GLFW_X11


### PR DESCRIPTION
GLFW itself only supports plain text (UTF-8) clipboard content. While this is enough for many applications, some applications need to allow copy and pasting other types of content between applications, like files and images. 

When applications need extra clipboard functionality and target a small number of platforms, they can use platform-specific code on many platforms to add the extra clipboard functionality they need. However, because of the way the X11 clipboard functionality interacts with the X11 event queue, it's not currently possible to fully implement this extra functionality while running on GLFW.

This pull request exposes a the X11 connection information that GLFW uses for clipboard functionality through the GLFW X11 native header/flag. It also adds a hook where clients can handle all X11 selection events that arrive to GLFW. This is about the minimum needed to allow clients to write their own clipboard handling code with extra functionality within a GLFW application. Since it is already possible to implement this functionality using the Windows native APIs, this allows an application which runs on Windows and Linux+X11 (and maybe others)  to add this functionality.

This functionality was developed as part of my work on JuniorsToolbox, so you can find commented client code that uses this new API [here](https://github.com/JoshuaMKW/JuniorsToolbox/blob/5c771af12e46a6574ed7892e29ff3cf67f1bbe3b/src/gui/clipboard.cpp#L385-L614); that should provide a decent example of how it can be used in other clients.