### PR TITLE
Set dock icon on MacOS

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -36,6 +36,8 @@
 #include <string.h>
 #include <assert.h>
 
+#define nullptr ((void*)0) // i like c++
+
 // HACK: This enum value is missing from framework headers on OS X 10.11 despite
 //       having been (according to documentation) added in Mac OS X 10.7
 #define NSWindowCollectionBehaviorFullScreenNone (1 << 9)


### PR DESCRIPTION
Currently on MacOS, GLFW throws the error _"Regular windows do not have icons on macOS",_ and I use raylib so I wanted to fix that. Now GLFW sets the dock icon instead of throwing an error.

Here's an example with raylib, compiled with my changes:
<img width="797" height="525" alt="Screenshot 2025-12-25 at 8 13 08 PM" src="https://github.com/user-attachments/assets/84511e54-6fc7-4ff8-8d16-52830622c6ce" />

## Summary of commits
* Added nullptr alias
* included more libraries: Cocoa and the objc runtime
* Added private function __CocoaSetDockIcon
* Changed the function _glfwSetWindowIconCocoa





skibidi