### PR TITLE
X11: Prevent BadWindow when creating small windows

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -278,6 +278,7 @@ video tutorials.
  - Corentin Wallez
  - Torsten Walluhn
  - Patrick Walton
+ - Ivor Wanders
  - Jim Wang
  - Xo Wang
  - Andre Weissflog

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ information on what to include when reporting a bug.
  - [Null] Added EGL context creation on Mesa via `EGL_MESA_platform_surfaceless`
  - [EGL] Allowed native access on Wayland with `GLFW_CONTEXT_CREATION_API` set to
    `GLFW_NATIVE_CONTEXT_API` (#2518)
+ - [X11] Bugfix: Prevent BadWindow when creating small windows (#2754)
 
 
 ## Contact

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -576,6 +576,10 @@ static GLFWbool createNativeWindow(_GLFWwindow* window,
         height *= _glfw.x11.contentScaleY;
     }
 
+    // The dimensions must be nonzero, or a BadValue error results.
+    width = _glfw_max(1, width);
+    height = _glfw_max(1, height);
+
     int xpos = 0, ypos = 0;
 
     if (wndconfig->xpos != GLFW_ANY_POSITION && wndconfig->ypos != GLFW_ANY_POSITION)


### PR DESCRIPTION
The glfwCreateWindow function ensures that the width and height are at least greater or equal than zero, but on X11 it is invalid to create a window with dimensions that equal zero, see [1].

This change ensures that the dimensions passed to XCreateWindow are at least 1 by 1.

This issue was detected in [2], where a call to glfwCreateWindow was done to request a 1x1 window, with a _glfw.x11.contentScaleX of less than 1.0 (0.958333) this results in a request for a 0x0 window which then causes an BadWindow error from X11.

[1]: https://gitlab.freedesktop.org/xorg/lib/libx11/-/blob/e003f52661679e95b51ff24e317af6178fe2a73c/specs/libX11/CH03.xml#L1333-1337
[2]: https://github.com/WerWolv/ImHex/pull/2390

---
Above the line is the commit message.

I wasn't too sure on how to get a permalink to the versioned and rendered documentation of libx11, so I linked to the XML for it at a commit hash. The human readable documentation for `XCreateWindow` can be found [here](https://www.x.org/releases/X11R7.6/doc/libX11/specs/libX11/libX11.html#Creating_Windows). Not too sure what the best practices are, happy to change it.