### PR TITLE
Add glfwSetInputMethodCursorPos and improve IME behavior on macOS and Win32

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -5024,6 +5024,28 @@ GLFWAPI void glfwGetCursorPos(GLFWwindow* window, double* xpos, double* ypos);
  */
 GLFWAPI void glfwSetCursorPos(GLFWwindow* window, double xpos, double ypos);
 
+/*! @brief Sets input method cursor anchor position relative to the content area.
+ *
+ *  This function sets the anchor position used by platform input method
+ *  systems (such as IME candidate windows).  The position is specified in
+ *  screen coordinates relative to the upper-left corner of the content area.
+ *
+ *  @param[in] window The desired window.
+ *  @param[in] xpos The desired x-coordinate, relative to the left edge of the
+ *  content area.
+ *  @param[in] ypos The desired y-coordinate, relative to the top edge of the
+ *  content area.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @since Added in version 3.5.
+ *
+ *  @ingroup input
+ */
+GLFWAPI void glfwSetInputMethodCursorPos(GLFWwindow* window, double xpos, double ypos);
+
 /*! @brief Creates a custom cursor.
  *
  *  Creates a new custom cursor image that can be set for a window with @ref
@@ -6566,4 +6588,3 @@ GLFWAPI VkResult glfwCreateWindowSurface(VkInstance instance, GLFWwindow* window
 #endif
 
 #endif /* _glfw3_h_ */
-

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,7 +139,8 @@ target_include_directories(glfw PRIVATE
 target_link_libraries(glfw PRIVATE Threads::Threads)
 
 if (GLFW_BUILD_WIN32)
-    list(APPEND glfw_PKG_LIBS "-lgdi32")
+    list(APPEND glfw_PKG_LIBS "-lgdi32" "-limm32")
+    target_link_libraries(glfw PRIVATE imm32)
 endif()
 
 if (GLFW_BUILD_COCOA)
@@ -338,4 +339,3 @@ if (GLFW_INSTALL)
             ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
             LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 endif()
-

--- a/src/internal.h
+++ b/src/internal.h
@@ -558,6 +558,8 @@ struct _GLFWwindow
     char                keys[GLFW_KEY_LAST + 1];
     // Virtual cursor position when cursor is disabled
     double              virtualCursorPosX, virtualCursorPosY;
+    // Input method cursor anchor position (for IME candidate windows)
+    double              inputMethodCursorPosX, inputMethodCursorPosY;
     GLFWbool            rawMouseMotion;
 
     _GLFWcontext        context;
@@ -1018,4 +1020,3 @@ int _glfw_max(int a, int b);
 void* _glfw_calloc(size_t count, size_t size);
 void* _glfw_realloc(void* pointer, size_t size);
 void _glfw_free(void* pointer);
-


### PR DESCRIPTION
## Summary
This PR improves IME integration in GLFW for desktop text input workflows.

**What’s included**
1. New API: glfwSetInputMethodCursorPos(GLFWwindow* window, double xpos, double ypos)
    - Lets applications provide the current text cursor anchor position (content-area coordinates).
    - ntended for IME candidate/composition UI positioning.
2. macOS (Cocoa) improvements
    - firstRectForCharacterRange now uses the provided input method cursor position and converts it to screen coordinates.
    - During IME composition, editing keys (Backspace/Delete/Enter/Arrow/Home/End/Escape) are not forwarded to app key handlers, preventing accidental deletion of already committed text.
    - Composition state is tracked from setMarkedText / unmarkText / insertText.
3. Win32 improvements
    - glfwSetInputMethodCursorPos updates IME candidate/composition windows via:
        - ImmSetCandidateWindow
        - ImmSetCompositionWindow
    - Position is converted with window content scale so placement remains correct under DPI scaling.
4. Build update
    - Links imm32 when building Win32 backend.

## Motivation
In real-world IME usage:

- Candidate windows should appear near the text caret, not at a fallback corner.
- During preedit/composition, Backspace should edit the preedit text only, not delete committed text in the application input field.
These issues are especially visible with CJK input methods.

## API Notes
- The new function stores an IME anchor position per window.
- It is safe to call every frame / whenever caret position changes.
- Non-implemented platforms will still compile and keep existing behavior.

## Files changed
- glfw3.h
- internal.h
- input.c
- cocoa_window.m
- CMakeLists.txt

## Validation
Tested locally with:

- macOS: candidate window follows caret; Backspace during composition no longer deletes committed app text.
- Win32 code path implemented and build linkage updated (imm32).