### PR TITLE
Add support for creating WebGPU surfaces

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -6531,19 +6531,6 @@ GLFWAPI VkResult glfwCreateWindowSurface(VkInstance instance, GLFWwindow* window
 
 #if defined(WEBGPU_H_)
 
-/*! @brief Provide the address of the `wgpuInstanceCreateSurface` function to GLFW.
- *
- * This function passes the address provided for the `wgpuInstanceCreateSurface` function
- * to GLFW.
- *
- * @param[in] addr The address of the `wgpuInstanceCreateSurface` function.
- *
- * @since Added in version 3.5
- *
- * @ingroup webgpu
- */
-GLFWAPI void glfwSetWGPUInstanceCreateSurfaceAddr(WGPUSurface (*addr)(WGPUInstance, const WGPUSurfaceDescriptor*));
-
 /*! @brief Creates a WebGPU surface for the specified window.
  * 
  * This function creates a WebGPU surface for the specified window.

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -6531,6 +6531,19 @@ GLFWAPI VkResult glfwCreateWindowSurface(VkInstance instance, GLFWwindow* window
 
 #if defined(WEBGPU_H_)
 
+/*! @brief Provide the address of the `wgpuInstanceCreateSurface` function to GLFW.
+ *
+ * This function passes the address provided for the `wgpuInstanceCreateSurface` function
+ * to GLFW.
+ *
+ * @param[in] addr The address of the `wgpuInstanceCreateSurface` function.
+ *
+ * @since Added in version 3.5
+ *
+ * @ingroup webgpu
+ */
+GLFWAPI void glfwSetWGPUInstanceCreateSurfaceAddr(WGPUSurface (*addr)(WGPUInstance, const WGPUSurfaceDescriptor*));
+
 /*! @brief Creates a WebGPU surface for the specified window.
  * 
  * This function creates a WebGPU surface for the specified window.

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -115,6 +115,10 @@ extern "C" {
  * VK_USE_PLATFORM_WIN32_KHR) so we offer our replacement symbols after it.
  */
 
+#if defined(GLFW_INCLUDE_WEBGPU)
+  #include <webgpu/webgpu.h>
+#endif /* WebGPU header */
+
 /* It is customary to use APIENTRY for OpenGL function pointer declarations on
  * all platforms.  Additionally, the Windows OpenGL header needs APIENTRY.
  */
@@ -6525,6 +6529,41 @@ GLFWAPI VkResult glfwCreateWindowSurface(VkInstance instance, GLFWwindow* window
 
 #endif /*VK_VERSION_1_0*/
 
+#if defined(WEBGPU_H_)
+
+/*! @brief Provide the address of the `wgpuInstanceCreateSurface` function to GLFW.
+ *
+ * This function passes the address provided for the `wgpuInstanceCreateSurface` function
+ * to GLFW.
+ *
+ * @param[in] addr The address of the `wgpuInstanceCreateSurface` function.
+ *
+ * @since Added in version 3.5
+ *
+ * @ingroup webgpu
+ */
+GLFWAPI void glfwSetWGPUInstanceCreateSurfaceAddr(WGPUSurface (*addr)(WGPUInstance, const WGPUSurfaceDescriptor*));
+
+/*! @brief Creates a WebGPU surface for the specified window.
+ * 
+ * This function creates a WebGPU surface for the specified window.
+ *
+ * If the surface could not be created this function returns `NULL`.
+ *
+ * It is the callers responsibility to destroy the surface. The surface
+ * must be destroyed using `wgpuSurfaceRelease`.
+ *
+ * @param[in] instance The WebGPU instance to create the surface in.
+ * @param[in] window The window to create the surface for.
+ * @return The handle of the surface. This is `NULL` if an error occurred.
+ *
+ * @since Added in version 3.5
+ *
+ * @ingroup webgpu
+ */
+GLFWAPI WGPUSurface glfwCreateWindowWGPUSurface(WGPUInstance instance, GLFWwindow* window);
+
+#endif /*WEBGPU_H_*/
 
 /*************************************************************************
  * Global definition cleanup

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,9 +3,10 @@ add_library(glfw ${GLFW_LIBRARY_TYPE}
                  "${GLFW_SOURCE_DIR}/include/GLFW/glfw3.h"
                  "${GLFW_SOURCE_DIR}/include/GLFW/glfw3native.h"
                  internal.h platform.h mappings.h
-                 context.c init.c input.c monitor.c platform.c vulkan.c window.c
-                 egl_context.c osmesa_context.c null_platform.h null_joystick.h
-                 null_init.c null_monitor.c null_window.c null_joystick.c)
+                 context.c init.c input.c monitor.c platform.c vulkan.c webgpu.c
+                 window.c egl_context.c osmesa_context.c null_platform.h
+                 null_joystick.h null_init.c null_monitor.c null_window.c
+                 null_joystick.c)
 
 # The time, thread and module code is shared between all backends on a given OS,
 # including the null backend, which still needs those bits to be functional
@@ -128,7 +129,8 @@ set_target_properties(glfw PROPERTIES
                       C_STANDARD 99
                       C_EXTENSIONS OFF
                       DEFINE_SYMBOL _GLFW_BUILD_DLL
-                      FOLDER "GLFW3")
+                      FOLDER "GLFW3"
+                      EXPORT_COMPILE_COMMANDS ON)
 
 target_include_directories(glfw PUBLIC
                            "$<BUILD_INTERFACE:${GLFW_SOURCE_DIR}/include>"

--- a/src/cocoa_init.m
+++ b/src/cocoa_init.m
@@ -564,7 +564,8 @@ GLFWbool _glfwConnectCocoa(int platformID, _GLFWplatform* platform)
         .getEGLNativeWindow = _glfwGetEGLNativeWindowCocoa,
         .getRequiredInstanceExtensions = _glfwGetRequiredInstanceExtensionsCocoa,
         .getPhysicalDevicePresentationSupport = _glfwGetPhysicalDevicePresentationSupportCocoa,
-        .createWindowSurface = _glfwCreateWindowSurfaceCocoa
+        .createWindowSurface = _glfwCreateWindowSurfaceCocoa,
+        .createWindowWGPUSurface = _glfwCreateWindowWGPUSurfaceCocoa
     };
 
     *platform = cocoa;

--- a/src/cocoa_platform.h
+++ b/src/cocoa_platform.h
@@ -276,6 +276,8 @@ void _glfwGetRequiredInstanceExtensionsCocoa(char** extensions);
 GLFWbool _glfwGetPhysicalDevicePresentationSupportCocoa(VkInstance instance, VkPhysicalDevice device, uint32_t queuefamily);
 VkResult _glfwCreateWindowSurfaceCocoa(VkInstance instance, _GLFWwindow* window, const VkAllocationCallbacks* allocator, VkSurfaceKHR* surface);
 
+WGPUSurface _glfwCreateWindowWGPUSurfaceCocoa(WGPUInstance instance, _GLFWwindow* window);
+
 void _glfwFreeMonitorCocoa(_GLFWmonitor* monitor);
 void _glfwGetMonitorPosCocoa(_GLFWmonitor* monitor, int* xpos, int* ypos);
 void _glfwGetMonitorContentScaleCocoa(_GLFWmonitor* monitor, float* xscale, float* yscale);

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -2020,6 +2020,26 @@ VkResult _glfwCreateWindowSurfaceCocoa(VkInstance instance,
     } // autoreleasepool
 }
 
+typedef struct WGPUSurfaceSourceMetalLayer {
+    WGPUChainedStruct chain;
+    void * layer;
+} WGPUSurfaceSourceMetalLayer;
+
+WGPUSurface _glfwCreateWindowWGPUSurfaceCocoa(WGPUInstance instance, _GLFWwindow* window) {
+    [window->ns.view setLayer:window->ns.layer];
+    [window->ns.view setWantsLayer:YES];
+
+    WGPUSurfaceSourceMetalLayer metalSurface;
+    metalSurface.chain.next = NULL;
+    metalSurface.chain.sType = WGPUSType_SurfaceSourceMetalLayer;
+    metalSurface.layer = window->ns.layer;
+
+    WGPUSurfaceDescriptor surfaceDescriptor;
+    surfaceDescriptor.nextInChain = &metalSurface.chain;
+    surfaceDescriptor.label = (WGPUStringView){ NULL, SIZE_MAX };
+
+    return wgpuInstanceCreateSurface(instance, &surfaceDescriptor);
+}
 
 //////////////////////////////////////////////////////////////////////////
 //////                        GLFW native API                       //////

--- a/src/init.c
+++ b/src/init.c
@@ -402,6 +402,8 @@ GLFWAPI int glfwInit(void)
     if (!_glfwSelectPlatform(_glfw.hints.init.platformID, &_glfw.platform))
         return GLFW_FALSE;
 
+    _glfwLoadWGPUInstanceCreateSurfaceAddr();
+
     if (!_glfw.platform.init())
     {
         terminate();

--- a/src/init.c
+++ b/src/init.c
@@ -402,8 +402,6 @@ GLFWAPI int glfwInit(void)
     if (!_glfwSelectPlatform(_glfw.hints.init.platformID, &_glfw.platform))
         return GLFW_FALSE;
 
-    _glfwLoadWGPUInstanceCreateSurfaceAddr();
-
     if (!_glfw.platform.init())
     {
         terminate();

--- a/src/internal.h
+++ b/src/internal.h
@@ -1051,8 +1051,6 @@ GLFWbool _glfwInitVulkan(int mode);
 void _glfwTerminateVulkan(void);
 const char* _glfwGetVulkanResultString(VkResult result);
 
-void _glfwLoadWGPUInstanceCreateSurfaceAddr(void);
-
 size_t _glfwEncodeUTF8(char* s, uint32_t codepoint);
 char** _glfwParseUriList(char* text, int* count);
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -331,6 +331,42 @@ typedef PFN_vkVoidFunction (APIENTRY * PFN_vkGetInstanceProcAddr)(VkInstance,con
 typedef VkResult (APIENTRY * PFN_vkEnumerateInstanceExtensionProperties)(const char*,uint32_t*,VkExtensionProperties*);
 #define vkGetInstanceProcAddr _glfw.vk.GetInstanceProcAddr
 
+// forward declare WebGPU types
+typedef struct WGPUInstanceImpl* WGPUInstance;
+typedef struct WGPUSurfaceImpl* WGPUSurface;
+
+typedef struct WGPUStringView {
+    char const * data;
+    size_t length;
+} WGPUStringView;
+
+typedef enum WGPUSType {
+    WGPUSType_ShaderSourceSPIRV = 0x00000001,
+    WGPUSType_ShaderSourceWGSL = 0x00000002,
+    WGPUSType_RenderPassMaxDrawCount = 0x00000003,
+    WGPUSType_SurfaceSourceMetalLayer = 0x00000004,
+    WGPUSType_SurfaceSourceWindowsHWND = 0x00000005,
+    WGPUSType_SurfaceSourceXlibWindow = 0x00000006,
+    WGPUSType_SurfaceSourceWaylandSurface = 0x00000007,
+    WGPUSType_SurfaceSourceAndroidNativeWindow = 0x00000008,
+    WGPUSType_SurfaceSourceXCBWindow = 0x00000009,
+    WGPUSType_Force32 = 0x7FFFFFFF
+} WGPUSType;
+
+typedef struct WGPUChainedStruct {
+    struct WGPUChainedStruct const * next;
+    WGPUSType sType;
+} WGPUChainedStruct;
+
+typedef struct WGPUSurfaceDescriptor {
+    WGPUChainedStruct const * nextInChain;
+    WGPUStringView label;
+} WGPUSurfaceDescriptor;
+
+typedef WGPUSurface (*PFN_wgpuInstanceCreateSurface)(WGPUInstance, const WGPUSurfaceDescriptor*);
+
+#define wgpuInstanceCreateSurface _glfw.wgpu.instanceCreateSurface
+
 #include "platform.h"
 
 #define GLFW_NATIVE_INCLUDE_NONE
@@ -759,6 +795,8 @@ struct _GLFWplatform
     void (*getRequiredInstanceExtensions)(char**);
     GLFWbool (*getPhysicalDevicePresentationSupport)(VkInstance,VkPhysicalDevice,uint32_t);
     VkResult (*createWindowSurface)(VkInstance,_GLFWwindow*,const VkAllocationCallbacks*,VkSurfaceKHR*);
+    // webgpu
+    WGPUSurface (*createWindowWGPUSurface)(WGPUInstance, _GLFWwindow*);
 };
 
 // Library global data
@@ -874,6 +912,10 @@ struct _GLFWlibrary
         GLFWbool        KHR_wayland_surface;
         GLFWbool        EXT_headless_surface;
     } vk;
+
+    struct {
+        PFN_wgpuInstanceCreateSurface instanceCreateSurface;
+    } wgpu;
 
     struct {
         GLFWmonitorfun  monitor;

--- a/src/internal.h
+++ b/src/internal.h
@@ -1051,6 +1051,8 @@ GLFWbool _glfwInitVulkan(int mode);
 void _glfwTerminateVulkan(void);
 const char* _glfwGetVulkanResultString(VkResult result);
 
+void _glfwLoadWGPUInstanceCreateSurfaceAddr(void);
+
 size_t _glfwEncodeUTF8(char* s, uint32_t codepoint);
 char** _glfwParseUriList(char* text, int* count);
 

--- a/src/webgpu.c
+++ b/src/webgpu.c
@@ -1,0 +1,54 @@
+//========================================================================
+// GLFW 3.5 - www.glfw.org
+//------------------------------------------------------------------------
+// Copyright (c) Sebastian Dawid <sdawid@techfak.uni-bielefeld.de>
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would
+//    be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such, and must not
+//    be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source
+//    distribution.
+//
+//========================================================================
+
+#include "internal.h"
+
+#include <assert.h>
+#include <stdlib.h>
+
+GLFWAPI void glfwSetWGPUInstanceCreateSurfaceAddr(WGPUSurface (*addr)(WGPUInstance, const WGPUSurfaceDescriptor*)) {
+    _GLFW_REQUIRE_INIT()
+    _glfw.wgpu.instanceCreateSurface = addr;
+}
+
+GLFWAPI WGPUSurface glfwCreateWindowWGPUSurface(WGPUInstance instance, GLFWwindow* handle) {
+    _GLFW_REQUIRE_INIT_OR_RETURN(NULL)
+
+    _GLFWwindow* window = (_GLFWwindow*)handle;
+
+    assert(window != NULL);
+    assert(instance != NULL);
+    assert(_glfw.wgpu.instanceCreateSurface != NULL);
+
+    if (window->context.client != GLFW_NO_API)
+    {
+        _glfwInputError(GLFW_INVALID_VALUE,
+                        "WebGPU: Window surface creation requires the window to have the client API set to GLFW_NO_API");
+        return NULL;
+    };
+
+    return _glfw.platform.createWindowWGPUSurface(instance, window);
+}

--- a/src/webgpu.c
+++ b/src/webgpu.c
@@ -28,14 +28,11 @@
 
 #include <assert.h>
 #include <stdlib.h>
-#if defined(_GLFW_WIN32)
-// TODO: Implement Window version
-#else
-#include <dlfcn.h>
-void _glfwLoadWGPUInstanceCreateSurfaceAddr() {
-    _glfw.wgpu.instanceCreateSurface = dlsym(RTLD_DEFAULT, "wgpuInstanceCreateSurface");
+
+GLFWAPI void glfwSetWGPUInstanceCreateSurfaceAddr(WGPUSurface (*addr)(WGPUInstance, const WGPUSurfaceDescriptor*)) {
+    _GLFW_REQUIRE_INIT()
+    _glfw.wgpu.instanceCreateSurface = addr;
 }
-#endif
 
 GLFWAPI WGPUSurface glfwCreateWindowWGPUSurface(WGPUInstance instance, GLFWwindow* handle) {
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL)

--- a/src/webgpu.c
+++ b/src/webgpu.c
@@ -28,11 +28,14 @@
 
 #include <assert.h>
 #include <stdlib.h>
-
-GLFWAPI void glfwSetWGPUInstanceCreateSurfaceAddr(WGPUSurface (*addr)(WGPUInstance, const WGPUSurfaceDescriptor*)) {
-    _GLFW_REQUIRE_INIT()
-    _glfw.wgpu.instanceCreateSurface = addr;
+#if defined(_GLFW_WIN32)
+// TODO: Implement Window version
+#else
+#include <dlfcn.h>
+void _glfwLoadWGPUInstanceCreateSurfaceAddr() {
+    _glfw.wgpu.instanceCreateSurface = dlsym(RTLD_DEFAULT, "wgpuInstanceCreateSurface");
 }
+#endif
 
 GLFWAPI WGPUSurface glfwCreateWindowWGPUSurface(WGPUInstance instance, GLFWwindow* handle) {
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL)

--- a/src/win32_init.c
+++ b/src/win32_init.c
@@ -669,7 +669,8 @@ GLFWbool _glfwConnectWin32(int platformID, _GLFWplatform* platform)
         .getEGLNativeWindow = _glfwGetEGLNativeWindowWin32,
         .getRequiredInstanceExtensions = _glfwGetRequiredInstanceExtensionsWin32,
         .getPhysicalDevicePresentationSupport = _glfwGetPhysicalDevicePresentationSupportWin32,
-        .createWindowSurface = _glfwCreateWindowSurfaceWin32
+        .createWindowSurface = _glfwCreateWindowSurfaceWin32,
+        .createWindowWGPUSurface = _glfwCreateWindowWGPUSurfaceWin32
     };
 
     *platform = win32;

--- a/src/win32_platform.h
+++ b/src/win32_platform.h
@@ -544,6 +544,8 @@ void _glfwGetRequiredInstanceExtensionsWin32(char** extensions);
 GLFWbool _glfwGetPhysicalDevicePresentationSupportWin32(VkInstance instance, VkPhysicalDevice device, uint32_t queuefamily);
 VkResult _glfwCreateWindowSurfaceWin32(VkInstance instance, _GLFWwindow* window, const VkAllocationCallbacks* allocator, VkSurfaceKHR* surface);
 
+WGPUSurface _glfwCreateWindowWGPUSurfaceWin32(WGPUInstance instance, _GLFWwindow* window);
+
 void _glfwFreeMonitorWin32(_GLFWmonitor* monitor);
 void _glfwGetMonitorPosWin32(_GLFWmonitor* monitor, int* xpos, int* ypos);
 void _glfwGetMonitorContentScaleWin32(_GLFWmonitor* monitor, float* xscale, float* yscale);

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -2562,6 +2562,26 @@ VkResult _glfwCreateWindowSurfaceWin32(VkInstance instance,
     return err;
 }
 
+typedef struct WGPUSurfaceSourceWindowsHWND {
+    WGPUChainedStruct chain;
+    void * hinstance;
+    void * hwnd;
+} WGPUSurfaceSourceWindowsHWND;
+
+WGPUSurface _glfwCreateWindowWGPUSurfaceWin32(WGPUInstance instance, _GLFWwindow *window) {
+    WGPUSurfaceSourceWindowsHWND windowsSurface;
+    windowsSurface.chain.sType = WGPUSType_SurfaceSourceWindowsHWND;
+    windowsSurface.chain.next = NULL;
+    windowsSurface.hinstance = _glfw.win32.instance;
+    windowsSurface.hwnd = window->win32.handle;
+
+    WGPUSurfaceDescriptor surfaceDescriptor;
+    surfaceDescriptor.nextInChain = &windowsSurface.chain;
+    surfaceDescriptor.label = (WGPUStringView){ NULL, SIZE_MAX };
+
+    return wgpuInstanceCreateSurface(instance, &surfaceDescriptor);
+}
+
 GLFWAPI HWND glfwGetWin32Window(GLFWwindow* handle)
 {
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -515,7 +515,8 @@ GLFWbool _glfwConnectWayland(int platformID, _GLFWplatform* platform)
         .getEGLNativeWindow = _glfwGetEGLNativeWindowWayland,
         .getRequiredInstanceExtensions = _glfwGetRequiredInstanceExtensionsWayland,
         .getPhysicalDevicePresentationSupport = _glfwGetPhysicalDevicePresentationSupportWayland,
-        .createWindowSurface = _glfwCreateWindowSurfaceWayland
+        .createWindowSurface = _glfwCreateWindowSurfaceWayland,
+        .createWindowWGPUSurface = _glfwCreateWindowWGPUSurfaceWayland
     };
 
     void* module = _glfwPlatformLoadModule("libwayland-client.so.0");

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -678,6 +678,8 @@ void _glfwGetRequiredInstanceExtensionsWayland(char** extensions);
 GLFWbool _glfwGetPhysicalDevicePresentationSupportWayland(VkInstance instance, VkPhysicalDevice device, uint32_t queuefamily);
 VkResult _glfwCreateWindowSurfaceWayland(VkInstance instance, _GLFWwindow* window, const VkAllocationCallbacks* allocator, VkSurfaceKHR* surface);
 
+WGPUSurface _glfwCreateWindowWGPUSurfaceWayland(WGPUInstance instance, _GLFWwindow* window);
+
 void _glfwFreeMonitorWayland(_GLFWmonitor* monitor);
 void _glfwGetMonitorPosWayland(_GLFWmonitor* monitor, int* xpos, int* ypos);
 void _glfwGetMonitorContentScaleWayland(_GLFWmonitor* monitor, float* xscale, float* yscale);

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -3326,6 +3326,25 @@ VkResult _glfwCreateWindowSurfaceWayland(VkInstance instance,
     return err;
 }
 
+typedef struct WGPUSurfaceSourceWaylandSurface {
+    WGPUChainedStruct chain;
+    void * display;
+    void * surface;
+} WGPUSurfaceSourceWaylandSurface;
+
+WGPUSurface _glfwCreateWindowWGPUSurfaceWayland(WGPUInstance instance, _GLFWwindow* window) {
+    WGPUSurfaceSourceWaylandSurface waylandSurface;   
+    waylandSurface.chain.sType = WGPUSType_SurfaceSourceWaylandSurface;
+    waylandSurface.chain.next = NULL;
+    waylandSurface.surface = window->wl.surface;
+    waylandSurface.display = _glfw.wl.display;
+
+    WGPUSurfaceDescriptor surfaceDescriptor;
+    surfaceDescriptor.nextInChain = &waylandSurface.chain;
+    surfaceDescriptor.label = (WGPUStringView){ NULL, SIZE_MAX };
+
+    return wgpuInstanceCreateSurface(instance, &surfaceDescriptor);
+}
 
 //////////////////////////////////////////////////////////////////////////
 //////                        GLFW native API                       //////

--- a/src/x11_init.c
+++ b/src/x11_init.c
@@ -1246,7 +1246,8 @@ GLFWbool _glfwConnectX11(int platformID, _GLFWplatform* platform)
         .getEGLNativeWindow = _glfwGetEGLNativeWindowX11,
         .getRequiredInstanceExtensions = _glfwGetRequiredInstanceExtensionsX11,
         .getPhysicalDevicePresentationSupport = _glfwGetPhysicalDevicePresentationSupportX11,
-        .createWindowSurface = _glfwCreateWindowSurfaceX11
+        .createWindowSurface = _glfwCreateWindowSurfaceX11,
+        .createWindowWGPUSurface = _glfwCreateWindowWGPUSurfaceX11
     };
 
     // HACK: If the application has left the locale as "C" then both wide

--- a/src/x11_platform.h
+++ b/src/x11_platform.h
@@ -963,6 +963,8 @@ void _glfwGetRequiredInstanceExtensionsX11(char** extensions);
 GLFWbool _glfwGetPhysicalDevicePresentationSupportX11(VkInstance instance, VkPhysicalDevice device, uint32_t queuefamily);
 VkResult _glfwCreateWindowSurfaceX11(VkInstance instance, _GLFWwindow* window, const VkAllocationCallbacks* allocator, VkSurfaceKHR* surface);
 
+WGPUSurface _glfwCreateWindowWGPUSurfaceX11(WGPUInstance instance, _GLFWwindow* window);
+
 void _glfwFreeMonitorX11(_GLFWmonitor* monitor);
 void _glfwGetMonitorPosX11(_GLFWmonitor* monitor, int* xpos, int* ypos);
 void _glfwGetMonitorContentScaleX11(_GLFWmonitor* monitor, float* xscale, float* yscale);


### PR DESCRIPTION
This PR adds the option to create a WebGPU surface using GLFW by calling `glfwCreateWindowWGPUSurface`.

The address of `wgpuInstanceCreateSurface` must be provided to the implementation via `glfwSetWGPUInstanceCreateSurfaceAddr`.

Including `<GLFW/glfw3.h>` will also include `<webgpu/webgpu.h>` if `GLFW_INCLUDE_WEBGPU` is defined before the include.

---

Example:
```c
#define GLFW_INCLUDE_WEBGPU
#include <GLFW/glfw3.h>

int main(void)
{
    glfwInit();
    glfwSetWGPUInstanceCreateSurfaceAddr(wgpuInstanceCreateSurface);

    glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
    GLFWwindow* window = glfwCreateWindow(800, 600, "WebGPU", NULL, NULL);
    WGPUInstance instance = wgpuCreateInstance(NULL);

    WGPUSurface surface = glfwCreateWindowWGPUSurface(instance, window);

    wgpuSurfaceRelease(surface);
    wgpuInstanceRelease(instance);
    glfwTerminate();
    return 0;
}
```