### PR TITLE
Wayland: Allow appId to be set with environmental variable

### DIFF
--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -965,8 +965,13 @@ static GLFWbool createLibdecorFrame(_GLFWwindow* window)
     libdecor_frame_commit(window->wl.libdecor.frame, frameState, NULL);
     libdecor_state_free(frameState);
 
-    if (strlen(window->wl.appId))
+    if (strlen(window->wl.appId)) {
         libdecor_frame_set_app_id(window->wl.libdecor.frame, window->wl.appId);
+    } else {
+        char *appId = getenv("GLFW_WAYLAND_APPID");
+        if (appId)
+            libdecor_frame_set_app_id(window->wl.libdecor.frame, appId);
+    }
 
     libdecor_frame_set_title(window->wl.libdecor.frame, window->title);
 
@@ -1081,8 +1086,13 @@ static GLFWbool createXdgShellObjects(_GLFWwindow* window)
 
     xdg_toplevel_add_listener(window->wl.xdg.toplevel, &xdgToplevelListener, window);
 
-    if (window->wl.appId)
+    if (window->wl.appId) {
         xdg_toplevel_set_app_id(window->wl.xdg.toplevel, window->wl.appId);
+    } else {
+        char *appId = getenv("GLFW_WAYLAND_APPID");
+        if (appId)
+            xdg_toplevel_set_app_id(window->wl.xdg.toplevel, appId);
+    }
 
     xdg_toplevel_set_title(window->wl.xdg.toplevel, window->title);
 
@@ -2545,6 +2555,12 @@ void _glfwFocusWindowWayland(_GLFWwindow* window)
         {
             xdg_activation_token_v1_set_app_id(window->wl.activationToken,
                                                requester->wl.appId);
+        } else {
+            char *appId = getenv("GLFW_WAYLAND_APPID");
+            if (appId) {
+                xdg_activation_token_v1_set_app_id(window->wl.activationToken,
+                                                   appId);
+            }
         }
     }
 


### PR DESCRIPTION
The primary purpose of this patch is to support Prism Launcher. Prism Launcher allows for using an alternate GLFW library and does so by launching Minecraft with the `-Dorg.lwjgl.glfw.libname=path/to/library` argument. However LWJGL3 does not have a command line argument to set the window appId which means that currently all Prism Launcher-managed Minecraft instances have a blank appId and are thus not correctly associated with Prism Launcher in Window Managers.

Unfortunately because Minecraft players frequently play old versions of Minecraft it's not really a valid solution to add such a command line argument to LWJGL3 as it would only fix future versions of Minecraft. Instead we can add an environmental variable fallback which is read only if the appId variable is not set. By doing so Prism Launcher can set this environmental variable for launched Minecraft instances and we can fix all existing versions of Minecraft and all existing modpacks (well, all versions of Minecraft with a version of LWJGL that works with the system GLFW library).