### PR TITLE
macOS: Fallback to first NSScreen in multi-display mirroring mode

### DIFF
--- a/src/cocoa_monitor.m
+++ b/src/cocoa_monitor.m
@@ -314,6 +314,7 @@ void _glfwPollMonitorsCocoa(void)
                _glfw.monitorCount * sizeof(_GLFWmonitor*));
     }
 
+    NSArray* screens = [NSScreen screens];
     for (uint32_t i = 0;  i < displayCount;  i++)
     {
         if (CGDisplayIsAsleep(displays[i]))
@@ -322,7 +323,7 @@ void _glfwPollMonitorsCocoa(void)
         const uint32_t unitNumber = CGDisplayUnitNumber(displays[i]);
         NSScreen* screen = nil;
 
-        for (screen in [NSScreen screens])
+        for (screen in screens)
         {
             NSNumber* screenNumber = [screen deviceDescription][@"NSScreenNumber"];
 
@@ -332,6 +333,9 @@ void _glfwPollMonitorsCocoa(void)
             if (CGDisplayUnitNumber([screenNumber unsignedIntValue]) == unitNumber)
                 break;
         }
+        // fallback: when displays are in mirroring mode, only one NSScreen exists
+        if(screen == nil)
+            screen = [[NSScreen screens] firstObject];
 
         // HACK: Compare unit numbers instead of display IDs to work around
         //       display replacement on machines with automatic graphics


### PR DESCRIPTION
On macOS, [NSScreen screens] may return only a single logical screen when displays are set to mirroring mode. In this case, matching by display ID or unit number can fail, leaving `screen` as nil. Add a fallback to use the first available NSScreen to ensure a valid screen object is always returned.