### PR TITLE
Wayland: Add #ifndef guard for _GNU_SOURCE in wl_window.c

### DIFF
--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -24,7 +24,9 @@
 //
 //========================================================================
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #include "internal.h"
 


### PR DESCRIPTION
Hi, in the GLFW Go/Golang binding project, there is [issue #359](https://github.com/go-gl/glfw/issues/359), which is trying to solve the warning message "wl_window.c:29: **_GNU_SOURCE" redefined**" during building for Wayland.

```
../../go/pkg/mod/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20250301202403-da16c1255728/glfw/src/wl_window.c:29: warning: "_GNU_SOURCE" redefined
   29 | #define _GNU_SOURCE
```

It happens because go-gl/glfw includes like ...

```
  #include "glfw/src/wl_init.c"     // 1. #include "internal.h" → standard headers → features.h ✓                                                                                                                                                                                                               
  #include "glfw/src/wl_monitor.c"  // 2. #include "internal.h" → features.h already in cache
  #include "glfw/src/wl_window.c"   // 3. #define _GNU_SOURCE ← too late!
```
... the “features.h” file expects “_GNU_SOURCE” (to internally activate “__USE_GNU”). Then the variable was added to the compiler's CFLAGS. And it leads to the warning about redefined _GNU_SOURCE in the file /src/wl_window.c during compilation.

This PR adds a guard for the variable.

```
  #ifndef _GNU_SOURCE                                                                                                                                                                                                                                                                                           
  #define _GNU_SOURCE
  #endif
```

I believe it means no harm for you, and it helps on our side.
Thank you very much

This PR allows editing by maintainers.