### PR TITLE
Wayland: Fix crash when dragging a file over the window

### DIFF
--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -2141,9 +2141,23 @@ static void dataOfferHandleOffer(void* userData,
     }
 }
 
+static void dataOfferHandleSourceActions(void* userData,
+                                         struct wl_data_offer* offer,
+                                         uint32_t sourceActions)
+{
+}
+
+static void dataOfferHandleAction(void* userData,
+                                  struct wl_data_offer* offer,
+                                  uint32_t dndAction)
+{
+}
+
 static const struct wl_data_offer_listener dataOfferListener =
 {
-    dataOfferHandleOffer
+    dataOfferHandleOffer,
+    dataOfferHandleSourceActions,
+    dataOfferHandleAction
 };
 
 static void dataDeviceHandleDataOffer(void* userData,


### PR DESCRIPTION
This fixes #2835. Tested on Niri and labwc. File drop works, clipboard works. I can add a simple app in tests if needed.