### PR TITLE
Report all missing X11 dependencies

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -165,6 +165,7 @@ video tutorials.
  - David Medlock
  - Bryce Mehring
  - Jonathan Mercier
+ - meta-legend
  - Marcel Metz
  - Lucas Michaudel
  - Liam Middlebrook

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ information on what to include when reporting a bug.
  - Added `glfwGetEGLConfig` function to query the `EGLConfig` of a window (#2045)
  - Added `glfwGetGLXFBConfig` function to query the `GLXFBConfig` of a window (#1925)
  - Updated minimum CMake version to 3.16 (#2541)
+ - Improved CMake reporting of missing X11 build dependencies (#2844)
  - Removed support for building with original MinGW (#2540)
  - [Win32] Removed support for Windows XP and Vista (#2505)
  - [Cocoa] Added `QuartzCore` framework as link-time dependency

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -176,41 +176,61 @@ if (GLFW_BUILD_X11)
     find_package(X11 REQUIRED)
     target_include_directories(glfw PRIVATE "${X11_X11_INCLUDE_PATH}")
 
+    set(missing_X11_deps)
+
     # Check for XRandR (modern resolution switching and gamma control)
     if (NOT X11_Xrandr_INCLUDE_PATH)
-        message(FATAL_ERROR "RandR headers not found; install libxrandr development package")
+        list(APPEND missing_X11_deps
+             "RandR headers not found (install libxrandr development package)")
+    else()
+        target_include_directories(glfw PRIVATE "${X11_Xrandr_INCLUDE_PATH}")
     endif()
-    target_include_directories(glfw PRIVATE "${X11_Xrandr_INCLUDE_PATH}")
 
     # Check for Xinerama (legacy multi-monitor support)
     if (NOT X11_Xinerama_INCLUDE_PATH)
-        message(FATAL_ERROR "Xinerama headers not found; install libxinerama development package")
+        list(APPEND missing_X11_deps
+             "Xinerama headers not found (install libxinerama development package)")
+    else()
+        target_include_directories(glfw PRIVATE "${X11_Xinerama_INCLUDE_PATH}")
     endif()
-    target_include_directories(glfw PRIVATE "${X11_Xinerama_INCLUDE_PATH}")
 
     # Check for Xkb (X keyboard extension)
     if (NOT X11_Xkb_INCLUDE_PATH)
-        message(FATAL_ERROR "XKB headers not found; install X11 development package")
+        list(APPEND missing_X11_deps
+             "XKB headers not found (install X11 development package)")
+    else()
+        target_include_directories(glfw PRIVATE "${X11_Xkb_INCLUDE_PATH}")
     endif()
-    target_include_directories(glfw PRIVATE "${X11_Xkb_INCLUDE_PATH}")
 
     # Check for Xcursor (cursor creation from RGBA images)
     if (NOT X11_Xcursor_INCLUDE_PATH)
-        message(FATAL_ERROR "Xcursor headers not found; install libxcursor development package")
+        list(APPEND missing_X11_deps
+             "Xcursor headers not found (install libxcursor development package)")
+    else()
+        target_include_directories(glfw PRIVATE "${X11_Xcursor_INCLUDE_PATH}")
     endif()
-    target_include_directories(glfw PRIVATE "${X11_Xcursor_INCLUDE_PATH}")
 
     # Check for XInput (modern HID input)
     if (NOT X11_Xi_INCLUDE_PATH)
-        message(FATAL_ERROR "XInput headers not found; install libxi development package")
+        list(APPEND missing_X11_deps
+             "XInput headers not found (install libxi development package)")
+    else()
+        target_include_directories(glfw PRIVATE "${X11_Xi_INCLUDE_PATH}")
     endif()
-    target_include_directories(glfw PRIVATE "${X11_Xi_INCLUDE_PATH}")
 
     # Check for X Shape (custom window input shape)
     if (NOT X11_Xshape_INCLUDE_PATH)
-        message(FATAL_ERROR "X Shape headers not found; install libxext development package")
+        list(APPEND missing_X11_deps
+             "X Shape headers not found (install libxext development package)")
+    else()
+        target_include_directories(glfw PRIVATE "${X11_Xshape_INCLUDE_PATH}")
     endif()
-    target_include_directories(glfw PRIVATE "${X11_Xshape_INCLUDE_PATH}")
+
+    if (missing_X11_deps)
+        list(TRANSFORM missing_X11_deps PREPEND " - ")
+        list(JOIN missing_X11_deps "\n" missing_X11_deps_text)
+        message(FATAL_ERROR "Missing X11 dependencies:\n${missing_X11_deps_text}")
+    endif()
 endif()
 
 if (UNIX AND NOT APPLE)


### PR DESCRIPTION
This replaces the previous PR that was closed after I accidentally deleted my fork. 

Old PR: #2873 


PR Description: 
Previously, the X11 dependency checks stopped at the first missing dependency header. This meant users could install the missing package, rerun CMake, then hit the next missing package, over and over again.

This changes the X11 checks to collect all missing dependency headers first, then report them together in one error.

This also resolves https://github.com/glfw/glfw/issues/2844

I don't use Linux so I tested it with WSL.

Before the fix:
```
CMake Error at src/CMakeLists.txt:181 (message):
  RandR headers not found; install libxrandr development package
```
After the fix:
```
CMake Error at src/CMakeLists.txt:232 (message):
  Missing X11 dependencies:
   - RandR headers not found (install libxrandr development package)
   - Xinerama headers not found (install libxinerama development package)
   - Xcursor headers not found (install libxcursor development package)
   - XInput headers not found (install libxi development package)
   - X Shape headers not found (install libxext development package)
```
After installing the required packages, it built successfully.