### PR TITLE
Fix building on old gnu/linux systems

### DIFF
--- a/examples/particles.c
+++ b/examples/particles.c
@@ -24,6 +24,8 @@
 //
 //========================================================================
 
+#define _GNU_SOURCE
+
 #if defined(_MSC_VER)
  // Make MS math.h define M_PI
  #define _USE_MATH_DEFINES

--- a/src/linux_joystick.c
+++ b/src/linux_joystick.c
@@ -25,6 +25,8 @@
 //
 //========================================================================
 
+#define _GNU_SOURCE
+
 #include "internal.h"
 
 #if defined(GLFW_BUILD_LINUX_JOYSTICK)

--- a/src/posix_time.c
+++ b/src/posix_time.c
@@ -25,6 +25,8 @@
 //
 //========================================================================
 
+#define _GNU_SOURCE
+
 #include "internal.h"
 
 #if defined(GLFW_BUILD_POSIX_TIMER)

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -24,6 +24,8 @@
 //
 //========================================================================
 
+#define _GNU_SOURCE
+
 #include "internal.h"
 
 #if defined(_GLFW_WAYLAND)

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -40,7 +40,9 @@
 #include <sys/mman.h>
 #include <sys/timerfd.h>
 #include <poll.h>
+#if __has_include(<linux/input-event-codes.h>)
 #include <linux/input-event-codes.h>
+#endif
 
 #include "wayland-client-protocol.h"
 #include "xdg-shell-client-protocol.h"


### PR DESCRIPTION
Fixes #2495:

- Some files including `time.h` were not setting `_GNU_SOURCE`, so builds failed as `CLOCK_REALTIME` and `CLOCK_MONOTONIC` were not defined
- Header `linux/input-event-codes.h` was added around 2015 to kernel tree, so it is not available in the old systems in question (#2495 references `manylinux2014`)
- `O_CLOEXEC` was also undeclared without `_GNU_SOURCE` defined