### PR TITLE
wl_init: fix possible integer overflow

### DIFF
--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -394,7 +394,7 @@ static GLFWbool loadCursorTheme(void)
     {
         errno = 0;
         const long cursorSizeLong = strtol(sizeString, NULL, 10);
-        if (errno == 0 && cursorSizeLong > 0 && cursorSizeLong < INT_MAX)
+        if (errno == 0 && cursorSizeLong > 0 && cursorSizeLong < INT_MAX / 2)
             cursorSize = (int) cursorSizeLong;
     }
 


### PR DESCRIPTION
Signed integer overflow is possible in 'cursorSize * 2' arithmetic expression in 413 line. This leads to undefined behavior. Left operand is in range [0x1..0x7FFFFFFE], right operand is '2'