### PR TITLE
refactor: Refactor function `_glfw_calloc`

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -251,13 +251,13 @@ void* _glfw_calloc(size_t count, size_t size)
     if (!count || !size)
         return NULL;
 
-    const size_t total_size = count * size;
-    if (total_size > SIZE_MAX)
+    if (count > SIZE_MAX / size)
     {
         _glfwInputError(GLFW_INVALID_VALUE, "Allocation size overflow");
         return NULL;
     }
 
+    const size_t total_size = count * size;
     void* block = _glfw.allocator.allocate(total_size, _glfw.allocator.user);
     if (!block)
     {


### PR DESCRIPTION
A simple refactor for the `_glfw_calloc` function. It does not modify the original function behavior, it just makes it more human readable and reduces the indentation.

Also, I created a constant called `total_size`, so the program doesn't need to multiply the same two variables three times.