### PR TITLE
Fix building GLFW on TCC and others GCC compatible compiler

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -37,10 +37,20 @@ add_executable(triangle-opengles WIN32 MACOSX_BUNDLE triangle-opengles.c ${ICON}
 add_executable(wave WIN32 MACOSX_BUNDLE wave.c ${ICON} ${GLAD_GL})
 add_executable(windows WIN32 MACOSX_BUNDLE windows.c ${ICON} ${GLAD_GL})
 
-target_link_libraries(particles Threads::Threads)
+target_link_libraries(boing m)
+target_link_libraries(gears m)
+target_link_libraries(heightmap m)
+target_link_libraries(offscreen m)
+target_link_libraries(particles Threads::Threads m)
 if (RT_LIBRARY)
     target_link_libraries(particles "${RT_LIBRARY}")
 endif()
+target_link_libraries(sharing m)
+target_link_libraries(splitview m)
+target_link_libraries(triangle-opengl m)
+target_link_libraries(triangle-opengles m)
+target_link_libraries(wave m)
+target_link_libraries(windows m)
 
 set(GUI_ONLY_BINARIES boing gears heightmap particles sharing splitview
     triangle-opengl triangle-opengles wave windows)
@@ -80,4 +90,3 @@ if (APPLE)
                           MACOSX_BUNDLE_ICON_FILE glfw.icns
                           MACOSX_BUNDLE_INFO_PLIST "${GLFW_SOURCE_DIR}/CMake/Info.plist.in")
 endif()
-

--- a/src/regex.h
+++ b/src/regex.h
@@ -1,0 +1,22 @@
+#ifndef _REGEX_H
+#define _REGEX_H
+#include <sys/types.h>
+
+/* simplify regex struct for compability with other C compilers */
+typedef struct {
+    size_t re_nsub;
+    char __padding[128];
+} regex_t;
+
+typedef int regoff_t;
+typedef struct { regoff_t rm_so; regoff_t rm_eo; } regmatch_t;
+
+int regcomp(regex_t *, const char *, int);
+int regexec(const regex_t *, const char *, size_t, regmatch_t *, int);
+void regfree(regex_t *);
+
+#define REG_EXTENDED 1
+#define REG_ICASE    2
+#define REG_NOSUB    4
+#define REG_NEWLINE  8
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-link_libraries(glfw)
+link_libraries(glfw m)
 
 include_directories("${GLFW_SOURCE_DIR}/deps")
 


### PR DESCRIPTION
@elmindreda,

Clang, GCC, TCC, TDM-GCC successful building.

My experiments on 2 CPUs Xeon E5-2699v3 (72 threads): I am surprised by the compilation speed on TCC, as well as equivalent resource consumption on monitoring

    TCC 0.3s compilation (difference ~14x)
    Clang 4.1s compilation
    GCC 5.2s compialtion

I think Gentoo Linux users will idolize Fabrice Bellard.

https://en.wikipedia.org/wiki/Gentoo_Linux

Install tcc compiler easy on Debian/Ubuntu `apt install tcc`

Wiki: https://en.wikipedia.org/wiki/Tiny_C_Compiler
Official site: https://bellard.org/tcc/