### PR TITLE
Cocoa: Fix glfwGetFramebufferSize() for non-retina windows.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -263,6 +263,7 @@ video tutorials.
  - Jared Tiala
  - Sergey Tikhomirov
  - Arthur Tombs
+ - Luis Torres
  - TronicLabs
  - Ioannis Tsakpinis
  - Samuli Tuomola

--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ information on what to include when reporting a bug.
  - Updated minimum CMake version to 3.16 (#2541)
  - [Cocoa] Added `QuartzCore` framework as link-time dependency
  - [Cocoa] Removed support for OS X 10.10 Yosemite and earlier (#2506)
+ - [Cocoa] Bugfix: glfwGetFramebufferSize() now returns correct values for
+   non-retina windows for some Macs. (#2478)
  - [Wayland] Bugfix: The fractional scaling related objects were not destroyed
  - [Wayland] Bugfix: `glfwInit` would segfault on compositor with no seat (#2517)
  - [Wayland] Bugfix: A drag entering a non-GLFW surface could cause a segfault

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -1133,13 +1133,25 @@ void _glfwGetFramebufferSizeCocoa(_GLFWwindow* window, int* width, int* height)
     @autoreleasepool {
 
     const NSRect contentRect = [window->ns.view frame];
-    const NSRect fbRect = [window->ns.view convertRectToBacking:contentRect];
 
-    if (width)
-        *width = (int) fbRect.size.width;
-    if (height)
-        *height = (int) fbRect.size.height;
+    if (window->ns.scaleFramebuffer)
+    {
+        const NSRect fbRect = [window->ns.view convertRectToBacking:contentRect];
 
+        if (width)
+            *width = (int) fbRect.size.width;
+        if (height)
+            *height = (int) fbRect.size.height;
+    }
+    else
+    {
+        if (width)
+            *width = (int) contentRect.size.width;
+        if (height)
+            *height = (int) contentRect.size.height;
+
+    }
+    
     } // autoreleasepool
 }
 


### PR DESCRIPTION
On some Macs, glfwGetFramebufferSize() would return a high-resolution result even when the GL framebuffer was not created in high-resolution (retina) mode. This is because the screen-to-pixel conversion function, convertRectToBacking(), doesn't take into account whether the framebuffer was created in high-resolution mode; it will always return a high-resolution result if the device is high-res.

Now we check whether the framebuffer is indeed in retina mode before using the convertRectToBacking() function.

Fixes #2478