### PR TITLE
Added Emscripten external platform (comment)

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -1344,6 +1344,10 @@ extern "C" {
 #define GLFW_PLATFORM_NULL          0x00060005
 /*! @} */
 
+/* Reserved platform define for external Emscripten ports: 0x00060006
+ * See https://github.com/pongasoft/emscripten-glfw
+ */
+
 #define GLFW_DONT_CARE              -1
 
 


### PR DESCRIPTION
This is the PR that was mentioned in this [discussion thread](https://discourse.glfw.org/t/glfw-3-4-external-platform/2572/1).

This PR "reserves" the Emscripten external platform in a comment to make sure this constant is not used in the future.

