### PR TITLE
Joystick Detection tweaks for Raspberry PI OS / Linux

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -98,6 +98,7 @@ video tutorials.
  - Björn Hempel
  - Matthew Henry
  - heromyth
+ - Jochen Heizmann
  - Lucas Hinderberger
  - Paul Holden
  - Hajime Hoshi

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ information on what to include when reporting a bug.
  - [Null] Added EGL context creation on Mesa via `EGL_MESA_platform_surfaceless`
  - [EGL] Allowed native access on Wayland with `GLFW_CONTEXT_CREATION_API` set to
    `GLFW_NATIVE_CONTEXT_API` (#2518)
+ - [Linux] Bugfix: Non-joystick input devices were incorrectly detected as joysticks on Raspberry PI OS
 
 
 ## Contact

--- a/src/linux_joystick.c
+++ b/src/linux_joystick.c
@@ -181,7 +181,7 @@ static GLFWbool openJoystickDevice(const char* path)
     // They are filtered out for enumeration. I wish there is a more robust way to detect if a device is really
     // a gamecontroller/gamepad, but I wasn't able to find a way.
     if (strstr(name, "Keyboard System Control") || 
-        strstr(name, "Keyboard Consumer Control" ||
+        strstr(name, "Keyboard Consumer Control") ||
         strstr(name, "11-0048 EP0110M09") ||
         strstr(name, "HID 046a:0023")) { 
         close(linjs.fd);

--- a/src/linux_joystick.c
+++ b/src/linux_joystick.c
@@ -157,8 +157,17 @@ static GLFWbool openJoystickDevice(const char* path)
     }
 
     // Ensure this device supports the events expected of a joystick
-    if (!isBitSet(EV_ABS, evBits))
+    // NOTE: SDL2 based Joystick Check
+    if (isBitSet(BTN_STYLUS, keyBits) ||
+        isBitSet(BTN_TOOL_PEN, keyBits) ||
+        isBitSet(BTN_TOOL_FINGER, keyBits) ||
+        isBitSet(BTN_MOUSE, keyBits) ||
+        isBitSet(BTN_TOUCH, keyBits) ||
+        (keyBits[0] & 0xFFFFFFFE) != 0)
     {
+        close(linjs.fd);
+        return GLFW_FALSE;
+    } else if (!isBitSet(EV_ABS, evBits)) {
         close(linjs.fd);
         return GLFW_FALSE;
     }
@@ -168,6 +177,17 @@ static GLFWbool openJoystickDevice(const char* path)
     if (ioctl(linjs.fd, EVIOCGNAME(sizeof(name)), name) < 0)
         strncpy(name, "Unknown", sizeof(name));
 
+    // NOTE: Some devices are still indentified as Gamepad devices (Rapsbery PI 500, Hypertouch Square Display).
+    // They are filtered out for enumeration. I wish there is a more robust way to detect if a device is really
+    // a gamecontroller/gamepad, but I wasn't able to find a way.
+    if (strstr(name, "Keyboard System Control") || 
+        strstr(name, "Keyboard Consumer Control" ||
+        strstr(name, "11-0048 EP0110M09") ||
+        strstr(name, "HID 046a:0023")) { 
+        close(linjs.fd);
+        return GLFW_FALSE;
+    } 
+    
     char guid[33] = "";
 
     // Generate a joystick GUID that matches the SDL 2.0.5+ one
@@ -433,4 +453,3 @@ void _glfwUpdateGamepadGUIDLinux(char* guid)
 }
 
 #endif // GLFW_BUILD_LINUX_JOYSTICK
-


### PR DESCRIPTION
# Improve joystick detection on Raspberry PI OS and Linux systems

When I used glfw3 with the Raspberry PI 500, I had the problem that devices got identified as Joysticks, that are clearly not Gamepads/Gamecontrollers. The same problem occured when using a PI Zero 2 with a Hyperpixel Square Touch Display. The device got enumerated as joystick, and when reading from it it produced constant `input events`.

I tried to fix this by:

1. **SDL2-compatible device filtering**: Implements the same device filtering logic used by SDL2 to exclude devices that have characteristics of non-joystick input devices (stylus, pen tools, finger tools, mouse buttons, touch interfaces).

2. **Device name filtering**: Adds explicit filtering for known problematic device names commonly found on Raspberry PI systems.

I know that the Device name filtering isn't very clean/nice approach, but I ran out of ideas on how to fix the issue in a more robust way.
