### PR TITLE
Wayland: Add glfwGetWaylandToplevel to export native xdg_toplevel

### DIFF
--- a/include/GLFW/glfw3native.h
+++ b/include/GLFW/glfw3native.h
@@ -554,6 +554,29 @@ GLFWAPI struct wl_output* glfwGetWaylandMonitor(GLFWmonitor* monitor);
  *  @ingroup native
  */
 GLFWAPI struct wl_surface* glfwGetWaylandWindow(GLFWwindow* window);
+
+/*! @brief Returns the native `struct xdg_toplevel*` of the specified window.
+ *
+ * If the window is managed by libdecor, this function dynamic-links and calls
+ * `libdecor_frame_get_xdg_toplevel` to retrieve the true underlying top-level
+ * surface from the active decoration plugin. If libdecor is inactive, it returns
+ * the standard XDG-shell top-level handle.
+ *
+ * @param[in] window The window whose top-level surface to retrieve.
+ * @return The native `struct xdg_toplevel*` of the specified window, or `NULL` if
+ * the window is not fully mapped or an [error](@ref error_handling) occurred.
+ *
+ * @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ * GLFW_PLATFORM_UNAVAILABLE.
+ *
+ * @thread_safety This function may be called from any thread. Access is not
+ * synchronized.
+ *
+ * @since Added in version 3.5.
+ *
+ * @ingroup native
+ */
+GLFWAPI struct xdg_toplevel* glfwGetWaylandToplevel(GLFWwindow* window);
 #endif
 
 #if defined(GLFW_EXPOSE_NATIVE_EGL)

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -3615,5 +3615,28 @@ GLFWAPI struct wl_surface* glfwGetWaylandWindow(GLFWwindow* handle)
     return window->wl.surface;
 }
 
+GLFWAPI struct xdg_toplevel* glfwGetWaylandToplevel(GLFWwindow* handle)
+{
+    _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    assert(window != NULL);
+
+    if (_glfw.wl.libdecor.context && window->wl.libdecor.frame)
+    {
+        extern void* dlsym(void* handle, const char* symbol);
+
+        PFN_libdecor_frame_get_xdg_toplevel real_libdecor_get_toplevel = 
+            (PFN_libdecor_frame_get_xdg_toplevel)dlsym(_glfw.wl.libdecor.handle, 
+                                                       "libdecor_frame_get_xdg_toplevel");
+
+        if (real_libdecor_get_toplevel)
+        {
+            return real_libdecor_get_toplevel(window->wl.libdecor.frame);
+        }
+    }
+
+    return window->wl.xdg.toplevel;    
+}
+
 #endif // _GLFW_WAYLAND
 


### PR DESCRIPTION
### Description
This PR introduces `glfwGetWaylandToplevel`, a new native platform-specific API function for the Wayland backend. 

### Why is this needed?
When GLFW utilizes `libdecor` for client-side window decorations, the internal `window->wl.xdg.toplevel` remains `NULL` because libdecor manages the top-level surface internally. This prevents applications from retrieving the actual `xdg_toplevel` handle required for advanced Wayland protocols, such as positioning modal dialogs or using specific shell extensions (e.g., `xdg_wm_dialog_v1`).

### How it works
The function checks if `libdecor` is active. If so, it dynamically loads and calls `libdecor_frame_get_xdg_toplevel` by using the internal `_glfw.wl.libdecor.handle` to break through the `RTLD_LOCAL` isolation. If `libdecor` is not used, it cleanly falls back to the standard `window->wl.xdg.toplevel`.