### PR TITLE
Cocoa: Add software renderer fallback for NSGL

### DIFF
--- a/src/nsgl_context.m
+++ b/src/nsgl_context.m
@@ -305,6 +305,19 @@ GLFWbool _glfwCreateContextNSGL(_GLFWwindow* window,
         [[NSOpenGLPixelFormat alloc] initWithAttributes:attribs];
     if (window->context.nsgl.pixelFormat == nil)
     {
+        // Fall back to the software renderer on systems with no accelerated
+        // renderer (e.g. VM guests). attribs[0] is always NSOpenGLPFAAccelerated
+        // (added at the top of this function); no pixel format can satisfy it
+        // without hardware acceleration. Retry once from attribs+1 so macOS can
+        // return its software (kCGLRendererGenericFloatID) renderer instead of
+        // failing. Hardware stays strictly preferred: the accelerated attempt
+        // runs first, so machines with a GPU never reach here.
+        assert(attribs[0] == NSOpenGLPFAAccelerated);
+        window->context.nsgl.pixelFormat =
+            [[NSOpenGLPixelFormat alloc] initWithAttributes:(attribs + 1)];
+    }
+    if (window->context.nsgl.pixelFormat == nil)
+    {
         _glfwInputError(GLFW_FORMAT_UNAVAILABLE,
                         "NSGL: Failed to find a suitable pixel format");
         return GLFW_FALSE;


### PR DESCRIPTION
## Summary

On a system with no accelerated OpenGL renderer (e.g. a GPU-less VM guest),
`_glfwCreateContextNSGL()` fails outright:

```
NSGL: Failed to find a suitable pixel format
```

`_glfwCreateContextNSGL()` adds `NSOpenGLPFAAccelerated` as `attribs[0]`, which
*requires* a hardware renderer. When none exists, `initWithAttributes:` returns
`nil` and context creation fails — even though the Apple software renderer is
present and usable.

This adds a fallback: if the accelerated pixel format is unavailable, retry once
from `attribs + 1` (dropping only `NSOpenGLPFAAccelerated`), so macOS can return
its software renderer instead of failing.

## Evidence

`CGLQueryRendererInfo()` on such a guest (macOS 15.7.7) reports exactly one
renderer:

```
renderer count: 1
  [0] id=0x01020400 accelerated=0 online=1 window=1
```

`0x01020400 & kCGLRendererIDMatchingMask (0x00FE7F00) == 0x00020400 ==
kCGLRendererGenericFloatID` — the Apple Software Renderer, `accelerated=0`,
`window=1` (can back a window). GLFW just never requests it.

## Why it is safe

- **Real GPU:** the accelerated request runs first and succeeds, so the fallback
  branch is never reached; behavior on hardware is unchanged.
- **No accelerated renderer:** the fallback yields a software context instead of
  a hard failure — strictly better than the status quo, since creation would
  otherwise fail entirely.

## Testing

Verified with a Fyne (Go, via `go-gl/glfw`) application requesting legacy
OpenGL 2.1: without the change it panics at window creation in a GPU-less
QEMU/KVM macOS 15.7.7 guest; with it, the window opens and renders (software, so
slow, but fully functional). No change on real Mac hardware.

## Notes

The patch relies on `attribs[0] == NSOpenGLPFAAccelerated` (guarded by an
`assert`), which holds in the current code. If you would prefer this gated behind
a window hint (per the request in #2080) rather than an unconditional fallback, I
am happy to rework it — the position-independent version would strip
`NSOpenGLPFAAccelerated` from the attribute list when the hint is set instead of
relying on the leading position.

Addresses #2080. Downstream context: go-gl/glfw#335, fyne-io/fyne#2373.
