### PR TITLE
Add window tiled state attribute

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -239,6 +239,7 @@ video tutorials.
  - Mikko Rytkönen
  - saikyun
  - Riku Salminen
+ - Anton Samokhvalov
  - Yoshinori Sano
  - Brandon Schaefer
  - Sebastian Schuberth

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ information on what to include when reporting a bug.
 
 ## Changelog since 3.4
 
+ - Added `GLFW_TILED` window attribute for querying compositor tiling state
  - Added `GLFW_UNLIMITED_MOUSE_BUTTONS` input mode that allows mouse buttons beyond
    the limit of the mouse button tokens to be reported (#2423)
  - Added `glfwGetEGLConfig` function to query the `EGLConfig` of a window (#2045)

--- a/docs/news.md
+++ b/docs/news.md
@@ -26,6 +26,12 @@ the `EGLConfig` of a window that has a `EGLSurface`.
 GLFW now provides the @ref glfwGetGLXFBConfig native access function for
 querying the `GLXFBConfig` of a window that has a `GLXWindow`.
 
+### Window tiling attribute {#window_tiling}
+
+GLFW now provides the @ref GLFW_TILED window attribute for querying whether the
+compositor has tiled a window.  This attribute is currently implemented on
+Wayland.
+
 
 ## Caveats {#caveats}
 
@@ -60,6 +66,7 @@ actively maintained and available on many platforms.
 
 ### New constants {#new_constants}
 
+- @ref GLFW_TILED
 - @ref GLFW_UNLIMITED_MOUSE_BUTTONS
 
 ## Release notes for earlier versions {#news_archive}

--- a/docs/window.md
+++ b/docs/window.md
@@ -1345,6 +1345,10 @@ See @ref window_iconify for details.
 __GLFW_MAXIMIZED__ indicates whether the specified window is maximized.  See
 @ref window_maximize for details.
 
+@anchor GLFW_TILED_attrib
+__GLFW_TILED__ indicates whether the compositor has tiled the specified window.
+It is currently implemented on Wayland and always false on other platforms.
+
 @anchor GLFW_HOVERED_attrib
 __GLFW_HOVERED__ indicates whether the cursor is currently directly over the
 content area of the window, with no other windows between.  See @ref

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -941,6 +941,12 @@ extern "C" {
  */
 #define GLFW_POSITION_Y             0x0002000F
 
+/*! @brief Window tiling window attribute.
+ *
+ *  Window tiling [window attribute](@ref GLFW_TILED_attrib).
+ */
+#define GLFW_TILED                  0x00020010
+
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_RED_BITS).

--- a/src/internal.h
+++ b/src/internal.h
@@ -540,6 +540,7 @@ struct _GLFWwindow
     GLFWbool            focusOnShow;
     GLFWbool            mousePassthrough;
     GLFWbool            shouldClose;
+    GLFWbool            tiled;
     void*               userPointer;
     GLFWbool            doublebuffer;
     GLFWvidmode         videoMode;

--- a/src/window.c
+++ b/src/window.c
@@ -893,6 +893,8 @@ GLFWAPI int glfwGetWindowAttrib(GLFWwindow* handle, int attrib)
             return _glfw.platform.windowVisible(window);
         case GLFW_MAXIMIZED:
             return _glfw.platform.windowMaximized(window);
+        case GLFW_TILED:
+            return window->tiled;
         case GLFW_HOVERED:
             return _glfw.platform.windowHovered(window);
         case GLFW_FOCUS_ON_SHOW:

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -392,6 +392,7 @@ typedef struct _GLFWwindowWayland
         GLFWbool                iconified;
         GLFWbool                activated;
         GLFWbool                fullscreen;
+        GLFWbool                tiled;
     } pending;
 
     struct {

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -730,6 +730,7 @@ static void xdgToplevelHandleConfigure(void* userData,
     window->wl.pending.activated  = GLFW_FALSE;
     window->wl.pending.maximized  = GLFW_FALSE;
     window->wl.pending.fullscreen = GLFW_FALSE;
+    window->wl.pending.tiled      = GLFW_FALSE;
 
     wl_array_for_each(state, states)
     {
@@ -740,6 +741,12 @@ static void xdgToplevelHandleConfigure(void* userData,
                 break;
             case XDG_TOPLEVEL_STATE_FULLSCREEN:
                 window->wl.pending.fullscreen = GLFW_TRUE;
+                break;
+            case XDG_TOPLEVEL_STATE_TILED_LEFT:
+            case XDG_TOPLEVEL_STATE_TILED_RIGHT:
+            case XDG_TOPLEVEL_STATE_TILED_TOP:
+            case XDG_TOPLEVEL_STATE_TILED_BOTTOM:
+                window->wl.pending.tiled = GLFW_TRUE;
                 break;
             case XDG_TOPLEVEL_STATE_RESIZING:
                 break;
@@ -808,6 +815,7 @@ static void xdgSurfaceHandleConfigure(void* userData,
     }
 
     window->wl.fullscreen = window->wl.pending.fullscreen;
+    window->tiled = window->wl.pending.tiled;
 
     int width  = window->wl.pending.width;
     int height = window->wl.pending.height;
@@ -858,19 +866,24 @@ void libdecorFrameHandleConfigure(struct libdecor_frame* frame,
     int width, height;
 
     enum libdecor_window_state windowState;
-    GLFWbool fullscreen, activated, maximized;
+    GLFWbool fullscreen, activated, maximized, tiled;
 
     if (libdecor_configuration_get_window_state(config, &windowState))
     {
         fullscreen = (windowState & LIBDECOR_WINDOW_STATE_FULLSCREEN) != 0;
         activated = (windowState & LIBDECOR_WINDOW_STATE_ACTIVE) != 0;
         maximized = (windowState & LIBDECOR_WINDOW_STATE_MAXIMIZED) != 0;
+        tiled = (windowState & (LIBDECOR_WINDOW_STATE_TILED_LEFT |
+                                LIBDECOR_WINDOW_STATE_TILED_RIGHT |
+                                LIBDECOR_WINDOW_STATE_TILED_TOP |
+                                LIBDECOR_WINDOW_STATE_TILED_BOTTOM)) != 0;
     }
     else
     {
         fullscreen = window->wl.fullscreen;
         activated = window->wl.activated;
         maximized = window->wl.maximized;
+        tiled = window->tiled;
     }
 
     if (!libdecor_configuration_get_content_size(config, frame, &width, &height))
@@ -917,6 +930,7 @@ void libdecorFrameHandleConfigure(struct libdecor_frame* frame,
     }
 
     window->wl.fullscreen = fullscreen;
+    window->tiled = tiled;
 
     GLFWbool damaged = GLFW_FALSE;
 


### PR DESCRIPTION
Some applications need to distinguish a freely resizable window from an extent controlled by a tiling compositor. For example, a grid-based application can align interactive floating resizes to its cell size without starting a resize feedback loop while tiled.

This adds the read-only `GLFW_TILED` window attribute. The Wayland backend tracks the xdg-shell tiled edge states for native decorations and the corresponding libdecor state flags for client-side decorations. Other backends report false.

The attribute is updated before resize callbacks are emitted, so applications can query the state while handling the new extent.

Tested with the upstream CMake build configured for Wayland, including a clean build of the GLFW static library.