### PR TITLE
Linux: Fix joystick EV_KEY handling indexing below 0 on keyboard input

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -154,6 +154,7 @@ video tutorials.
  - Jean-Luc Mackail
  - Hans Mackowiak
  - Ramiro Magno
+ - Liam Malone
  - Дмитри Малышев
  - Zbigniew Mandziejewicz
  - Adam Marcus

--- a/src/linux_joystick.c
+++ b/src/linux_joystick.c
@@ -50,7 +50,7 @@
 //
 static void handleKeyEvent(_GLFWjoystick* js, int code, int value)
 {
-    _glfwInputJoystickButton(js,
+    if (code - BTN_MISC >= 0) _glfwInputJoystickButton(js,
                              js->linjs.keyMap[code - BTN_MISC],
                              value ? GLFW_PRESS : GLFW_RELEASE);
 }


### PR DESCRIPTION
Refreshes #2455 by @ptrToLiam, preserving the original code change and contributor credit.

I can reproduce this today with a Keychron Q3 Max connected over Bluetooth via raylib 6.0 / raylib-zig / Zig 0.16.0 on Linux.

Temporary logging in `src/linux_joystick.c` showed:

```text
GLFW joystick EV_KEY: code=28 BTN_MISC=256 index=-228 value=0 name=Keychron Q3 Max Keyboard
```

Without this guard, GLFW indexes:

```c
js->linjs.keyMap[code - BTN_MISC]
```

with a negative index and crashes.

I tested #2455’s patch against raylib 6.0's bundled GLFW. The `src/linux_joystick.c` hunk applied cleanly and fixed my repro; raylib's `InitWindow` completed and the program exited cleanly.

Related: #2484.