### PR TITLE
Explicitly unmap iconified windows before restoring them.

### DIFF
--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -2339,6 +2339,9 @@ void _glfwRestoreWindowX11(_GLFWwindow* window)
 
     if (_glfwWindowIconifiedX11(window))
     {
+        // Some window managers do not unmap iconified windows, and XMapWindow is
+        // then no-op. Explicitly unmap the window to make sure it gets restored.
+        XUnmapWindow(_glfw.x11.display, window->x11.handle);
         XMapWindow(_glfw.x11.display, window->x11.handle);
         waitForVisibilityNotify(window);
     }

--- a/tests/iconify.c
+++ b/tests/iconify.c
@@ -56,6 +56,8 @@ static void error_callback(int error, const char* description)
 
 static void key_callback(GLFWwindow* window, int key, int scancode, int action, int mods)
 {
+    static GLFWwindow *iconified;
+
     printf("%0.2f Key %s\n",
            glfwGetTime(),
            action == GLFW_PRESS ? "pressed" : "released");
@@ -67,12 +69,15 @@ static void key_callback(GLFWwindow* window, int key, int scancode, int action, 
     {
         case GLFW_KEY_I:
             glfwIconifyWindow(window);
+            iconified = window;
             break;
         case GLFW_KEY_M:
             glfwMaximizeWindow(window);
             break;
         case GLFW_KEY_R:
+            if (iconified) window = iconified;
             glfwRestoreWindow(window);
+            iconified = NULL;
             break;
         case GLFW_KEY_ESCAPE:
             glfwSetWindowShouldClose(window, GLFW_TRUE);
@@ -253,9 +258,10 @@ int main(int argc, char** argv)
         if (fullscreen)
             monitor = glfwGetPrimaryMonitor();
 
-        window_count = 1;
+        window_count = 2;
         windows = calloc(window_count, sizeof(GLFWwindow*));
         windows[0] = create_window(monitor);
+        windows[1] = create_window(monitor);
     }
 
     for (i = 0;  i < window_count;  i++)


### PR DESCRIPTION
Closes: #2077

The test can be used to reproduce the issue with Mutter without the UnmapWindow, and check that window restore works when it is added.