### PR TITLE
Fix memory leak of un-cleaned up callbacks.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -306,6 +306,7 @@ video tutorials.
  - Jonas Ådahl
  - Lasse Öörni
  - Leonard König
+ - Noël Lemouël
  - Aaron Day
  - All the unmentioned and anonymous contributors in the GLFW community, for bug
    reports, patches, feedback, testing and encouragement

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -306,6 +306,7 @@ video tutorials.
  - Jonas Ådahl
  - Lasse Öörni
  - Leonard König
+ - Aaron Day
  - All the unmentioned and anonymous contributors in the GLFW community, for bug
    reports, patches, feedback, testing and encouragement
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ information on what to include when reporting a bug.
  - [Wayland] Bugfix: Mouse wheel scroll distance was incorrect on some compositors
  - [Wayland] Bugfix: `glfwSwapBuffers` would halt with nonzero swap interval when window
    was suspended (#1350,#2582,#2640,#2719,#2723,#2800,#2827)
+ - [Wayland] Bugfix: Fix memory leak in _glfwPostEmptyEventWayland by cleaning up callback
  - [X11] Bugfix: Running without a WM could trigger an assert (#2593,#2601,#2631)
  - [X11] Bugfix: Occasional crash when an idle display awakes (#2766) 
  - [X11] Bugfix: Prevent BadWindow when creating small windows with a content scale

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -2925,9 +2925,20 @@ void _glfwWaitEventsTimeoutWayland(double timeout)
     handleEvents(&timeout);
 }
 
+static void sync_done_handler(void* data, struct wl_callback* callback, uint32_t callback_data)
+{
+    /* Nothing to do, just destroy the callback */
+    wl_callback_destroy(callback);
+}
+
+static struct wl_callback_listener sync_listener = {
+    sync_done_handler
+};
+
 void _glfwPostEmptyEventWayland(void)
 {
-    wl_display_sync(_glfw.wl.display);
+    struct wl_callback *cb = wl_display_sync(_glfw.wl.display);
+    wl_callback_add_listener(cb, &sync_listener, NULL);
     flushDisplay();
 }
 


### PR DESCRIPTION
Copying the logic from libSDL fix.
https://github.com/libsdl-org/SDL/pull/8060/files