### PR TITLE
Round halfway away from zero per fractional-scale-v1 protocol spec

### DIFF
--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -461,8 +461,9 @@ static void resizeFramebuffer(_GLFWwindow* window)
 {
     if (window->wl.fractionalScale)
     {
-        window->wl.fbWidth = (window->wl.width * window->wl.scalingNumerator) / 120;
-        window->wl.fbHeight = (window->wl.height * window->wl.scalingNumerator) / 120;
+        // Round halfway away from zero per fractional-scale-v1 protocol spec
+        window->wl.fbWidth = (window->wl.width * window->wl.scalingNumerator + 60) / 120;
+        window->wl.fbHeight = (window->wl.height * window->wl.scalingNumerator + 60) / 120;
     }
     else
     {


### PR DESCRIPTION
When using glfw with Minecraft (compiling glfw from source and using Prism Launcher's Workarounds -> "Use system installation of GLFW") for native Wayland support, the framebuffer is slightly smaller than the actual resolution for certain sizes and scale levels (for example, 4K at 132.5% scale, which is 159/120 for `wp_fractional_scale_v1::preferred_scale`), causing the compositor (tested with KDE Plasma) to slightly upscale the window, making it blurry.

This PR fixes the framebuffer size calculation to match [the spec](https://wayland.app/protocols/fractional-scale-v1) which states "For toplevel surfaces, the size is rounded halfway away from zero."