### PR TITLE
ci: Use GitHub actions for MINGW CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,12 +9,6 @@ branches:
 skip_tags: true
 environment:
     matrix:
-        - GENERATOR: MinGW Makefiles
-          BUILD_SHARED_LIBS: ON
-          CFLAGS: -Werror
-        - GENERATOR: MinGW Makefiles
-          BUILD_SHARED_LIBS: OFF
-          CFLAGS: -Werror
         - GENERATOR: Visual Studio 12 2013
           BUILD_SHARED_LIBS: ON
           CFLAGS: /WX
@@ -24,14 +18,6 @@ environment:
 matrix:
     fast_finish: true
 for:
--
-    matrix:
-        only:
-            - GENERATOR: MinGW Makefiles
-    build_script:
-        - set PATH=%PATH:C:\Program Files\Git\usr\bin=C:\MinGW\bin%
-        - cmake -B build -G "%GENERATOR%" -DBUILD_SHARED_LIBS=%BUILD_SHARED_LIBS%
-        - cmake --build build
 -
     matrix:
         only:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,29 @@ jobs:
             - name: Build Cocoa shared library
               run: cmake --build build-cocoa-shared --parallel
 
+    build-mingw:
+      name: Windows (MINGW)
+      runs-on: windows-latest
+      timeout-minutes: 4
+      strategy:
+        matrix:
+            BUILD_SHARED_LIBS: [ ON, OFF ]
+      defaults:
+        run:
+          # Use MinGW environment
+          shell: bash
+      env:
+          CFLAGS: -Werror
+          CMAKE_GENERATOR: MinGW Makefiles
+      steps:
+          - uses: actions/checkout@v4
+          - name: Configure MINGW library
+            run: cmake -B build -DBUILD_SHARED_LIBS=${{matrix.BUILD_SHARED_LIBS}}
+          - name: Build MINGW library
+            run: cmake --build build --parallel
+          - name: Install MINGW library to /tmp
+            run: cmake --install build --prefix /tmp
+
     build-windows-vs2022:
         name: Windows (VS2022)
         runs-on: windows-latest


### PR DESCRIPTION
The version of MinGW in AppVeyor is quite old. Using GNU  5.3.0

Whereas GitHub actions is using GNU 12.2.0
```
Run cmake -B build -DBUILD_SHARED_LIBS=OFF
-- Building for: MinGW Makefiles
-- The C compiler identification is GNU 12.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/mingw64/bin/gcc.exe - skipped
```

Unless the intent of the AppVeyor build is to keep support for older versions of MinGW, I'd say this is an improvement.

This CI change is also inline with issue #2540 