### PR TITLE
Wayland: Update cursor position while dragging

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -193,6 +193,7 @@ video tutorials.
  - F. Nedelec
  - n3rdopolis
  - Kristian Nielsen
+ - Thor Gabelgaard Nielsen
  - Joel Niemelä
  - Victor Nova
  - Kamil Nowakowski

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ information on what to include when reporting a bug.
    was suspended (#1350,#2582,#2640,#2719,#2723,#2800,#2827)
  - [Wayland] Bugfix: `glfwPostEmptyEvent` would leak a callback proxy (#2836)
  - [Wayland] Bugfix: `glfwHideWindow` did not always send its request immediately
+ - [Wayland] Bugfix: The cursor position was not updated while dragging over a window
  - [X11] Bugfix: Running without a WM could trigger an assert (#2593,#2601,#2631)
  - [X11] Bugfix: Occasional crash when an idle display awakes (#2766) 
  - [X11] Bugfix: Prevent BadWindow when creating small windows with a content scale

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -2224,6 +2224,13 @@ static void dataDeviceHandleMotion(void* userData,
                                    wl_fixed_t x,
                                    wl_fixed_t y)
 {
+    if (!_glfw.wl.dragFocus)
+        return;
+
+    _GLFWwindow* window = _glfw.wl.dragFocus;
+    window->wl.cursorPosX = wl_fixed_to_double(x);
+    window->wl.cursorPosY = wl_fixed_to_double(y);
+    _glfwInputCursorPos(window, window->wl.cursorPosX, window->wl.cursorPosY);
 }
 
 static void dataDeviceHandleDrop(void* userData,


### PR DESCRIPTION
The cursor position would not change until after paths were dropped on a window. This ensures the position of the corresponding window is updated, which matches the behaviour under X11.