### PR TITLE
Prevent occasional app crash when waking from an idle display on X11

### DIFF
--- a/src/x11_monitor.c
+++ b/src/x11_monitor.c
@@ -151,6 +151,11 @@ void _glfwPollMonitorsX11(void)
             }
 
             XRRCrtcInfo* ci = XRRGetCrtcInfo(_glfw.x11.display, sr, oi->crtc);
+            if (!ci) {
+                XRRFreeOutputInfo(oi);
+                continue;
+            }
+
             if (ci->rotation == RR_Rotate_90 || ci->rotation == RR_Rotate_270)
             {
                 widthMM  = oi->mm_height;


### PR DESCRIPTION
This fixes an issue where GLFW apps will occasionally crash on X11 when waking up from system display idle.

The issue was discussed in the Kitty app [here](https://github.com/kovidgoyal/kitty/issues/1006) and this [same fix](https://github.com/kovidgoyal/kitty/commit/ab7f3310c4f7982026a897155eabb097683658b2) was applied to their vendored GLFW code. This is currently affecting [Fyne apps](https://github.com/fyne-io/fyne/issues/5899) and this same fix was proposed to [go-gl/glfw](https://github.com/go-gl/glfw/pull/411) but it was requested that this be fixed upstream.