### PR TITLE
Wayland: Check whether locales are the empty string and ignore them if they are

### DIFF
--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -1860,11 +1860,11 @@ static void keyboardHandleKeymap(void* userData,
 
     // Look up the preferred locale, falling back to "C" as default.
     locale = getenv("LC_ALL");
-    if (!locale)
+    if (!locale || strlen(locale) == 0)
         locale = getenv("LC_CTYPE");
-    if (!locale)
+    if (!locale || strlen(locale) == 0)
         locale = getenv("LANG");
-    if (!locale)
+    if (!locale || strlen(locale) == 0)
         locale = "C";
 
     composeTable =


### PR DESCRIPTION
This fixes a confusing error in compiling the xkb compose table if LC_ALL, LC_CTYPE, or LANG are set to the empty string:
```
xkbcommon: ERROR: couldn't find a Compose file for locale "" (mapped to "")
GLFW: Wayland: Failed to create XKB compose table
```
By checking for the empty string, the locales are instead ignored and GLFW initialises properly. Other applications don't seem to have an issue with empty locale strings, so I think following their behaviour is the way to go.