### PR TITLE
include xkb_common.h in wl_platform.h as well

### DIFF
--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -42,6 +42,7 @@ typedef struct VkWaylandSurfaceCreateInfoKHR
 typedef VkResult (APIENTRY *PFN_vkCreateWaylandSurfaceKHR)(VkInstance,const VkWaylandSurfaceCreateInfoKHR*,const VkAllocationCallbacks*,VkSurfaceKHR*);
 typedef VkBool32 (APIENTRY *PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR)(VkPhysicalDevice,uint32_t,struct wl_display*);
 
+#include "xkb_unicode.h"
 #include "posix_poll.h"
 
 typedef int (* PFN_wl_display_flush)(struct wl_display* display);


### PR DESCRIPTION
Fixes this on my machine:

```
/home/andrei/Projects/glfw/src/xkb_unicode.c:939:12: error: use of undeclared identifier 'GLFW_INVALID_CODEPOINT'
    return GLFW_INVALID_CODEPOINT;
````

I imagine I'm running into this (but others/CI is not) because I'm hand-rolling my own build system for this rather than using the provided CMake one. Nonetheless, this seems like a valid change, as Wayland also requires `xkb_common.h`.