### PR TITLE
Wayland: Don't segfault

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -81,6 +81,7 @@ video tutorials.
  - Mário Freitas
  - Friz64
  - GeO4d
+ - a-usr
  - Marcus Geelnard
  - Gegy
  - ghuser404

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ information on what to include when reporting a bug.
  - [Wayland] Bugfix: The `libwayland-client` library was not unloaded at termination
  - [Wayland] Bugfix: Scroll events were sent twice on some versions of GNOME (#2494)
  - [Wayland] Bugfix: Two-dimensional scroll input was emitted as separate axes
+- [Wayland] Bugfix: Receiving a keyboardModifier event before the keymap event would cause a segmentation fault
  - [X11] Bugfix: Running without a WM could trigger an assert (#2593,#2601,#2631)
  - [X11] Bugfix: Occasional crash when an idle display awakes (#2766) 
  - [X11] Bugfix: Prevent BadWindow when creating small windows with a content scale

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -1969,7 +1969,7 @@ static void keyboardHandleModifiers(void* userData,
 {
     _glfw.wl.serial = serial;
 
-    if (!_glfw.wl.xkb.keymap)
+    if (!_glfw.wl.xkb.keymap || !_glfw.wl.xkb.state)
         return;
 
     xkb_state_update_mask(_glfw.wl.xkb.state,


### PR DESCRIPTION
Since the compositor may send key modifiers before the keymap event, we may end up making libxkbcommon dereference a nullpointer for a state, which is... inconvenient.