### PR TITLE
Fix joystick callback when it's already connected on app start

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -1261,11 +1261,8 @@ GLFWAPI void* glfwGetJoystickUserPointer(int jid)
 GLFWAPI GLFWjoystickfun glfwSetJoystickCallback(GLFWjoystickfun cbfun)
 {
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
-
-    if (!initJoysticks())
-        return NULL;
-
     _GLFW_SWAP(GLFWjoystickfun, _glfw.callbacks.joystick, cbfun);
+    initJoysticks();
     return cbfun;
 }
 


### PR DESCRIPTION
Joystick events aren't been risen if the gamepad is alredy connected on app start.

As an aternative method you can use joystickPresent to manually call the function:
```rust
_ = glfw.setJoystickCallback(&onJoystick);
// force connection events
for (0..glfw.JOYSTICK_LAST + 1) |jid| {
    if (glfw.joystickPresent(@intCast(jid)) != 0) onJoystick(@intCast(jid), glfw.CONNECTED);
}
```