### PR TITLE
Wayland: Reset key repeat timer on window destruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ information on what to include when reporting a bug.
  - [Wayland] Bugfix: `glfwInit` would segfault on compositor with no seat (#2517)
  - [Wayland] Bugfix: A drag entering a non-GLFW surface could cause a segfault
  - [Wayland] Bugfix: Ignore key repeat events when no window has keyboard focus (#2727)
+ - [Wayland] Bugfix: Reset key repeat timer when window destroyed (#2741,#2727)
  - [X11] Bugfix: Running without a WM could trigger an assert (#2593,#2601,#2631)
  - [Null] Added Vulkan 'window' surface creation via `VK_EXT_headless_surface`
  - [Null] Added EGL context creation on Mesa via `EGL_MESA_platform_surfaceless`

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -2187,7 +2187,12 @@ void _glfwDestroyWindowWayland(_GLFWwindow* window)
         _glfw.wl.pointerFocus = NULL;
 
     if (window == _glfw.wl.keyboardFocus)
+	{
+		struct itimerspec timer = {0};
+		timerfd_settime(_glfw.wl.keyRepeatTimerfd, 0, &timer, NULL);
+
         _glfw.wl.keyboardFocus = NULL;
+	}
 
     if (window->wl.fractionalScale)
         wp_fractional_scale_v1_destroy(window->wl.fractionalScale);


### PR DESCRIPTION
Windows with keyboard focus may have an active key repeat timer. This should be reset when the window is closed, or key repeat events could be sent to a NULL window were it not for the quickfix in PR #2732.

Fixes #2741
Probably the source of #2727