### PR TITLE
Wayland: Fix crash when unplugging the mouse during a cursor animation

### DIFF
--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -1239,6 +1239,9 @@ static GLFWbool createNativeSurface(_GLFWwindow* window,
 static void setCursorImage(_GLFWwindow* window,
                            _GLFWcursorWayland* cursorWayland)
 {
+    if (!_glfw.wl.pointer)
+        return;
+    
     struct itimerspec timer = {0};
     struct wl_cursor* wlCursor = cursorWayland->cursor;
     struct wl_cursor_image* image;


### PR DESCRIPTION
If the mouse was unplugged while a cursor animation was still running, no pointer leave event might be processed before the seat dropped pointer capability and GLFW destroyed its wl_pointer. The animated-cursor timer could then still fire and call wl_pointer_set_cursor with a null pointer, causing a crash inside wl_proxy_get_version.

Guard setCursorImage() so that cursor updates are skipped when _glfw.wl.pointer is null. A similar guard already exists in _glfwSetCursorWayland.