### PR TITLE
resolve build problem in cygwin toolchain

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -92,7 +92,7 @@ extern "C" {
 
 /* If we are we on Windows, we want a single define for it.
  */
-#if !defined(_WIN32) && (defined(__WIN32__) || defined(WIN32) || defined(__MINGW32__))
+#if !defined(_WIN32) && (defined(__WIN32__) || defined(WIN32) || defined(__MINGW32__) || defined(_GLFW_WIN32))
  #define _WIN32
 #endif /* _WIN32 */
 


### PR DESCRIPTION
when building using cmake. it defines the macro _GLFW_WIN32 for win32. but the glfw don't recognise the macro. so that the definitions in the win_thread.c .... etc are not defined. so undefined error arise when building a application. This error arises only when using cygwin toolchain. when using mingw, it defines __MINGW32__ so the glfw recognise it.