### PR TITLE
FIX: Validation layers not found by triangle-vulkan test

### DIFF
--- a/tests/triangle-vulkan.c
+++ b/tests/triangle-vulkan.c
@@ -1573,7 +1573,7 @@ static void demo_init_vk(struct demo *demo) {
     demo->enabled_layer_count = 0;
 
     char *instance_validation_layers_alt1[] = {
-        "VK_LAYER_LUNARG_standard_validation"
+        "VK_LAYER_KHRONOS_validation"
     };
 
     char *instance_validation_layers_alt2[] = {
@@ -1605,7 +1605,7 @@ static void demo_init_vk(struct demo *demo) {
                     instance_layers);
             if (validation_found) {
                 demo->enabled_layer_count = ARRAY_SIZE(instance_validation_layers_alt1);
-                demo->enabled_layers[0] = "VK_LAYER_LUNARG_standard_validation";
+                demo->enabled_layers[0] = "VK_LAYER_KHRONOS_validation";
                 validation_layer_count = 1;
             } else {
                 // use alternative set of validation layers


### PR DESCRIPTION
Fixes the following error when calling `./tests/triangle-vulkan --validate` on latest Arch Linux:

```
$ ./tests/triangle-vulkan --validate
Cannot find layer: VK_LAYER_LUNARG_standard_validation
Cannot find layer: VK_LAYER_GOOGLE_threading
vkEnumerateInstanceLayerProperties failed to find required validation layer.

Please look at the Getting Started guide for additional information.
```