### PR TITLE
Win32: Clear to black in WM_PAINT for transparent framebuffer windows

### DIFF
--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -1139,6 +1139,22 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
         case WM_PAINT:
         {
             _glfwInputWindowDamage(window);
+
+            // The DWM redirection surface starts with undefined alpha.
+            // Clear to BLACKNESS which should zero out the alpha components as well.
+            if (window->win32.transparent)
+            {
+                PAINTSTRUCT ps;
+                HDC hdc = BeginPaint(hWnd, &ps);
+                PatBlt(hdc,
+                       ps.rcPaint.left,
+                       ps.rcPaint.top,
+                       ps.rcPaint.right  - ps.rcPaint.left,
+                       ps.rcPaint.bottom - ps.rcPaint.top,
+                       BLACKNESS);
+                EndPaint(hWnd, &ps);
+                return 0;
+            }
             break;
         }
 


### PR DESCRIPTION
The DWM redirection surface may contain undefined alpha values, causing the window to composite incorrectly. PatBlt with BLACKNESS clears both RGB and alpha to zero.
Repro for the issue: https://github.com/jeweg/glfw_repro1