### PR TITLE
Cocoa: Remove strict GPU acceleration requirement

### DIFF
--- a/src/nsgl_context.m
+++ b/src/nsgl_context.m
@@ -199,7 +199,6 @@ GLFWbool _glfwCreateContextNSGL(_GLFWwindow* window,
     NSOpenGLPixelFormatAttribute attribs[40];
     int index = 0;
 
-    ADD_ATTRIB(NSOpenGLPFAAccelerated);
     ADD_ATTRIB(NSOpenGLPFAClosestPolicy);
 
     if (ctxconfig->nsgl.offline)


### PR DESCRIPTION
Requiring GPU acceleration on MacOS causes rendering to fail on iGPU and some devices. Shouldn't glfw leave it to MacOS to decide whether it wants to use software renderer or GPU acceleration? 
