### PR TITLE
Update documentation, added missing dependency needed for fedora

### DIFF
--- a/docs/compile.md
+++ b/docs/compile.md
@@ -66,7 +66,7 @@ On Fedora and derivatives like Red Hat you will need the `wayland-devel` and
 These will pull in all other dependencies.
 
 ```sh
-sudo dnf install wayland-devel libxkbcommon-devel libXcursor-devel libXi-devel libXinerama-devel libXrandr-devel
+sudo dnf install wayland-devel libxkbcommon-devel libXcursor-devel libXi-devel libXinerama-devel libXrandr-devel libXxf86vm-devel
 ```
 
 On FreeBSD you will need the `wayland`, `libxkbcommon` and `evdev-proto` packages to


### PR DESCRIPTION
When I tried to compile the project in Fedora I got an error about a missing dependency (libXxf86vm-devel). I just added this dependency to the documentation, in case someone else runs into the same issue.
