### PR TITLE
Fix windowProc not working when SetPropW() fails silently

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -232,6 +232,7 @@ video tutorials.
  - Jan Schürkamp
  - Christian Sdunek
  - Matt Sealey
+ - Perumaal Shanmugam
  - Steve Sexton
  - Arkady Shapkin
  - Mingjie Shen

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ information on what to include when reporting a bug.
  - [Null] Added EGL context creation on Mesa via `EGL_MESA_platform_surfaceless`
  - [EGL] Allowed native access on Wayland with `GLFW_CONTEXT_CREATION_API` set to
    `GLFW_NATIVE_CONTEXT_API` (#2518)
+ - [Win32] Bugfix: Fix `windowProc` to work when `SetPropW` fails silently
 
 
 ## Contact

--- a/src/win32_init.c
+++ b/src/win32_init.c
@@ -493,18 +493,19 @@ void _glfwInputErrorWin32(int error, const char* description)
     WCHAR buffer[_GLFW_MESSAGE_SIZE] = L"";
     char message[_GLFW_MESSAGE_SIZE] = "";
 
+    DWORD lastError = GetLastError();
     FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM |
                        FORMAT_MESSAGE_IGNORE_INSERTS |
                        FORMAT_MESSAGE_MAX_WIDTH_MASK,
                    NULL,
-                   GetLastError() & 0xffff,
+                   lastError & 0xffff,
                    MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
                    buffer,
                    sizeof(buffer) / sizeof(WCHAR),
                    NULL);
     WideCharToMultiByte(CP_UTF8, 0, buffer, -1, message, sizeof(message), NULL, NULL);
 
-    _glfwInputError(error, "%s: %s", description, message);
+    _glfwInputError(error, "%s (0x%lx / %lu): %s", description, lastError, lastError, message);
 }
 
 // Updates key names according to the current keyboard layout


### PR DESCRIPTION
**Issue**

In some cases, on Windows, `SetPropW` returns `FALSE`.
glfw currently silently ignores the result.
This means that the message pump `windowProc` fails to work (does not receive keyboard events for example). Drawing is fine though as it's a different GLFW mechanism.

I had this failure frequently infrequently and it was frustrating to deal with (just have to rerun the program a few times and hope `SetPropW` doesn't return `FALSE`). So sending this fix in case others are facing the issue on Windows.

**Fix**

On Windows+GLFW, `windowProc` will fallback to looking up the GLFW window list (just like `PollEvents` does).
Also added the error code to `_glfwInputError` message to aid debugging in the future.

My suggestion is to get rid of `SetPropW`/`GetPropW` as it is a string-based Windows API (slow/fragile) - we already have the lightweight linked list, might as well just use it always - also it's usually just the one or two windows we deal with.

- [x] Verified on Windows - message pump is stable with this fix (once I was able to repro this issue).