### PR TITLE
Fix documentation for glfwGetTimerValue

### DIFF
--- a/docs/input.md
+++ b/docs/input.md
@@ -940,9 +940,10 @@ with @ref glfwGetTimerValue.
 uint64_t value = glfwGetTimerValue();
 ```
 
-This value is in 1&nbsp;/&nbsp;frequency seconds.  The frequency of the raw
-timer varies depending on the operating system and hardware.  You can query the
-frequency, in Hz, with @ref glfwGetTimerFrequency.
+This function returns the current value of the raw timer. To get the current time in 
+1&nbsp;/&nbsp;frequency seconds, use `glfwGetTimerValue() / glfwGetTimerFrequency()`.
+The frequency of the rawtimer varies depending on the operating system and hardware.
+You can query the frequency, in Hz, with @ref glfwGetTimerFrequency.
 
 ```c
 uint64_t frequency = glfwGetTimerFrequency();

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -6037,9 +6037,12 @@ GLFWAPI void glfwSetTime(double time);
 
 /*! @brief Returns the current value of the raw timer.
  *
- *  This function returns the current value of the raw timer, measured in
- *  1&nbsp;/&nbsp;frequency seconds.  To get the frequency, call @ref
- *  glfwGetTimerFrequency.
+ *  This function returns the current value of the raw timer. To get the 
+ *  current time measured in 1&nbsp;/&nbsp;frequency seconds, use 
+ *  @ref glfwGetTimerValue / @ref glfwGetTimerFrequency.
+ *  To get the frequency, call @ref glfwGetTimerFrequency.
+ *  
+ *  
  *
  *  @return The value of the timer, or zero if an
  *  [error](@ref error_handling) occurred.


### PR DESCRIPTION
Corrected formatting issues since in order to get 1/frequency seconds, it should be computed via 
glfwGetTimerValue() / glfwGetTimerFrequency() 

Fixes #2264