### PR TITLE
Add X11 override redirect on window construction

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -313,6 +313,6 @@ video tutorials.
  - Jonas Ådahl
  - Lasse Öörni
  - Leonard König
+ - Sooly890
  - All the unmentioned and anonymous contributors in the GLFW community, for bug
    reports, patches, feedback, testing and encouragement
-

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ information on what to include when reporting a bug.
 
 ## Changelog since 3.5
 
-- Added `GLFW_X11_OVERRIDE_REDIRECT` window hint to bypass window managers taking control of a window when undesired
+- Added the `GLFW_X11_OVERRIDE_REDIRECT` window hint to bypass window manager control of a window when needed.
 
 
 ## Contact

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ information on what to include when reporting a bug.
 
 ## Changelog since 3.5
 
-None.
+- Added `GLFW_X11_OVERRIDE_REDIRECT` window hint to bypass window managers taking control of a window when undesired
 
 
 ## Contact
@@ -137,4 +137,3 @@ request, please file it in the
 
 Finally, if you're interested in helping out with the development of GLFW or
 porting it to your favorite platform, join us on the forum or GitHub.
-

--- a/docs/news.md
+++ b/docs/news.md
@@ -7,7 +7,7 @@
 
 ### X11 override redirect on window creation
 
-GLFW now provides the @ref GLFW_X11_OVERRIDE_REDIRECT_hint window hint to set override redirect on window creation.
+GLFW now provides the @ref GLFW_X11_OVERRIDE_REDIRECT_hint window hint to set override-redirect on window creation.
 
 ## Caveats {#caveats}
 

--- a/docs/news.md
+++ b/docs/news.md
@@ -5,6 +5,10 @@
 
 ## New features {#features}
 
+### X11 override redirect on window creation
+
+GLFW now provides the @ref GLFW_X11_OVERRIDE_REDIRECT_hint window hint to set override redirect on window creation.
+
 ## Caveats {#caveats}
 
 ## Deprecations {#deprecations}
@@ -19,6 +23,8 @@
 
 ### New constants {#new_constants}
 
+- @ref GLFW_X11_OVERRIDE_REDIRECT_hint
+
 ## Release notes for earlier versions {#news_archive}
 
 - [Release notes for 3.5](https://www.glfw.org/docs/3.5/news.html)
@@ -27,4 +33,3 @@
 - [Release notes for 3.2](https://www.glfw.org/docs/3.2/news.html)
 - [Release notes for 3.1](https://www.glfw.org/docs/3.1/news.html)
 - [Release notes for 3.0](https://www.glfw.org/docs/3.0/news.html)
-

--- a/docs/window.md
+++ b/docs/window.md
@@ -529,7 +529,7 @@ hints need to be set to something other than an empty string for them to take ef
 These are set with @ref glfwWindowHintString.
 
 @anchor GLFW_X11_OVERRIDE_REDIRECT_hint
-**GLFW_X11_OVERRIDE_REDIRECT** bypasses the window manager's control over a window. This is useful when a window needs to get around window manager's usage of a window (such as i3, which is extremely strict on where windows go). Accepted values are `GLFW_TRUE` and `GLFW_FALSE`.
+__GLFW_X11_OVERRIDE_REDIRECT__ bypasses the window manager's control for the created window (ICCCM override-redirect). This is set with @ref glfwWindowHint. Accepted values are `GLFW_TRUE` and `GLFW_FALSE`.
 
 #### Supported and default values {#window_hints_values}
 
@@ -582,6 +582,7 @@ GLFW_COCOA_GRAPHICS_SWITCHING | `GLFW_FALSE`                | `GLFW_TRUE` or `GL
 GLFW_WAYLAND_APP_ID           | `""`                        | An ASCII encoded Wayland `app_id` name
 GLFW_X11_CLASS_NAME           | `""`                        | An ASCII encoded `WM_CLASS` class name
 GLFW_X11_INSTANCE_NAME        | `""`                        | An ASCII encoded `WM_CLASS` instance name
+GLFW_X11_OVERRIDE_REDIRECT    | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
 
 
 ## Window event processing {#window_events}

--- a/docs/window.md
+++ b/docs/window.md
@@ -2,32 +2,30 @@
 
 [TOC]
 
-This guide introduces the window related functions of GLFW.  For details on
-a specific function in this category, see the @ref window.  There are also
+This guide introduces the window related functions of GLFW. For details on
+a specific function in this category, see the @ref window. There are also
 guides for the other areas of GLFW.
 
- - @ref intro_guide
- - @ref context_guide
- - @ref vulkan_guide
- - @ref monitor_guide
- - @ref input_guide
-
+- @ref intro_guide
+- @ref context_guide
+- @ref vulkan_guide
+- @ref monitor_guide
+- @ref input_guide
 
 ## Window objects {#window_object}
 
-The @ref GLFWwindow object encapsulates both a window and a context.  They are
+The @ref GLFWwindow object encapsulates both a window and a context. They are
 created with @ref glfwCreateWindow and destroyed with @ref glfwDestroyWindow, or
-@ref glfwTerminate, if any remain.  As the window and context are inseparably
+@ref glfwTerminate, if any remain. As the window and context are inseparably
 linked, the object pointer is used as both a context and window handle.
 
 To see the event stream provided to the various window related callbacks, run
 the `events` test program.
 
-
 ### Window creation {#window_creation}
 
 A window and its OpenGL or OpenGL ES context are created with @ref
-glfwCreateWindow, which returns a handle to the created window object.  For
+glfwCreateWindow, which returns a handle to the created window object. For
 example, this creates a 640 by 480 windowed mode window:
 
 ```c
@@ -41,11 +39,10 @@ The window handle is passed to all window related functions and is provided to
 along with all input events, so event handlers can tell which window received
 the event.
 
-
 #### Full screen windows {#window_full_screen}
 
 To create a full screen window, you need to specify which monitor the window
-should use.  In most cases, the user's primary monitor is a good choice.
+should use. In most cases, the user's primary monitor is a good choice.
 For more information about retrieving monitors, see @ref monitor_monitors.
 
 ```c
@@ -62,41 +59,40 @@ with the same function.
 Each field of the @ref GLFWvidmode structure corresponds to a function parameter
 or window hint and combine to form the _desired video mode_ for that window.
 The supported video mode most closely matching the desired video mode will be
-set for the chosen monitor as long as the window has input focus.  For more
+set for the chosen monitor as long as the window has input focus. For more
 information about retrieving video modes, see @ref monitor_modes.
 
-Video mode field        | Corresponds to
-----------------        | --------------
-GLFWvidmode.width       | `width` parameter of @ref glfwCreateWindow
-GLFWvidmode.height      | `height` parameter of @ref glfwCreateWindow
-GLFWvidmode.redBits     | @ref GLFW_RED_BITS hint
-GLFWvidmode.greenBits   | @ref GLFW_GREEN_BITS hint
-GLFWvidmode.blueBits    | @ref GLFW_BLUE_BITS hint
-GLFWvidmode.refreshRate | @ref GLFW_REFRESH_RATE hint
+| Video mode field        | Corresponds to                              |
+| ----------------------- | ------------------------------------------- |
+| GLFWvidmode.width       | `width` parameter of @ref glfwCreateWindow  |
+| GLFWvidmode.height      | `height` parameter of @ref glfwCreateWindow |
+| GLFWvidmode.redBits     | @ref GLFW_RED_BITS hint                     |
+| GLFWvidmode.greenBits   | @ref GLFW_GREEN_BITS hint                   |
+| GLFWvidmode.blueBits    | @ref GLFW_BLUE_BITS hint                    |
+| GLFWvidmode.refreshRate | @ref GLFW_REFRESH_RATE hint                 |
 
 Once you have a full screen window, you can change its resolution, refresh rate
-and monitor with @ref glfwSetWindowMonitor.  If you only need change its
-resolution you can also call @ref glfwSetWindowSize.  In all cases, the new
+and monitor with @ref glfwSetWindowMonitor. If you only need change its
+resolution you can also call @ref glfwSetWindowSize. In all cases, the new
 video mode will be selected the same way as the video mode chosen by @ref
-glfwCreateWindow.  If the window has an OpenGL or OpenGL ES context, it will be
+glfwCreateWindow. If the window has an OpenGL or OpenGL ES context, it will be
 unaffected.
 
 By default, the original video mode of the monitor will be restored and the
 window iconified if it loses input focus, to allow the user to switch back to
-the desktop.  This behavior can be disabled with the
+the desktop. This behavior can be disabled with the
 [GLFW_AUTO_ICONIFY](@ref GLFW_AUTO_ICONIFY_hint) window hint, for example if you
 wish to simultaneously cover multiple monitors with full screen windows.
 
 If a monitor is disconnected, all windows that are full screen on that monitor
-will be switched to windowed mode.  See @ref monitor_event for more information.
-
+will be switched to windowed mode. See @ref monitor_event for more information.
 
 #### "Windowed full screen" windows {#window_windowed_full_screen}
 
 If the closest match for the desired video mode is the current one, the video
 mode will not be changed, making window creation faster and application
-switching much smoother.  This is sometimes called _windowed full screen_ or
-_borderless full screen_ window and counts as a full screen window.  To create
+switching much smoother. This is sometimes called _windowed full screen_ or
+_borderless full screen_ window and counts as a full screen window. To create
 such a window, request the current video mode.
 
 ```c
@@ -122,7 +118,6 @@ Note that @ref glfwGetVideoMode returns the _current_ video mode of a monitor,
 so if you already have a full screen window on that monitor that you want to
 make windowed full screen, you need to have saved the desktop resolution before.
 
-
 ### Window destruction {#window_destruction}
 
 When a window is no longer needed, destroy it with @ref glfwDestroyWindow.
@@ -131,41 +126,40 @@ When a window is no longer needed, destroy it with @ref glfwDestroyWindow.
 glfwDestroyWindow(window);
 ```
 
-Window destruction always succeeds.  Before the actual destruction, all
+Window destruction always succeeds. Before the actual destruction, all
 callbacks are removed so no further events will be delivered for the window.
 All windows remaining when @ref glfwTerminate is called are destroyed as well.
 
 When a full screen window is destroyed, the original video mode of its monitor
 is restored, but the gamma ramp is left untouched.
 
-
 ### Window creation hints {#window_hints}
 
 There are a number of hints that can be set before the creation of a window and
-context.  Some affect the window itself, others affect the framebuffer or
-context.  These hints are set to their default values each time the library is
-initialized with @ref glfwInit.  Integer value hints can be set individually
+context. Some affect the window itself, others affect the framebuffer or
+context. These hints are set to their default values each time the library is
+initialized with @ref glfwInit. Integer value hints can be set individually
 with @ref glfwWindowHint and string value hints with @ref glfwWindowHintString.
 You can reset all at once to their defaults with @ref glfwDefaultWindowHints.
 
-Some hints are platform specific.  These are always valid to set on any
-platform but they will only affect their specific platform.  Other platforms
-will ignore them.  Setting these hints requires no platform specific headers or
+Some hints are platform specific. These are always valid to set on any
+platform but they will only affect their specific platform. Other platforms
+will ignore them. Setting these hints requires no platform specific headers or
 calls.
 
 @note Window hints need to be set before the creation of the window and context
-you wish to have the specified attributes.  They function as additional
+you wish to have the specified attributes. They function as additional
 arguments to @ref glfwCreateWindow.
-
 
 #### Hard and soft constraints {#window_hints_hard}
 
-Some window hints are hard constraints.  These must match the available
-capabilities _exactly_ for window and context creation to succeed.  Hints
+Some window hints are hard constraints. These must match the available
+capabilities _exactly_ for window and context creation to succeed. Hints
 that are not hard constraints are matched as closely as possible, but the
 resulting context and framebuffer may differ from what these hints requested.
 
 The following hints are always hard constraints:
+
 - @ref GLFW_STEREO
 - @ref GLFW_DOUBLEBUFFER
 - [GLFW_CLIENT_API](@ref GLFW_CLIENT_API_hint)
@@ -173,110 +167,109 @@ The following hints are always hard constraints:
 
 The following additional hints are hard constraints when requesting an OpenGL
 context, but are ignored when requesting an OpenGL ES context:
+
 - [GLFW_OPENGL_FORWARD_COMPAT](@ref GLFW_OPENGL_FORWARD_COMPAT_hint)
 - [GLFW_OPENGL_PROFILE](@ref GLFW_OPENGL_PROFILE_hint)
-
 
 #### Window related hints {#window_hints_wnd}
 
 @anchor GLFW_RESIZABLE_hint
-__GLFW_RESIZABLE__ specifies whether the windowed mode window will be resizable
-_by the user_.  The window will still be resizable using the @ref
-glfwSetWindowSize function.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.
+**GLFW_RESIZABLE** specifies whether the windowed mode window will be resizable
+_by the user_. The window will still be resizable using the @ref
+glfwSetWindowSize function. Possible values are `GLFW_TRUE` and `GLFW_FALSE`.
 This hint is ignored for full screen and undecorated windows.
 
 @anchor GLFW_VISIBLE_hint
-__GLFW_VISIBLE__ specifies whether the windowed mode window will be initially
-visible.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  This hint is
+**GLFW_VISIBLE** specifies whether the windowed mode window will be initially
+visible. Possible values are `GLFW_TRUE` and `GLFW_FALSE`. This hint is
 ignored for full screen windows.
 
 @anchor GLFW_DECORATED_hint
-__GLFW_DECORATED__ specifies whether the windowed mode window will have window
-decorations such as a border, a close widget, etc.  An undecorated window will
+**GLFW_DECORATED** specifies whether the windowed mode window will have window
+decorations such as a border, a close widget, etc. An undecorated window will
 not be resizable by the user but will still allow the user to generate close
-events on some platforms.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.
+events on some platforms. Possible values are `GLFW_TRUE` and `GLFW_FALSE`.
 This hint is ignored for full screen windows.
 
 @anchor GLFW_FOCUSED_hint
-__GLFW_FOCUSED__ specifies whether the windowed mode window will be given input
-focus when created.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  This
+**GLFW_FOCUSED** specifies whether the windowed mode window will be given input
+focus when created. Possible values are `GLFW_TRUE` and `GLFW_FALSE`. This
 hint is ignored for full screen and initially hidden windows.
 
 @anchor GLFW_AUTO_ICONIFY_hint
-__GLFW_AUTO_ICONIFY__ specifies whether the full screen window will
+**GLFW_AUTO_ICONIFY** specifies whether the full screen window will
 automatically iconify and restore the previous video mode on input focus loss.
-Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  This hint is ignored for
+Possible values are `GLFW_TRUE` and `GLFW_FALSE`. This hint is ignored for
 windowed mode windows.
 
 @anchor GLFW_FLOATING_hint
-__GLFW_FLOATING__ specifies whether the windowed mode window will be floating
-above other regular windows, also called topmost or always-on-top.  This is
+**GLFW_FLOATING** specifies whether the windowed mode window will be floating
+above other regular windows, also called topmost or always-on-top. This is
 intended primarily for debugging purposes and cannot be used to implement proper
-full screen windows.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  This
+full screen windows. Possible values are `GLFW_TRUE` and `GLFW_FALSE`. This
 hint is ignored for full screen windows.
 
 @anchor GLFW_MAXIMIZED_hint
-__GLFW_MAXIMIZED__ specifies whether the windowed mode window will be maximized
-when created.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  This hint is
+**GLFW_MAXIMIZED** specifies whether the windowed mode window will be maximized
+when created. Possible values are `GLFW_TRUE` and `GLFW_FALSE`. This hint is
 ignored for full screen windows.
 
 @anchor GLFW_CENTER_CURSOR_hint
-__GLFW_CENTER_CURSOR__ specifies whether the cursor should be centered over
-newly created full screen windows.  Possible values are `GLFW_TRUE` and
-`GLFW_FALSE`.  This hint is ignored for windowed mode windows.
+**GLFW_CENTER_CURSOR** specifies whether the cursor should be centered over
+newly created full screen windows. Possible values are `GLFW_TRUE` and
+`GLFW_FALSE`. This hint is ignored for windowed mode windows.
 
 @anchor GLFW_TRANSPARENT_FRAMEBUFFER_hint
-__GLFW_TRANSPARENT_FRAMEBUFFER__ specifies whether the window framebuffer will
-be transparent.  If enabled and supported by the system, the window framebuffer
-alpha channel will be used to combine the framebuffer with the background.  This
-does not affect window decorations.  Possible values are `GLFW_TRUE` and
+**GLFW_TRANSPARENT_FRAMEBUFFER** specifies whether the window framebuffer will
+be transparent. If enabled and supported by the system, the window framebuffer
+alpha channel will be used to combine the framebuffer with the background. This
+does not affect window decorations. Possible values are `GLFW_TRUE` and
 `GLFW_FALSE`.
 
 @anchor GLFW_FOCUS_ON_SHOW_hint
-__GLFW_FOCUS_ON_SHOW__ specifies whether the window will be given input
+**GLFW_FOCUS_ON_SHOW** specifies whether the window will be given input
 focus when @ref glfwShowWindow is called. Possible values are `GLFW_TRUE` and
 `GLFW_FALSE`.
 
 @anchor GLFW_SCALE_TO_MONITOR
-__GLFW_SCALE_TO_MONITOR__ specified whether the window content area should be
-resized based on [content scale](@ref window_scale) changes.  This can be
+**GLFW_SCALE_TO_MONITOR** specified whether the window content area should be
+resized based on [content scale](@ref window_scale) changes. This can be
 because of a global user settings change or because the window was moved to
 a monitor with different scale settings.
 
 This hint only has an effect on platforms where screen coordinates and pixels
-always map 1:1, such as Windows and X11.  On platforms like macOS the resolution
+always map 1:1, such as Windows and X11. On platforms like macOS the resolution
 of the framebuffer can change independently of the window size.
 
 @anchor GLFW_SCALE_FRAMEBUFFER_hint
 @anchor GLFW_COCOA_RETINA_FRAMEBUFFER_hint
-__GLFW_SCALE_FRAMEBUFFER__ specifies whether the framebuffer should be resized
-based on [content scale](@ref window_scale) changes.  This can be
+**GLFW_SCALE_FRAMEBUFFER** specifies whether the framebuffer should be resized
+based on [content scale](@ref window_scale) changes. This can be
 because of a global user settings change or because the window was moved to
 a monitor with different scale settings.
 
 This hint only has an effect on platforms where screen coordinates can be scaled
-relative to pixel coordinates, such as macOS and Wayland.  On platforms like
+relative to pixel coordinates, such as macOS and Wayland. On platforms like
 Windows and X11 the framebuffer and window content area sizes always map 1:1.
 
-This is the new name, introduced in GLFW 3.4.  The older
-`GLFW_COCOA_RETINA_FRAMEBUFFER` name is also available for compatibility.  Both
+This is the new name, introduced in GLFW 3.4. The older
+`GLFW_COCOA_RETINA_FRAMEBUFFER` name is also available for compatibility. Both
 names modify the same hint value.
 
 @anchor GLFW_MOUSE_PASSTHROUGH_hint
-__GLFW_MOUSE_PASSTHROUGH__ specifies whether the window is transparent to mouse
+**GLFW_MOUSE_PASSTHROUGH** specifies whether the window is transparent to mouse
 input, letting any mouse events pass through to whatever window is behind it.
-This is only supported for undecorated windows.  Decorated windows with this
-enabled will behave differently between platforms.  Possible values are
+This is only supported for undecorated windows. Decorated windows with this
+enabled will behave differently between platforms. Possible values are
 `GLFW_TRUE` and `GLFW_FALSE`.
 
 @anchor GLFW_POSITION_X
 @anchor GLFW_POSITION_Y
-__GLFW_POSITION_X__ and __GLFW_POSITION_Y__ specify the desired initial position
-of the window.  The window manager may modify or ignore these coordinates.  If
+**GLFW_POSITION_X** and **GLFW_POSITION_Y** specify the desired initial position
+of the window. The window manager may modify or ignore these coordinates. If
 either or both of these hints are set to `GLFW_ANY_POSITION` then the window
 manager will position the window where it thinks the user will prefer it.
 Possible values are any valid screen coordinates and `GLFW_ANY_POSITION`.
-
 
 #### Framebuffer related hints {#window_hints_fb}
 
@@ -286,99 +279,97 @@ Possible values are any valid screen coordinates and `GLFW_ANY_POSITION`.
 @anchor GLFW_ALPHA_BITS
 @anchor GLFW_DEPTH_BITS
 @anchor GLFW_STENCIL_BITS
-__GLFW_RED_BITS__, __GLFW_GREEN_BITS__, __GLFW_BLUE_BITS__, __GLFW_ALPHA_BITS__,
-__GLFW_DEPTH_BITS__ and __GLFW_STENCIL_BITS__ specify the desired bit depths of
-the various components of the default framebuffer.  A value of `GLFW_DONT_CARE`
+**GLFW_RED_BITS**, **GLFW_GREEN_BITS**, **GLFW_BLUE_BITS**, **GLFW_ALPHA_BITS**,
+**GLFW_DEPTH_BITS** and **GLFW_STENCIL_BITS** specify the desired bit depths of
+the various components of the default framebuffer. A value of `GLFW_DONT_CARE`
 means the application has no preference.
 
 @anchor GLFW_ACCUM_RED_BITS
 @anchor GLFW_ACCUM_GREEN_BITS
 @anchor GLFW_ACCUM_BLUE_BITS
 @anchor GLFW_ACCUM_ALPHA_BITS
-__GLFW_ACCUM_RED_BITS__, __GLFW_ACCUM_GREEN_BITS__, __GLFW_ACCUM_BLUE_BITS__ and
-__GLFW_ACCUM_ALPHA_BITS__ specify the desired bit depths of the various
-components of the accumulation buffer.  A value of `GLFW_DONT_CARE` means the
+**GLFW_ACCUM_RED_BITS**, **GLFW_ACCUM_GREEN_BITS**, **GLFW_ACCUM_BLUE_BITS** and
+**GLFW_ACCUM_ALPHA_BITS** specify the desired bit depths of the various
+components of the accumulation buffer. A value of `GLFW_DONT_CARE` means the
 application has no preference.
 
 Accumulation buffers are a legacy OpenGL feature and should not be used in new
 code.
 
 @anchor GLFW_AUX_BUFFERS
-__GLFW_AUX_BUFFERS__ specifies the desired number of auxiliary buffers.  A value
+**GLFW_AUX_BUFFERS** specifies the desired number of auxiliary buffers. A value
 of `GLFW_DONT_CARE` means the application has no preference.
 
 Auxiliary buffers are a legacy OpenGL feature and should not be used in new
 code.
 
 @anchor GLFW_STEREO
-__GLFW_STEREO__ specifies whether to use OpenGL stereoscopic rendering.
-Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  This is a hard constraint.
+**GLFW_STEREO** specifies whether to use OpenGL stereoscopic rendering.
+Possible values are `GLFW_TRUE` and `GLFW_FALSE`. This is a hard constraint.
 
 @anchor GLFW_SAMPLES
-__GLFW_SAMPLES__ specifies the desired number of samples to use for
-multisampling.  Zero disables multisampling.  A value of `GLFW_DONT_CARE` means
+**GLFW_SAMPLES** specifies the desired number of samples to use for
+multisampling. Zero disables multisampling. A value of `GLFW_DONT_CARE` means
 the application has no preference.
 
 @anchor GLFW_SRGB_CAPABLE
-__GLFW_SRGB_CAPABLE__ specifies whether the framebuffer should be sRGB capable.
+**GLFW_SRGB_CAPABLE** specifies whether the framebuffer should be sRGB capable.
 Possible values are `GLFW_TRUE` and `GLFW_FALSE`.
 
-@note __OpenGL:__ If enabled and supported by the system, the
-`GL_FRAMEBUFFER_SRGB` enable will control sRGB rendering.  By default, sRGB
+@note **OpenGL:** If enabled and supported by the system, the
+`GL_FRAMEBUFFER_SRGB` enable will control sRGB rendering. By default, sRGB
 rendering will be disabled.
 
-@note __OpenGL ES:__ If enabled and supported by the system, the context will
+@note **OpenGL ES:** If enabled and supported by the system, the context will
 always have sRGB rendering enabled.
 
 @anchor GLFW_DOUBLEBUFFER
 @anchor GLFW_DOUBLEBUFFER_hint
-__GLFW_DOUBLEBUFFER__ specifies whether the framebuffer should be double
-buffered.  You nearly always want to use double buffering.  This is a hard
-constraint.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.
-
+**GLFW_DOUBLEBUFFER** specifies whether the framebuffer should be double
+buffered. You nearly always want to use double buffering. This is a hard
+constraint. Possible values are `GLFW_TRUE` and `GLFW_FALSE`.
 
 #### Monitor related hints {#window_hints_mtr}
 
 @anchor GLFW_REFRESH_RATE
-__GLFW_REFRESH_RATE__ specifies the desired refresh rate for full screen
-windows.  A value of `GLFW_DONT_CARE` means the highest available refresh rate
-will be used.  This hint is ignored for windowed mode windows.
-
+**GLFW_REFRESH_RATE** specifies the desired refresh rate for full screen
+windows. A value of `GLFW_DONT_CARE` means the highest available refresh rate
+will be used. This hint is ignored for windowed mode windows.
 
 #### Context related hints {#window_hints_ctx}
 
 @anchor GLFW_CLIENT_API_hint
-__GLFW_CLIENT_API__ specifies which client API to create the context for.
+**GLFW_CLIENT_API** specifies which client API to create the context for.
 Possible values are `GLFW_OPENGL_API`, `GLFW_OPENGL_ES_API` and `GLFW_NO_API`.
 This is a hard constraint.
 
 @anchor GLFW_CONTEXT_CREATION_API_hint
-__GLFW_CONTEXT_CREATION_API__ specifies which context creation API to use to
-create the context.  Possible values are `GLFW_NATIVE_CONTEXT_API`,
-`GLFW_EGL_CONTEXT_API` and `GLFW_OSMESA_CONTEXT_API`.  This is a hard
-constraint.  If no client API is requested, this hint is ignored.
+**GLFW_CONTEXT_CREATION_API** specifies which context creation API to use to
+create the context. Possible values are `GLFW_NATIVE_CONTEXT_API`,
+`GLFW_EGL_CONTEXT_API` and `GLFW_OSMESA_CONTEXT_API`. This is a hard
+constraint. If no client API is requested, this hint is ignored.
 
 An [extension loader library](@ref context_glext_auto) that assumes it knows
 which API was used to create the current context may fail if you change this
-hint.  This can be resolved by having it load functions via @ref
+hint. This can be resolved by having it load functions via @ref
 glfwGetProcAddress.
 
-@note __Wayland:__ The EGL API _is_ the native context creation API, so this hint
+@note **Wayland:** The EGL API _is_ the native context creation API, so this hint
 will have no effect.
 
-@note __X11:__ On some Linux systems, creating contexts via both the native and EGL
-APIs in a single process will cause the application to segfault.  Stick to one
+@note **X11:** On some Linux systems, creating contexts via both the native and EGL
+APIs in a single process will cause the application to segfault. Stick to one
 API or the other on Linux for now.
 
-@note __OSMesa:__ As its name implies, an OpenGL context created with OSMesa
-does not update the window contents when its buffers are swapped.  Use OpenGL
+@note **OSMesa:** As its name implies, an OpenGL context created with OSMesa
+does not update the window contents when its buffers are swapped. Use OpenGL
 functions or the OSMesa native access functions @ref glfwGetOSMesaColorBuffer
 and @ref glfwGetOSMesaDepthBuffer to retrieve the framebuffer contents.
 
 @anchor GLFW_CONTEXT_VERSION_MAJOR_hint
 @anchor GLFW_CONTEXT_VERSION_MINOR_hint
-__GLFW_CONTEXT_VERSION_MAJOR__ and __GLFW_CONTEXT_VERSION_MINOR__ specify the
-client API version that the created context must be compatible with.  The exact
+**GLFW_CONTEXT_VERSION_MAJOR** and **GLFW_CONTEXT_VERSION_MINOR** specify the
+client API version that the created context must be compatible with. The exact
 behavior of these hints depend on the requested client API.
 
 While there is no way to ask the driver for a context of the highest supported
@@ -388,35 +379,35 @@ context, which is the default for these hints.
 Do not confuse these hints with @ref GLFW_VERSION_MAJOR and @ref
 GLFW_VERSION_MINOR, which provide the API version of the GLFW header.
 
-@note __OpenGL:__ These hints are not hard constraints, but creation will fail
-if the OpenGL version of the created context is less than the one requested.  It
+@note **OpenGL:** These hints are not hard constraints, but creation will fail
+if the OpenGL version of the created context is less than the one requested. It
 is therefore perfectly safe to use the default of version 1.0 for legacy code
 and you will still get backwards-compatible contexts of version 3.0 and above
 when available.
 
-@note __OpenGL ES:__ These hints are not hard constraints, but creation will
+@note **OpenGL ES:** These hints are not hard constraints, but creation will
 fail if the OpenGL ES version of the created context is less than the one
-requested.  Additionally, OpenGL ES 1.x cannot be returned if 2.0 or later was
-requested, and vice versa.  This is because OpenGL ES 3.x is backward compatible
+requested. Additionally, OpenGL ES 1.x cannot be returned if 2.0 or later was
+requested, and vice versa. This is because OpenGL ES 3.x is backward compatible
 with 2.0, but OpenGL ES 2.0 is not backward compatible with 1.x.
 
-@note __macOS:__ The OS only supports core profile contexts for OpenGL versions 3.2
-and later.  Before creating an OpenGL context of version 3.2 or later you must
+@note **macOS:** The OS only supports core profile contexts for OpenGL versions 3.2
+and later. Before creating an OpenGL context of version 3.2 or later you must
 set the [GLFW_OPENGL_PROFILE](@ref GLFW_OPENGL_PROFILE_hint) hint accordingly.
 OpenGL 3.0 and 3.1 contexts are not supported at all on macOS.
 
 @anchor GLFW_OPENGL_FORWARD_COMPAT_hint
-__GLFW_OPENGL_FORWARD_COMPAT__ specifies whether the OpenGL context should be
+**GLFW_OPENGL_FORWARD_COMPAT** specifies whether the OpenGL context should be
 forward-compatible, i.e. one where all functionality deprecated in the requested
-version of OpenGL is removed.  This must only be used if the requested OpenGL
-version is 3.0 or above.  If OpenGL ES is requested, this hint is ignored.
+version of OpenGL is removed. This must only be used if the requested OpenGL
+version is 3.0 or above. If OpenGL ES is requested, this hint is ignored.
 
 Forward-compatibility is described in detail in the
 [OpenGL Reference Manual](https://www.opengl.org/registry/).
 
 @anchor GLFW_CONTEXT_DEBUG_hint
 @anchor GLFW_OPENGL_DEBUG_CONTEXT_hint
-__GLFW_CONTEXT_DEBUG__ specifies whether the context should be created in debug
+**GLFW_CONTEXT_DEBUG** specifies whether the context should be created in debug
 mode, which may provide additional error and diagnostic reporting functionality.
 Possible values are `GLFW_TRUE` and `GLFW_FALSE`.
 
@@ -425,34 +416,34 @@ Debug contexts for OpenGL and OpenGL ES are described in detail by the
 
 [GL_KHR_debug]: https://www.khronos.org/registry/OpenGL/extensions/KHR/KHR_debug.txt
 
-@note `GLFW_CONTEXT_DEBUG` is the new name introduced in GLFW 3.4.  The older
+@note `GLFW_CONTEXT_DEBUG` is the new name introduced in GLFW 3.4. The older
 `GLFW_OPENGL_DEBUG_CONTEXT` name is also available for compatibility.
 
 @anchor GLFW_OPENGL_PROFILE_hint
-__GLFW_OPENGL_PROFILE__ specifies which OpenGL profile to create the context
-for.  Possible values are one of `GLFW_OPENGL_CORE_PROFILE` or
+**GLFW_OPENGL_PROFILE** specifies which OpenGL profile to create the context
+for. Possible values are one of `GLFW_OPENGL_CORE_PROFILE` or
 `GLFW_OPENGL_COMPAT_PROFILE`, or `GLFW_OPENGL_ANY_PROFILE` to not request
-a specific profile.  If requesting an OpenGL version below 3.2,
-`GLFW_OPENGL_ANY_PROFILE` must be used.  If OpenGL ES is requested, this hint
+a specific profile. If requesting an OpenGL version below 3.2,
+`GLFW_OPENGL_ANY_PROFILE` must be used. If OpenGL ES is requested, this hint
 is ignored.
 
 OpenGL profiles are described in detail in the
 [OpenGL Reference Manual](https://www.opengl.org/registry/).
 
 @anchor GLFW_CONTEXT_ROBUSTNESS_hint
-__GLFW_CONTEXT_ROBUSTNESS__ specifies the robustness strategy to be used by the
-context.  This can be one of `GLFW_NO_RESET_NOTIFICATION` or
+**GLFW_CONTEXT_ROBUSTNESS** specifies the robustness strategy to be used by the
+context. This can be one of `GLFW_NO_RESET_NOTIFICATION` or
 `GLFW_LOSE_CONTEXT_ON_RESET`, or `GLFW_NO_ROBUSTNESS` to not request
 a robustness strategy.
 
 @anchor GLFW_CONTEXT_RELEASE_BEHAVIOR_hint
-__GLFW_CONTEXT_RELEASE_BEHAVIOR__ specifies the release behavior to be
-used by the context.  Possible values are one of `GLFW_ANY_RELEASE_BEHAVIOR`,
-`GLFW_RELEASE_BEHAVIOR_FLUSH` or `GLFW_RELEASE_BEHAVIOR_NONE`.  If the
+**GLFW_CONTEXT_RELEASE_BEHAVIOR** specifies the release behavior to be
+used by the context. Possible values are one of `GLFW_ANY_RELEASE_BEHAVIOR`,
+`GLFW_RELEASE_BEHAVIOR_FLUSH` or `GLFW_RELEASE_BEHAVIOR_NONE`. If the
 behavior is `GLFW_ANY_RELEASE_BEHAVIOR`, the default behavior of the context
-creation API will be used.  If the behavior is `GLFW_RELEASE_BEHAVIOR_FLUSH`,
+creation API will be used. If the behavior is `GLFW_RELEASE_BEHAVIOR_FLUSH`,
 the pipeline will be flushed whenever the context is released from being the
-current one.  If the behavior is `GLFW_RELEASE_BEHAVIOR_NONE`, the pipeline will
+current one. If the behavior is `GLFW_RELEASE_BEHAVIOR_NONE`, the pipeline will
 not be flushed on release.
 
 Context release behaviors are described in detail by the
@@ -461,8 +452,8 @@ Context release behaviors are described in detail by the
 [GL_KHR_context_flush_control]: https://www.opengl.org/registry/specs/KHR/context_flush_control.txt
 
 @anchor GLFW_CONTEXT_NO_ERROR_hint
-__GLFW_CONTEXT_NO_ERROR__ specifies whether errors should be generated by the
-context.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  If enabled,
+**GLFW_CONTEXT_NO_ERROR** specifies whether errors should be generated by the
+context. Possible values are `GLFW_TRUE` and `GLFW_FALSE`. If enabled,
 situations that would have generated errors instead cause undefined behavior.
 
 The no error mode for OpenGL and OpenGL ES is described in detail by the
@@ -470,36 +461,34 @@ The no error mode for OpenGL and OpenGL ES is described in detail by the
 
 [GL_KHR_no_error]: https://www.opengl.org/registry/specs/KHR/no_error.txt
 
-
 #### Win32 specific hints {#window_hints_win32}
 
 @anchor GLFW_WIN32_KEYBOARD_MENU_hint
-__GLFW_WIN32_KEYBOARD_MENU__ specifies whether to allow access to the window
-menu via the Alt+Space and Alt-and-then-Space keyboard shortcuts.  This is
+**GLFW_WIN32_KEYBOARD_MENU** specifies whether to allow access to the window
+menu via the Alt+Space and Alt-and-then-Space keyboard shortcuts. This is
 ignored on other platforms.
 
 @anchor GLFW_WIN32_SHOWDEFAULT_hint
-__GLFW_WIN32_SHOWDEFAULT__ specifies whether to show the window the way
+**GLFW_WIN32_SHOWDEFAULT** specifies whether to show the window the way
 specified in the program's `STARTUPINFO` when it is shown for the first time.
 This is the same information as the `Run` option in the shortcut properties
-window.  If this information was not specified when the program was started,
-GLFW behaves as if this hint was set to `GLFW_FALSE`.  Possible values are
-`GLFW_TRUE` and `GLFW_FALSE`.  This is ignored on other platforms.
-
+window. If this information was not specified when the program was started,
+GLFW behaves as if this hint was set to `GLFW_FALSE`. Possible values are
+`GLFW_TRUE` and `GLFW_FALSE`. This is ignored on other platforms.
 
 #### macOS specific hints {#window_hints_osx}
 
 @anchor GLFW_COCOA_FRAME_NAME_hint
-__GLFW_COCOA_FRAME_NAME__ specifies the UTF-8 encoded name to use for autosaving
-the window frame, or if empty disables frame autosaving for the window.  This is
-ignored on other platforms.  This is set with @ref glfwWindowHintString.
+**GLFW_COCOA_FRAME_NAME** specifies the UTF-8 encoded name to use for autosaving
+the window frame, or if empty disables frame autosaving for the window. This is
+ignored on other platforms. This is set with @ref glfwWindowHintString.
 
 @anchor GLFW_COCOA_GRAPHICS_SWITCHING_hint
-__GLFW_COCOA_GRAPHICS_SWITCHING__ specifies whether to in Automatic Graphics
+**GLFW_COCOA_GRAPHICS_SWITCHING** specifies whether to in Automatic Graphics
 Switching, i.e. to allow the system to choose the integrated GPU for the OpenGL
 context and move it between GPUs if necessary or whether to force it to always
-run on the discrete GPU.  This only affects systems with both integrated and
-discrete GPUs.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  This is
+run on the discrete GPU. This only affects systems with both integrated and
+discrete GPUs. Possible values are `GLFW_TRUE` and `GLFW_FALSE`. This is
 ignored on other platforms.
 
 Simpler programs and tools may want to enable this to save power, while games
@@ -510,94 +499,91 @@ A bundled application that wishes to participate in Automatic Graphics Switching
 should also declare this in its `Info.plist` by setting the
 `NSSupportsAutomaticGraphicsSwitching` key to `true`.
 
-
 #### Wayland specific window hints {#window_hints_wayland}
 
 @anchor GLFW_WAYLAND_APP_ID_hint
-__GLFW_WAYLAND_APP_ID__ specifies the Wayland app_id for a window, used
+**GLFW_WAYLAND_APP_ID** specifies the Wayland app_id for a window, used
 by window managers to identify types of windows. This is set with
 @ref glfwWindowHintString.
-
 
 #### X11 specific window hints {#window_hints_x11}
 
 @anchor GLFW_X11_CLASS_NAME_hint
 @anchor GLFW_X11_INSTANCE_NAME_hint
-__GLFW_X11_CLASS_NAME__ and __GLFW_X11_INSTANCE_NAME__ specifies the desired
-ASCII encoded class and instance parts of the ICCCM `WM_CLASS` window property.  Both
+**GLFW_X11_CLASS_NAME** and **GLFW_X11_INSTANCE_NAME** specifies the desired
+ASCII encoded class and instance parts of the ICCCM `WM_CLASS` window property. Both
 hints need to be set to something other than an empty string for them to take effect.
 These are set with @ref glfwWindowHintString.
 
+@anchor GLFW_X11_OVERRIDE_REDIRECT_hint
+**GLFW_X11_OVERRIDE_REDIRECT** bypasses the window manager's control over a window. This is useful when a window needs to get around window manager's usage of a window (such as i3, which is extremely strict on where windows go). Accepted values are GLFW_TRUE and GLFW_FALSE.
 
 #### Supported and default values {#window_hints_values}
 
-Window hint                   | Default value               | Supported values
------------------------------ | --------------------------- | ----------------
-GLFW_RESIZABLE                | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`
-GLFW_VISIBLE                  | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`
-GLFW_DECORATED                | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`
-GLFW_FOCUSED                  | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`
-GLFW_AUTO_ICONIFY             | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`
-GLFW_FLOATING                 | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
-GLFW_MAXIMIZED                | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
-GLFW_CENTER_CURSOR            | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`
-GLFW_TRANSPARENT_FRAMEBUFFER  | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
-GLFW_FOCUS_ON_SHOW            | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`
-GLFW_SCALE_TO_MONITOR         | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
-GLFW_SCALE_FRAMEBUFFER        | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`
-GLFW_MOUSE_PASSTHROUGH        | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
-GLFW_POSITION_X               | `GLFW_ANY_POSITION`         | Any valid screen x-coordinate or `GLFW_ANY_POSITION`
-GLFW_POSITION_Y               | `GLFW_ANY_POSITION`         | Any valid screen y-coordinate or `GLFW_ANY_POSITION`
-GLFW_RED_BITS                 | 8                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`
-GLFW_GREEN_BITS               | 8                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`
-GLFW_BLUE_BITS                | 8                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`
-GLFW_ALPHA_BITS               | 8                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`
-GLFW_DEPTH_BITS               | 24                          | 0 to `INT_MAX` or `GLFW_DONT_CARE`
-GLFW_STENCIL_BITS             | 8                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`
-GLFW_ACCUM_RED_BITS           | 0                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`
-GLFW_ACCUM_GREEN_BITS         | 0                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`
-GLFW_ACCUM_BLUE_BITS          | 0                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`
-GLFW_ACCUM_ALPHA_BITS         | 0                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`
-GLFW_AUX_BUFFERS              | 0                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`
-GLFW_SAMPLES                  | 0                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`
-GLFW_REFRESH_RATE             | `GLFW_DONT_CARE`            | 0 to `INT_MAX` or `GLFW_DONT_CARE`
-GLFW_STEREO                   | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
-GLFW_SRGB_CAPABLE             | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
-GLFW_DOUBLEBUFFER             | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`
-GLFW_CLIENT_API               | `GLFW_OPENGL_API`           | `GLFW_OPENGL_API`, `GLFW_OPENGL_ES_API` or `GLFW_NO_API`
-GLFW_CONTEXT_CREATION_API     | `GLFW_NATIVE_CONTEXT_API`   | `GLFW_NATIVE_CONTEXT_API`, `GLFW_EGL_CONTEXT_API` or `GLFW_OSMESA_CONTEXT_API`
-GLFW_CONTEXT_VERSION_MAJOR    | 1                           | Any valid major version number of the chosen client API
-GLFW_CONTEXT_VERSION_MINOR    | 0                           | Any valid minor version number of the chosen client API
-GLFW_CONTEXT_ROBUSTNESS       | `GLFW_NO_ROBUSTNESS`        | `GLFW_NO_ROBUSTNESS`, `GLFW_NO_RESET_NOTIFICATION` or `GLFW_LOSE_CONTEXT_ON_RESET`
-GLFW_CONTEXT_RELEASE_BEHAVIOR | `GLFW_ANY_RELEASE_BEHAVIOR` | `GLFW_ANY_RELEASE_BEHAVIOR`, `GLFW_RELEASE_BEHAVIOR_FLUSH` or `GLFW_RELEASE_BEHAVIOR_NONE`
-GLFW_OPENGL_FORWARD_COMPAT    | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
-GLFW_CONTEXT_DEBUG            | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
-GLFW_OPENGL_PROFILE           | `GLFW_OPENGL_ANY_PROFILE`   | `GLFW_OPENGL_ANY_PROFILE`, `GLFW_OPENGL_COMPAT_PROFILE` or `GLFW_OPENGL_CORE_PROFILE`
-GLFW_WIN32_KEYBOARD_MENU      | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
-GLFW_WIN32_SHOWDEFAULT        | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
-GLFW_COCOA_FRAME_NAME         | `""`                        | A UTF-8 encoded frame autosave name
-GLFW_COCOA_GRAPHICS_SWITCHING | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
-GLFW_WAYLAND_APP_ID           | `""`                        | An ASCII encoded Wayland `app_id` name
-GLFW_X11_CLASS_NAME           | `""`                        | An ASCII encoded `WM_CLASS` class name
-GLFW_X11_INSTANCE_NAME        | `""`                        | An ASCII encoded `WM_CLASS` instance name
-
+| Window hint                   | Default value               | Supported values                                                                           |
+| ----------------------------- | --------------------------- | ------------------------------------------------------------------------------------------ |
+| GLFW_RESIZABLE                | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
+| GLFW_VISIBLE                  | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
+| GLFW_DECORATED                | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
+| GLFW_FOCUSED                  | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
+| GLFW_AUTO_ICONIFY             | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
+| GLFW_FLOATING                 | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
+| GLFW_MAXIMIZED                | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
+| GLFW_CENTER_CURSOR            | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
+| GLFW_TRANSPARENT_FRAMEBUFFER  | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
+| GLFW_FOCUS_ON_SHOW            | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
+| GLFW_SCALE_TO_MONITOR         | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
+| GLFW_SCALE_FRAMEBUFFER        | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
+| GLFW_MOUSE_PASSTHROUGH        | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
+| GLFW_POSITION_X               | `GLFW_ANY_POSITION`         | Any valid screen x-coordinate or `GLFW_ANY_POSITION`                                       |
+| GLFW_POSITION_Y               | `GLFW_ANY_POSITION`         | Any valid screen y-coordinate or `GLFW_ANY_POSITION`                                       |
+| GLFW_RED_BITS                 | 8                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`                                                         |
+| GLFW_GREEN_BITS               | 8                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`                                                         |
+| GLFW_BLUE_BITS                | 8                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`                                                         |
+| GLFW_ALPHA_BITS               | 8                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`                                                         |
+| GLFW_DEPTH_BITS               | 24                          | 0 to `INT_MAX` or `GLFW_DONT_CARE`                                                         |
+| GLFW_STENCIL_BITS             | 8                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`                                                         |
+| GLFW_ACCUM_RED_BITS           | 0                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`                                                         |
+| GLFW_ACCUM_GREEN_BITS         | 0                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`                                                         |
+| GLFW_ACCUM_BLUE_BITS          | 0                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`                                                         |
+| GLFW_ACCUM_ALPHA_BITS         | 0                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`                                                         |
+| GLFW_AUX_BUFFERS              | 0                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`                                                         |
+| GLFW_SAMPLES                  | 0                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`                                                         |
+| GLFW_REFRESH_RATE             | `GLFW_DONT_CARE`            | 0 to `INT_MAX` or `GLFW_DONT_CARE`                                                         |
+| GLFW_STEREO                   | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
+| GLFW_SRGB_CAPABLE             | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
+| GLFW_DOUBLEBUFFER             | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
+| GLFW_CLIENT_API               | `GLFW_OPENGL_API`           | `GLFW_OPENGL_API`, `GLFW_OPENGL_ES_API` or `GLFW_NO_API`                                   |
+| GLFW_CONTEXT_CREATION_API     | `GLFW_NATIVE_CONTEXT_API`   | `GLFW_NATIVE_CONTEXT_API`, `GLFW_EGL_CONTEXT_API` or `GLFW_OSMESA_CONTEXT_API`             |
+| GLFW_CONTEXT_VERSION_MAJOR    | 1                           | Any valid major version number of the chosen client API                                    |
+| GLFW_CONTEXT_VERSION_MINOR    | 0                           | Any valid minor version number of the chosen client API                                    |
+| GLFW_CONTEXT_ROBUSTNESS       | `GLFW_NO_ROBUSTNESS`        | `GLFW_NO_ROBUSTNESS`, `GLFW_NO_RESET_NOTIFICATION` or `GLFW_LOSE_CONTEXT_ON_RESET`         |
+| GLFW_CONTEXT_RELEASE_BEHAVIOR | `GLFW_ANY_RELEASE_BEHAVIOR` | `GLFW_ANY_RELEASE_BEHAVIOR`, `GLFW_RELEASE_BEHAVIOR_FLUSH` or `GLFW_RELEASE_BEHAVIOR_NONE` |
+| GLFW_OPENGL_FORWARD_COMPAT    | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
+| GLFW_CONTEXT_DEBUG            | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
+| GLFW_OPENGL_PROFILE           | `GLFW_OPENGL_ANY_PROFILE`   | `GLFW_OPENGL_ANY_PROFILE`, `GLFW_OPENGL_COMPAT_PROFILE` or `GLFW_OPENGL_CORE_PROFILE`      |
+| GLFW_WIN32_KEYBOARD_MENU      | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
+| GLFW_WIN32_SHOWDEFAULT        | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
+| GLFW_COCOA_FRAME_NAME         | `""`                        | A UTF-8 encoded frame autosave name                                                        |
+| GLFW_COCOA_GRAPHICS_SWITCHING | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
+| GLFW_WAYLAND_APP_ID           | `""`                        | An ASCII encoded Wayland `app_id` name                                                     |
+| GLFW_X11_CLASS_NAME           | `""`                        | An ASCII encoded `WM_CLASS` class name                                                     |
+| GLFW_X11_INSTANCE_NAME        | `""`                        | An ASCII encoded `WM_CLASS` instance name                                                  |
 
 ## Window event processing {#window_events}
 
 See @ref events.
-
 
 ## Window properties and events {#window_properties}
 
 ### User pointer {#window_userptr}
 
 Each window has a user pointer that can be set with @ref
-glfwSetWindowUserPointer and queried with @ref glfwGetWindowUserPointer.  This
+glfwSetWindowUserPointer and queried with @ref glfwGetWindowUserPointer. This
 can be used for any purpose you need and will not be modified by GLFW throughout
 the life-time of the window.
 
 The initial value of the pointer is `NULL`.
-
 
 ### Window closing and close flag {#window_close}
 
@@ -607,7 +593,7 @@ The window is however not actually destroyed and, unless you watch for this
 state change, nothing further happens.
 
 The current state of the close flag is returned by @ref glfwWindowShouldClose
-and can be set or cleared directly with @ref glfwSetWindowShouldClose.  A common
+and can be set or cleared directly with @ref glfwSetWindowShouldClose. A common
 pattern is to use the close flag as a main loop condition.
 
 ```c
@@ -639,21 +625,20 @@ void window_close_callback(GLFWwindow* window)
 }
 ```
 
-
 ### Window size {#window_size}
 
-The size of a window can be changed with @ref glfwSetWindowSize.  For windowed
+The size of a window can be changed with @ref glfwSetWindowSize. For windowed
 mode windows, this sets the size, in
 [screen coordinates](@ref coordinate_systems) of the _content area_ or _content
-area_ of the window.  The window system may impose limits on window size.
+area_ of the window. The window system may impose limits on window size.
 
 ```c
 glfwSetWindowSize(window, 640, 480);
 ```
 
 For full screen windows, the specified size becomes the new resolution of the
-window's desired video mode.  The video mode most closely matching the new
-desired video mode is set immediately.  The window is resized to fit the
+window's desired video mode. The video mode most closely matching the new
+desired video mode is set immediately. The window is resized to fit the
 resolution of the set video mode.
 
 If you wish to be notified when a window is resized, whether by the user, the
@@ -681,12 +666,12 @@ glfwGetWindowSize(window, &width, &height);
 ```
 
 @note Do not pass the window size to `glViewport` or other pixel-based OpenGL
-calls.  The window size is in screen coordinates, not pixels.  Use the
+calls. The window size is in screen coordinates, not pixels. Use the
 [framebuffer size](@ref window_fbsize), which is in pixels, for pixel-based
 calls.
 
 The above functions work with the size of the content area, but decorated
-windows typically have title bars and window frames around this rectangle.  You
+windows typically have title bars and window frames around this rectangle. You
 can retrieve the extents of these with @ref glfwGetWindowFrameSize.
 
 ```c
@@ -695,16 +680,15 @@ glfwGetWindowFrameSize(window, &left, &top, &right, &bottom);
 ```
 
 The returned values are the distances, in screen coordinates, from the edges of
-the content area to the corresponding edges of the full window.  As they are
+the content area to the corresponding edges of the full window. As they are
 distances and not coordinates, they are always zero or positive.
-
 
 ### Framebuffer size {#window_fbsize}
 
 While the size of a window is measured in screen coordinates, OpenGL works with
-pixels.  The size you pass into `glViewport`, for example, should be in pixels.
+pixels. The size you pass into `glViewport`, for example, should be in pixels.
 On some machines screen coordinates and pixels are the same, but on others they
-will not be.  There is a second set of functions to retrieve the size, in
+will not be. There is a second set of functions to retrieve the size, in
 pixels, of the framebuffer of a window.
 
 If you wish to be notified when the framebuffer of a window is resized, whether
@@ -736,7 +720,6 @@ glViewport(0, 0, width, height);
 The size of a framebuffer may change independently of the size of a window, for
 example if the window is dragged between a regular monitor and a high-DPI one.
 
-
 ### Window content scale {#window_scale}
 
 The content scale for a window can be retrieved with @ref
@@ -748,15 +731,15 @@ glfwGetWindowContentScale(window, &xscale, &yscale);
 ```
 
 The content scale can be thought of as the ratio between the current DPI and the
-platform's default DPI.  It is intended to be a scaling factor to apply to the
-pixel dimensions of text and other UI elements.  If the dimensions scaled by
+platform's default DPI. It is intended to be a scaling factor to apply to the
+pixel dimensions of text and other UI elements. If the dimensions scaled by
 this factor looks appropriate on your machine then it should appear at
 a reasonable size on other machines with different DPI and scaling settings.
 
 This relies on the DPI and scaling settings on both machines being appropriate.
 
 The content scale may depend on both the monitor resolution and pixel density
-and on user settings like DPI or a scaling percentage.  It may be very different
+and on user settings like DPI or a scaling percentage. It may be very different
 from the raw DPI calculated from the physical size and current resolution.
 
 On systems where each monitors can have its own content scale, the window
@@ -782,27 +765,26 @@ void window_content_scale_callback(GLFWwindow* window, float xscale, float yscal
 
 On platforms where pixels and screen coordinates always map 1:1, the window
 will need to be resized to appear the same size when it is moved to a monitor
-with a different content scale.  To have this done automatically both when the
+with a different content scale. To have this done automatically both when the
 window is created and when its content scale later changes, set the @ref
 GLFW_SCALE_TO_MONITOR window hint.
 
 On platforms where pixels do not necessarily equal screen coordinates, the
 framebuffer will instead need to be sized to provide a full resolution image
-for the window.  When the window moves between monitors with different content
+for the window. When the window moves between monitors with different content
 scales, the window size will remain the same but the framebuffer size will
-change.  This is done automatically by default.  To disable this resizing, set
+change. This is done automatically by default. To disable this resizing, set
 the @ref GLFW_SCALE_FRAMEBUFFER window hint.
 
-Both of these hints also apply when the window is created.  Every window starts
-out with a content scale of one.  A window with one or both of these hints set
+Both of these hints also apply when the window is created. Every window starts
+out with a content scale of one. A window with one or both of these hints set
 will adapt to the appropriate scale in the process of being created, set up and
 shown.
-
 
 ### Window size limits {#window_sizelimits}
 
 The minimum and maximum size of the content area of a windowed mode window can
-be enforced with @ref glfwSetWindowSizeLimits.  The user may resize the window
+be enforced with @ref glfwSetWindowSizeLimits. The user may resize the window
 to any size and aspect ratio within the specified limits, unless the aspect
 ratio is also set.
 
@@ -820,7 +802,7 @@ glfwSetWindowSizeLimits(window, 640, 480, GLFW_DONT_CARE, GLFW_DONT_CARE);
 To disable size limits for a window, set them all to `GLFW_DONT_CARE`.
 
 The aspect ratio of the content area of a windowed mode window can be enforced
-with @ref glfwSetWindowAspectRatio.  The user may resize the window freely
+with @ref glfwSetWindowAspectRatio. The user may resize the window freely
 unless size limits are also set, but the size will be constrained to maintain
 the aspect ratio.
 
@@ -829,7 +811,7 @@ glfwSetWindowAspectRatio(window, 16, 9);
 ```
 
 The aspect ratio is specified as a numerator and denominator, corresponding to
-the width and height, respectively.  If you want a window to maintain its
+the width and height, respectively. If you want a window to maintain its
 current aspect ratio, use its current size as the ratio.
 
 ```c
@@ -844,12 +826,11 @@ To disable the aspect ratio limit for a window, set both terms to
 You can have both size limits and aspect ratio set for a window, but the results
 are undefined if they conflict.
 
-
 ### Window position {#window_pos}
 
 By default, the window manager chooses the position of new windowed mode
 windows, based on its size and which monitor the user appears to be working on.
-This is most often the right choice.  If you need to create a window at
+This is most often the right choice. If you need to create a window at
 a specific position, you can set the desired position with the @ref
 GLFW_POSITION_X and @ref GLFW_POSITION_Y window hints.
 
@@ -861,7 +842,7 @@ glfwWindowHint(GLFW_POSITION_Y, 83);
 To restore the previous behavior, set these hints to `GLFW_ANY_POSITION`.
 
 The position of a windowed mode window can be changed with @ref
-glfwSetWindowPos.  This moves the window so that the upper-left corner of its
+glfwSetWindowPos. This moves the window so that the upper-left corner of its
 content area has the specified [screen coordinates](@ref coordinate_systems).
 The window system may put limitations on window placement.
 
@@ -893,17 +874,16 @@ int xpos, ypos;
 glfwGetWindowPos(window, &xpos, &ypos);
 ```
 
-@note __Wayland:__ An applications cannot know the positions of its windows or
-whether one has been moved.  The @ref GLFW_POSITION_X and @ref GLFW_POSITION_Y
-window hints are ignored.  The @ref glfwGetWindowPos and @ref glfwSetWindowPos
-functions emit @ref GLFW_FEATURE_UNAVAILABLE.  The window position callback will
+@note **Wayland:** An applications cannot know the positions of its windows or
+whether one has been moved. The @ref GLFW_POSITION_X and @ref GLFW_POSITION_Y
+window hints are ignored. The @ref glfwGetWindowPos and @ref glfwSetWindowPos
+functions emit @ref GLFW_FEATURE_UNAVAILABLE. The window position callback will
 not be called.
-
 
 ### Window title {#window_title}
 
 All GLFW windows have a title, although undecorated or full screen windows may
-not display it or only display it in a task bar or similar interface.  You can
+not display it or only display it in a task bar or similar interface. You can
 set a new UTF-8 encoded window title with @ref glfwSetWindowTitle.
 
 ```c
@@ -934,7 +914,7 @@ const char* title = glfwGetWindowTitle(window);
 
 ### Window icon {#window_icon}
 
-Decorated windows have icons on some platforms.  You can set this icon by
+Decorated windows have icons on some platforms. You can set this icon by
 specifying a list of candidate images with @ref glfwSetWindowIcon.
 
 ```c
@@ -946,7 +926,7 @@ glfwSetWindowIcon(window, 2, images);
 ```
 
 The image data is 32-bit, little-endian, non-premultiplied RGBA, i.e. eight bits
-per channel with the red channel first.  The pixels are arranged canonically as
+per channel with the red channel first. The pixels are arranged canonically as
 sequential rows, starting from the top-left corner.
 
 To revert to the default window icon, pass in an empty image array.
@@ -955,10 +935,9 @@ To revert to the default window icon, pass in an empty image array.
 glfwSetWindowIcon(window, 0, NULL);
 ```
 
-
 ### Window monitor {#window_monitor}
 
-Full screen windows are associated with a specific monitor.  You can get the
+Full screen windows are associated with a specific monitor. You can get the
 handle for this monitor with @ref glfwGetWindowMonitor.
 
 ```c
@@ -967,13 +946,13 @@ GLFWmonitor* monitor = glfwGetWindowMonitor(window);
 
 This monitor handle is one of those returned by @ref glfwGetMonitors.
 
-For windowed mode windows, this function returns `NULL`.  This is how to tell
+For windowed mode windows, this function returns `NULL`. This is how to tell
 full screen windows from windowed mode windows.
 
 You can move windows between monitors or between full screen and windowed mode
-with @ref glfwSetWindowMonitor.  When making a window full screen on the same or
+with @ref glfwSetWindowMonitor. When making a window full screen on the same or
 on a different monitor, specify the desired monitor, resolution and refresh
-rate.  The position arguments are ignored.
+rate. The position arguments are ignored.
 
 ```c
 const GLFWvidmode* mode = glfwGetVideoMode(monitor);
@@ -981,7 +960,7 @@ const GLFWvidmode* mode = glfwGetVideoMode(monitor);
 glfwSetWindowMonitor(window, monitor, 0, 0, mode->width, mode->height, mode->refreshRate);
 ```
 
-When making the window windowed, specify the desired position and size.  The
+When making the window windowed, specify the desired position and size. The
 refresh rate argument is ignored.
 
 ```c
@@ -989,10 +968,9 @@ glfwSetWindowMonitor(window, NULL, xpos, ypos, width, height, 0);
 ```
 
 This restores any previous window settings such as whether it is decorated,
-floating, resizable, has size or aspect ratio limits, etc..  To restore a window
+floating, resizable, has size or aspect ratio limits, etc.. To restore a window
 that was originally windowed to its original size and position, save these
 before making it full screen and then pass them in as above.
-
 
 ### Window iconification {#window_iconify}
 
@@ -1005,7 +983,7 @@ glfwIconifyWindow(window);
 When a full screen window is iconified, the original video mode of its monitor
 is restored until the user or application restores the window.
 
-Iconified windows can be restored with @ref glfwRestoreWindow.  This function
+Iconified windows can be restored with @ref glfwRestoreWindow. This function
 also restores windows from maximization.
 
 ```c
@@ -1044,12 +1022,11 @@ You can also get the current iconification state with @ref glfwGetWindowAttrib.
 int iconified = glfwGetWindowAttrib(window, GLFW_ICONIFIED);
 ```
 
-@note __Wayland:__ An application cannot know if any of its windows have been
-iconified or restore one from iconification.  The @ref glfwRestoreWindow
+@note **Wayland:** An application cannot know if any of its windows have been
+iconified or restore one from iconification. The @ref glfwRestoreWindow
 function can only restore windows from maximization and the iconify callback
-will not be called.  The [GLFW_ICONIFIED](@ref GLFW_ICONIFIED_attrib) attribute
-will be false.  The @ref glfwIconifyWindow function works normally.
-
+will not be called. The [GLFW_ICONIFIED](@ref GLFW_ICONIFIED_attrib) attribute
+will be false. The @ref glfwIconifyWindow function works normally.
 
 ### Window maximization {#window_maximize}
 
@@ -1062,7 +1039,7 @@ glfwMaximizeWindow(window);
 Full screen windows cannot be maximized and passing a full screen window to this
 function does nothing.
 
-Maximized windows can be restored with @ref glfwRestoreWindow.  This function
+Maximized windows can be restored with @ref glfwRestoreWindow. This function
 also restores windows from iconification.
 
 ```c
@@ -1098,14 +1075,13 @@ You can also get the current maximization state with @ref glfwGetWindowAttrib.
 int maximized = glfwGetWindowAttrib(window, GLFW_MAXIMIZED);
 ```
 
-By default, newly created windows are not maximized.  You can change this
+By default, newly created windows are not maximized. You can change this
 behavior by setting the [GLFW_MAXIMIZED](@ref GLFW_MAXIMIZED_hint) window hint
 before creating the window.
 
 ```c
 glfwWindowHint(GLFW_MAXIMIZED, GLFW_TRUE);
 ```
-
 
 ### Window visibility {#window_hide}
 
@@ -1116,7 +1092,7 @@ glfwHideWindow(window);
 ```
 
 This makes the window completely invisible to the user, including removing it
-from the task bar, dock or window list.  Full screen windows cannot be hidden
+from the task bar, dock or window list. Full screen windows cannot be hidden
 and calling @ref glfwHideWindow on a full screen window does nothing.
 
 Hidden windows can be shown with @ref glfwShowWindow.
@@ -1136,7 +1112,7 @@ You can also get the current visibility state with @ref glfwGetWindowAttrib.
 int visible = glfwGetWindowAttrib(window, GLFW_VISIBLE);
 ```
 
-By default, newly created windows are visible.  You can change this behavior by
+By default, newly created windows are visible. You can change this behavior by
 setting the [GLFW_VISIBLE](@ref GLFW_VISIBLE_hint) window hint before creating
 the window.
 
@@ -1144,10 +1120,9 @@ the window.
 glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
 ```
 
-Windows created hidden are completely invisible to the user until shown.  This
+Windows created hidden are completely invisible to the user until shown. This
 can be useful if you need to set up your window further before showing it, for
 example moving it to a specific location.
-
 
 ### Window input focus {#window_focus}
 
@@ -1159,7 +1134,7 @@ glfwFocusWindow(window);
 ```
 
 Keep in mind that it can be very disruptive to the user when a window is forced
-to the top.  For a less disruptive way of getting the user's attention, see
+to the top. For a less disruptive way of getting the user's attention, see
 [attention requests](@ref window_attention).
 
 If you wish to be notified when a window gains or loses input focus, whether by
@@ -1191,14 +1166,13 @@ You can also get the current input focus state with @ref glfwGetWindowAttrib.
 int focused = glfwGetWindowAttrib(window, GLFW_FOCUSED);
 ```
 
-By default, newly created windows are given input focus.  You can change this
+By default, newly created windows are given input focus. You can change this
 behavior by setting the [GLFW_FOCUSED](@ref GLFW_FOCUSED_hint) window hint
 before creating the window.
 
 ```c
 glfwWindowHint(GLFW_FOCUSED, GLFW_FALSE);
 ```
-
 
 ### Window attention request {#window_attention}
 
@@ -1210,9 +1184,8 @@ glfwRequestWindowAttention(window);
 ```
 
 The system will highlight the specified window, or on platforms where this is
-not supported, the application as a whole.  Once the user has given it
+not supported, the application as a whole. Once the user has given it
 attention, the system will automatically end the request.
-
 
 ### Window damage and refresh {#window_refresh}
 
@@ -1238,11 +1211,10 @@ void window_refresh_callback(GLFWwindow* window)
 window contents are saved off-screen, this callback might only be called when
 the window or framebuffer is resized.
 
-
 ### Window transparency {#window_transparency}
 
 GLFW supports two kinds of transparency for windows; framebuffer transparency
-and whole window transparency.  A single window may not use both methods.  The
+and whole window transparency. A single window may not use both methods. The
 results of doing this are undefined.
 
 Both methods require the platform to support it and not every version of every
@@ -1258,8 +1230,8 @@ glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_TRUE);
 ```
 
 If supported by the system, the window content area will be composited with the
-background using the framebuffer per-pixel alpha channel.  This requires desktop
-compositing to be enabled on the system.  It does not affect window decorations.
+background using the framebuffer per-pixel alpha channel. This requires desktop
+compositing to be enabled on the system. It does not affect window decorations.
 
 You can check whether the window framebuffer was successfully made transparent
 with the
@@ -1283,7 +1255,7 @@ glfwSetWindowOpacity(window, 0.5f);
 ```
 
 The opacity (or alpha) value is a positive finite number between zero and one,
-where 0 (zero) is fully transparent and 1 (one) is fully opaque.  The initial
+where 0 (zero) is fully transparent and 1 (one) is fully opaque. The initial
 opacity value for newly created windows is 1.
 
 The current opacity of a window can be queried with @ref glfwGetWindowOpacity.
@@ -1302,13 +1274,12 @@ If you want to use either of these transparency methods to display a temporary
 overlay like for example a notification, the @ref GLFW_FLOATING and @ref
 GLFW_MOUSE_PASSTHROUGH window hints and attributes may be useful.
 
-
 ### Window attributes {#window_attribs}
 
 Windows have a number of attributes that can be returned using @ref
-glfwGetWindowAttrib.  Some reflect state that may change as a result of user
+glfwGetWindowAttrib. Some reflect state that may change as a result of user
 interaction, (e.g. whether it has input focus), while others reflect inherent
-properties of the window (e.g. what kind of border it has).  Some are related to
+properties of the window (e.g. what kind of border it has). Some are related to
 the window and others to its OpenGL or OpenGL ES context.
 
 ```c
@@ -1329,92 +1300,89 @@ changed with @ref glfwSetWindowAttrib.
 glfwSetWindowAttrib(window, GLFW_RESIZABLE, GLFW_FALSE);
 ```
 
-
-
 #### Window related attributes {#window_attribs_wnd}
 
 @anchor GLFW_FOCUSED_attrib
-__GLFW_FOCUSED__ indicates whether the specified window has input focus.  See
+**GLFW_FOCUSED** indicates whether the specified window has input focus. See
 @ref window_focus for details.
 
 @anchor GLFW_ICONIFIED_attrib
-__GLFW_ICONIFIED__ indicates whether the specified window is iconified.
+**GLFW_ICONIFIED** indicates whether the specified window is iconified.
 See @ref window_iconify for details.
 
 @anchor GLFW_MAXIMIZED_attrib
-__GLFW_MAXIMIZED__ indicates whether the specified window is maximized.  See
+**GLFW_MAXIMIZED** indicates whether the specified window is maximized. See
 @ref window_maximize for details.
 
 @anchor GLFW_HOVERED_attrib
-__GLFW_HOVERED__ indicates whether the cursor is currently directly over the
-content area of the window, with no other windows between.  See @ref
+**GLFW_HOVERED** indicates whether the cursor is currently directly over the
+content area of the window, with no other windows between. See @ref
 cursor_enter for details.
 
 @anchor GLFW_VISIBLE_attrib
-__GLFW_VISIBLE__ indicates whether the specified window is visible.  See @ref
+**GLFW_VISIBLE** indicates whether the specified window is visible. See @ref
 window_hide for details.
 
 @anchor GLFW_RESIZABLE_attrib
-__GLFW_RESIZABLE__ indicates whether the specified window is resizable _by the
-user_.  This can be set before creation with the
+**GLFW_RESIZABLE** indicates whether the specified window is resizable _by the
+user_. This can be set before creation with the
 [GLFW_RESIZABLE](@ref GLFW_RESIZABLE_hint) window hint or after with @ref
 glfwSetWindowAttrib.
 
 @anchor GLFW_DECORATED_attrib
-__GLFW_DECORATED__ indicates whether the specified window has decorations such
-as a border, a close widget, etc.  This can be set before creation with the
+**GLFW_DECORATED** indicates whether the specified window has decorations such
+as a border, a close widget, etc. This can be set before creation with the
 [GLFW_DECORATED](@ref GLFW_DECORATED_hint) window hint or after with @ref
 glfwSetWindowAttrib.
 
 @anchor GLFW_AUTO_ICONIFY_attrib
-__GLFW_AUTO_ICONIFY__ indicates whether the specified full screen window is
-iconified on focus loss, a close widget, etc.  This can be set before creation
+**GLFW_AUTO_ICONIFY** indicates whether the specified full screen window is
+iconified on focus loss, a close widget, etc. This can be set before creation
 with the [GLFW_AUTO_ICONIFY](@ref GLFW_AUTO_ICONIFY_hint) window hint or after
 with @ref glfwSetWindowAttrib.
 
 @anchor GLFW_FLOATING_attrib
-__GLFW_FLOATING__ indicates whether the specified window is floating, also
-called topmost or always-on-top.  This can be set before creation with the
+**GLFW_FLOATING** indicates whether the specified window is floating, also
+called topmost or always-on-top. This can be set before creation with the
 [GLFW_FLOATING](@ref GLFW_FLOATING_hint) window hint or after with @ref
 glfwSetWindowAttrib.
 
 @anchor GLFW_TRANSPARENT_FRAMEBUFFER_attrib
-__GLFW_TRANSPARENT_FRAMEBUFFER__ indicates whether the specified window has
+**GLFW_TRANSPARENT_FRAMEBUFFER** indicates whether the specified window has
 a transparent framebuffer, i.e. the window contents is composited with the
-background using the window framebuffer alpha channel.  See @ref
+background using the window framebuffer alpha channel. See @ref
 window_transparency for details.
 
 @anchor GLFW_FOCUS_ON_SHOW_attrib
-__GLFW_FOCUS_ON_SHOW__ specifies whether the window will be given input
+**GLFW_FOCUS_ON_SHOW** specifies whether the window will be given input
 focus when @ref glfwShowWindow is called. This can be set before creation
 with the [GLFW_FOCUS_ON_SHOW](@ref GLFW_FOCUS_ON_SHOW_hint) window hint or
 after with @ref glfwSetWindowAttrib.
 
 @anchor GLFW_MOUSE_PASSTHROUGH_attrib
-__GLFW_MOUSE_PASSTHROUGH__ specifies whether the window is transparent to mouse
+**GLFW_MOUSE_PASSTHROUGH** specifies whether the window is transparent to mouse
 input, letting any mouse events pass through to whatever window is behind it.
 This can be set before creation with the
 [GLFW_MOUSE_PASSTHROUGH](@ref GLFW_MOUSE_PASSTHROUGH_hint) window hint or after
-with @ref glfwSetWindowAttrib.  This is only supported for undecorated windows.
+with @ref glfwSetWindowAttrib. This is only supported for undecorated windows.
 Decorated windows with this enabled will behave differently between platforms.
-
 
 #### Context related attributes {#window_attribs_ctx}
 
 @anchor GLFW_CLIENT_API_attrib
-__GLFW_CLIENT_API__ indicates the client API provided by the window's context;
+**GLFW_CLIENT_API** indicates the client API provided by the window's context;
 either `GLFW_OPENGL_API`, `GLFW_OPENGL_ES_API` or `GLFW_NO_API`.
 
 @anchor GLFW_CONTEXT_CREATION_API_attrib
-__GLFW_CONTEXT_CREATION_API__ indicates the context creation API used to create
+**GLFW_CONTEXT_CREATION_API** indicates the context creation API used to create
 the window's context; either `GLFW_NATIVE_CONTEXT_API`, `GLFW_EGL_CONTEXT_API`
 or `GLFW_OSMESA_CONTEXT_API`.
 
 @anchor GLFW_CONTEXT_VERSION_MAJOR_attrib
 @anchor GLFW_CONTEXT_VERSION_MINOR_attrib
 @anchor GLFW_CONTEXT_REVISION_attrib
-__GLFW_CONTEXT_VERSION_MAJOR__, __GLFW_CONTEXT_VERSION_MINOR__ and
-__GLFW_CONTEXT_REVISION__ indicate the client API version of the window's
+**GLFW_CONTEXT_VERSION_MAJOR**, **GLFW_CONTEXT_VERSION_MINOR** and
+**GLFW_CONTEXT_REVISION** indicate the client API version of the window's
 context.
 
 @note Do not confuse these attributes with `GLFW_VERSION_MAJOR`,
@@ -1422,72 +1390,71 @@ context.
 of the GLFW header.
 
 @anchor GLFW_OPENGL_FORWARD_COMPAT_attrib
-__GLFW_OPENGL_FORWARD_COMPAT__ is `GLFW_TRUE` if the window's context is an
+**GLFW_OPENGL_FORWARD_COMPAT** is `GLFW_TRUE` if the window's context is an
 OpenGL forward-compatible one, or `GLFW_FALSE` otherwise.
 
 @anchor GLFW_CONTEXT_DEBUG_attrib
 @anchor GLFW_OPENGL_DEBUG_CONTEXT_attrib
-__GLFW_CONTEXT_DEBUG__ is `GLFW_TRUE` if the window's context is in debug
+**GLFW_CONTEXT_DEBUG** is `GLFW_TRUE` if the window's context is in debug
 mode, or `GLFW_FALSE` otherwise.
 
-This is the new name, introduced in GLFW 3.4.  The older
+This is the new name, introduced in GLFW 3.4. The older
 `GLFW_OPENGL_DEBUG_CONTEXT` name is also available for compatibility.
 
 @anchor GLFW_OPENGL_PROFILE_attrib
-__GLFW_OPENGL_PROFILE__ indicates the OpenGL profile used by the context.  This
+**GLFW_OPENGL_PROFILE** indicates the OpenGL profile used by the context. This
 is `GLFW_OPENGL_CORE_PROFILE` or `GLFW_OPENGL_COMPAT_PROFILE` if the context
 uses a known profile, or `GLFW_OPENGL_ANY_PROFILE` if the OpenGL profile is
-unknown or the context is an OpenGL ES context.  Note that the returned profile
+unknown or the context is an OpenGL ES context. Note that the returned profile
 may not match the profile bits of the context flags, as GLFW will try other
 means of detecting the profile when no bits are set.
 
 @anchor GLFW_CONTEXT_RELEASE_BEHAVIOR_attrib
-__GLFW_CONTEXT_RELEASE_BEHAVIOR__ indicates the release used by the context.
+**GLFW_CONTEXT_RELEASE_BEHAVIOR** indicates the release used by the context.
 Possible values are one of `GLFW_ANY_RELEASE_BEHAVIOR`,
-`GLFW_RELEASE_BEHAVIOR_FLUSH` or `GLFW_RELEASE_BEHAVIOR_NONE`.  If the
+`GLFW_RELEASE_BEHAVIOR_FLUSH` or `GLFW_RELEASE_BEHAVIOR_NONE`. If the
 behavior is `GLFW_ANY_RELEASE_BEHAVIOR`, the default behavior of the context
-creation API will be used.  If the behavior is `GLFW_RELEASE_BEHAVIOR_FLUSH`,
+creation API will be used. If the behavior is `GLFW_RELEASE_BEHAVIOR_FLUSH`,
 the pipeline will be flushed whenever the context is released from being the
-current one.  If the behavior is `GLFW_RELEASE_BEHAVIOR_NONE`, the pipeline will
+current one. If the behavior is `GLFW_RELEASE_BEHAVIOR_NONE`, the pipeline will
 not be flushed on release.
 
 @anchor GLFW_CONTEXT_NO_ERROR_attrib
-__GLFW_CONTEXT_NO_ERROR__ indicates whether errors are generated by the context.
-Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  If enabled, situations that
+**GLFW_CONTEXT_NO_ERROR** indicates whether errors are generated by the context.
+Possible values are `GLFW_TRUE` and `GLFW_FALSE`. If enabled, situations that
 would have generated errors instead cause undefined behavior.
 
 @anchor GLFW_CONTEXT_ROBUSTNESS_attrib
-__GLFW_CONTEXT_ROBUSTNESS__ indicates the robustness strategy used by the
-context.  This is `GLFW_LOSE_CONTEXT_ON_RESET` or `GLFW_NO_RESET_NOTIFICATION`
+**GLFW_CONTEXT_ROBUSTNESS** indicates the robustness strategy used by the
+context. This is `GLFW_LOSE_CONTEXT_ON_RESET` or `GLFW_NO_RESET_NOTIFICATION`
 if the window's context supports robustness, or `GLFW_NO_ROBUSTNESS` otherwise.
-
 
 #### Framebuffer related attributes {#window_attribs_fb}
 
 GLFW does not expose most attributes of the default framebuffer (i.e. the
 framebuffer attached to the window) as these can be queried directly with either
-OpenGL, OpenGL ES or Vulkan.  The one exception is
+OpenGL, OpenGL ES or Vulkan. The one exception is
 [GLFW_DOUBLEBUFFER](@ref GLFW_DOUBLEBUFFER_attrib), as this is not provided by
 OpenGL ES.
 
 If you are using version 3.0 or later of OpenGL or OpenGL ES, the
 `glGetFramebufferAttachmentParameteriv` function can be used to retrieve the
 number of bits for the red, green, blue, alpha, depth and stencil buffer
-channels.  Otherwise, the `glGetIntegerv` function can be used.
+channels. Otherwise, the `glGetIntegerv` function can be used.
 
-The number of MSAA samples are always retrieved with `glGetIntegerv`.  For
+The number of MSAA samples are always retrieved with `glGetIntegerv`. For
 contexts supporting framebuffer objects, the number of samples of the currently
 bound framebuffer is returned.
 
-Attribute    | glGetIntegerv     | glGetFramebufferAttachmentParameteriv
------------- | ----------------- | -------------------------------------
-Red bits     | `GL_RED_BITS`     | `GL_FRAMEBUFFER_ATTACHMENT_RED_SIZE`
-Green bits   | `GL_GREEN_BITS`   | `GL_FRAMEBUFFER_ATTACHMENT_GREEN_SIZE`
-Blue bits    | `GL_BLUE_BITS`    | `GL_FRAMEBUFFER_ATTACHMENT_BLUE_SIZE`
-Alpha bits   | `GL_ALPHA_BITS`   | `GL_FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE`
-Depth bits   | `GL_DEPTH_BITS`   | `GL_FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE`
-Stencil bits | `GL_STENCIL_BITS` | `GL_FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE`
-MSAA samples | `GL_SAMPLES`      | _Not provided by this function_
+| Attribute    | glGetIntegerv     | glGetFramebufferAttachmentParameteriv    |
+| ------------ | ----------------- | ---------------------------------------- |
+| Red bits     | `GL_RED_BITS`     | `GL_FRAMEBUFFER_ATTACHMENT_RED_SIZE`     |
+| Green bits   | `GL_GREEN_BITS`   | `GL_FRAMEBUFFER_ATTACHMENT_GREEN_SIZE`   |
+| Blue bits    | `GL_BLUE_BITS`    | `GL_FRAMEBUFFER_ATTACHMENT_BLUE_SIZE`    |
+| Alpha bits   | `GL_ALPHA_BITS`   | `GL_FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE`   |
+| Depth bits   | `GL_DEPTH_BITS`   | `GL_FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE`   |
+| Stencil bits | `GL_STENCIL_BITS` | `GL_FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE` |
+| MSAA samples | `GL_SAMPLES`      | _Not provided by this function_          |
 
 When calling `glGetFramebufferAttachmentParameteriv`, the red, green, blue and
 alpha sizes are queried from the `GL_BACK_LEFT`, while the depth and stencil
@@ -1495,26 +1462,25 @@ sizes are queried from the `GL_DEPTH` and `GL_STENCIL` attachments,
 respectively.
 
 @anchor GLFW_DOUBLEBUFFER_attrib
-__GLFW_DOUBLEBUFFER__ indicates whether the specified window is double-buffered
-when rendering with OpenGL or OpenGL ES.  This can be set before creation with
+**GLFW_DOUBLEBUFFER** indicates whether the specified window is double-buffered
+when rendering with OpenGL or OpenGL ES. This can be set before creation with
 the [GLFW_DOUBLEBUFFER](@ref GLFW_DOUBLEBUFFER_hint) window hint.
-
 
 ## Buffer swapping {#buffer_swap}
 
-GLFW windows are by default double buffered.  That means that you have two
-rendering buffers; a front buffer and a back buffer.  The front buffer is
+GLFW windows are by default double buffered. That means that you have two
+rendering buffers; a front buffer and a back buffer. The front buffer is
 the one being displayed and the back buffer the one you render to.
 
 When the entire frame has been rendered, it is time to swap the back and the
 front buffers in order to display what has been rendered and begin rendering
-a new frame.  This is done with @ref glfwSwapBuffers.
+a new frame. This is done with @ref glfwSwapBuffers.
 
 ```c
 glfwSwapBuffers(window);
 ```
 
-Sometimes it can be useful to select when the buffer swap will occur.  With the
+Sometimes it can be useful to select when the buffer swap will occur. With the
 function @ref glfwSwapInterval it is possible to select the minimum number of
 monitor refreshes the driver should wait from the time @ref glfwSwapBuffers was
 called before swapping the buffers:
@@ -1524,10 +1490,10 @@ glfwSwapInterval(1);
 ```
 
 If the interval is zero, the swap will take place immediately when @ref
-glfwSwapBuffers is called without waiting for a refresh.  Otherwise at least
-interval retraces will pass between each buffer swap.  Using a swap interval of
+glfwSwapBuffers is called without waiting for a refresh. Otherwise at least
+interval retraces will pass between each buffer swap. Using a swap interval of
 zero can be useful for benchmarking purposes, when it is not desirable to
-measure the time it takes to wait for the vertical retrace.  However, a swap
+measure the time it takes to wait for the vertical retrace. However, a swap
 interval of one lets you avoid tearing.
 
 Note that this may not work on all machines, as some drivers have
@@ -1537,6 +1503,5 @@ requests.
 A context that supports either the `WGL_EXT_swap_control_tear` or the
 `GLX_EXT_swap_control_tear` extension also accepts _negative_ swap intervals,
 which allows the driver to swap immediately even if a frame arrives a little bit
-late.  This trades the risk of visible tears for greater framerate stability.
+late. This trades the risk of visible tears for greater framerate stability.
 You can check for these extensions with @ref glfwExtensionSupported.
-

--- a/docs/window.md
+++ b/docs/window.md
@@ -529,7 +529,7 @@ hints need to be set to something other than an empty string for them to take ef
 These are set with @ref glfwWindowHintString.
 
 @anchor GLFW_X11_OVERRIDE_REDIRECT_hint
-**GLFW_X11_OVERRIDE_REDIRECT** bypasses the window manager's control over a window. This is useful when a window needs to get around window manager's usage of a window (such as i3, which is extremely strict on where windows go). Accepted values are GLFW_TRUE and GLFW_FALSE.
+**GLFW_X11_OVERRIDE_REDIRECT** bypasses the window manager's control over a window. This is useful when a window needs to get around window manager's usage of a window (such as i3, which is extremely strict on where windows go). Accepted values are `GLFW_TRUE` and `GLFW_FALSE`.
 
 #### Supported and default values {#window_hints_values}
 

--- a/docs/window.md
+++ b/docs/window.md
@@ -2,30 +2,32 @@
 
 [TOC]
 
-This guide introduces the window related functions of GLFW. For details on
-a specific function in this category, see the @ref window. There are also
+This guide introduces the window related functions of GLFW.  For details on
+a specific function in this category, see the @ref window.  There are also
 guides for the other areas of GLFW.
 
-- @ref intro_guide
-- @ref context_guide
-- @ref vulkan_guide
-- @ref monitor_guide
-- @ref input_guide
+ - @ref intro_guide
+ - @ref context_guide
+ - @ref vulkan_guide
+ - @ref monitor_guide
+ - @ref input_guide
+
 
 ## Window objects {#window_object}
 
-The @ref GLFWwindow object encapsulates both a window and a context. They are
+The @ref GLFWwindow object encapsulates both a window and a context.  They are
 created with @ref glfwCreateWindow and destroyed with @ref glfwDestroyWindow, or
-@ref glfwTerminate, if any remain. As the window and context are inseparably
+@ref glfwTerminate, if any remain.  As the window and context are inseparably
 linked, the object pointer is used as both a context and window handle.
 
 To see the event stream provided to the various window related callbacks, run
 the `events` test program.
 
+
 ### Window creation {#window_creation}
 
 A window and its OpenGL or OpenGL ES context are created with @ref
-glfwCreateWindow, which returns a handle to the created window object. For
+glfwCreateWindow, which returns a handle to the created window object.  For
 example, this creates a 640 by 480 windowed mode window:
 
 ```c
@@ -39,10 +41,11 @@ The window handle is passed to all window related functions and is provided to
 along with all input events, so event handlers can tell which window received
 the event.
 
+
 #### Full screen windows {#window_full_screen}
 
 To create a full screen window, you need to specify which monitor the window
-should use. In most cases, the user's primary monitor is a good choice.
+should use.  In most cases, the user's primary monitor is a good choice.
 For more information about retrieving monitors, see @ref monitor_monitors.
 
 ```c
@@ -59,40 +62,41 @@ with the same function.
 Each field of the @ref GLFWvidmode structure corresponds to a function parameter
 or window hint and combine to form the _desired video mode_ for that window.
 The supported video mode most closely matching the desired video mode will be
-set for the chosen monitor as long as the window has input focus. For more
+set for the chosen monitor as long as the window has input focus.  For more
 information about retrieving video modes, see @ref monitor_modes.
 
-| Video mode field        | Corresponds to                              |
-| ----------------------- | ------------------------------------------- |
-| GLFWvidmode.width       | `width` parameter of @ref glfwCreateWindow  |
-| GLFWvidmode.height      | `height` parameter of @ref glfwCreateWindow |
-| GLFWvidmode.redBits     | @ref GLFW_RED_BITS hint                     |
-| GLFWvidmode.greenBits   | @ref GLFW_GREEN_BITS hint                   |
-| GLFWvidmode.blueBits    | @ref GLFW_BLUE_BITS hint                    |
-| GLFWvidmode.refreshRate | @ref GLFW_REFRESH_RATE hint                 |
+Video mode field        | Corresponds to
+----------------        | --------------
+GLFWvidmode.width       | `width` parameter of @ref glfwCreateWindow
+GLFWvidmode.height      | `height` parameter of @ref glfwCreateWindow
+GLFWvidmode.redBits     | @ref GLFW_RED_BITS hint
+GLFWvidmode.greenBits   | @ref GLFW_GREEN_BITS hint
+GLFWvidmode.blueBits    | @ref GLFW_BLUE_BITS hint
+GLFWvidmode.refreshRate | @ref GLFW_REFRESH_RATE hint
 
 Once you have a full screen window, you can change its resolution, refresh rate
-and monitor with @ref glfwSetWindowMonitor. If you only need change its
-resolution you can also call @ref glfwSetWindowSize. In all cases, the new
+and monitor with @ref glfwSetWindowMonitor.  If you only need change its
+resolution you can also call @ref glfwSetWindowSize.  In all cases, the new
 video mode will be selected the same way as the video mode chosen by @ref
-glfwCreateWindow. If the window has an OpenGL or OpenGL ES context, it will be
+glfwCreateWindow.  If the window has an OpenGL or OpenGL ES context, it will be
 unaffected.
 
 By default, the original video mode of the monitor will be restored and the
 window iconified if it loses input focus, to allow the user to switch back to
-the desktop. This behavior can be disabled with the
+the desktop.  This behavior can be disabled with the
 [GLFW_AUTO_ICONIFY](@ref GLFW_AUTO_ICONIFY_hint) window hint, for example if you
 wish to simultaneously cover multiple monitors with full screen windows.
 
 If a monitor is disconnected, all windows that are full screen on that monitor
-will be switched to windowed mode. See @ref monitor_event for more information.
+will be switched to windowed mode.  See @ref monitor_event for more information.
+
 
 #### "Windowed full screen" windows {#window_windowed_full_screen}
 
 If the closest match for the desired video mode is the current one, the video
 mode will not be changed, making window creation faster and application
-switching much smoother. This is sometimes called _windowed full screen_ or
-_borderless full screen_ window and counts as a full screen window. To create
+switching much smoother.  This is sometimes called _windowed full screen_ or
+_borderless full screen_ window and counts as a full screen window.  To create
 such a window, request the current video mode.
 
 ```c
@@ -118,6 +122,7 @@ Note that @ref glfwGetVideoMode returns the _current_ video mode of a monitor,
 so if you already have a full screen window on that monitor that you want to
 make windowed full screen, you need to have saved the desktop resolution before.
 
+
 ### Window destruction {#window_destruction}
 
 When a window is no longer needed, destroy it with @ref glfwDestroyWindow.
@@ -126,40 +131,41 @@ When a window is no longer needed, destroy it with @ref glfwDestroyWindow.
 glfwDestroyWindow(window);
 ```
 
-Window destruction always succeeds. Before the actual destruction, all
+Window destruction always succeeds.  Before the actual destruction, all
 callbacks are removed so no further events will be delivered for the window.
 All windows remaining when @ref glfwTerminate is called are destroyed as well.
 
 When a full screen window is destroyed, the original video mode of its monitor
 is restored, but the gamma ramp is left untouched.
 
+
 ### Window creation hints {#window_hints}
 
 There are a number of hints that can be set before the creation of a window and
-context. Some affect the window itself, others affect the framebuffer or
-context. These hints are set to their default values each time the library is
-initialized with @ref glfwInit. Integer value hints can be set individually
+context.  Some affect the window itself, others affect the framebuffer or
+context.  These hints are set to their default values each time the library is
+initialized with @ref glfwInit.  Integer value hints can be set individually
 with @ref glfwWindowHint and string value hints with @ref glfwWindowHintString.
 You can reset all at once to their defaults with @ref glfwDefaultWindowHints.
 
-Some hints are platform specific. These are always valid to set on any
-platform but they will only affect their specific platform. Other platforms
-will ignore them. Setting these hints requires no platform specific headers or
+Some hints are platform specific.  These are always valid to set on any
+platform but they will only affect their specific platform.  Other platforms
+will ignore them.  Setting these hints requires no platform specific headers or
 calls.
 
 @note Window hints need to be set before the creation of the window and context
-you wish to have the specified attributes. They function as additional
+you wish to have the specified attributes.  They function as additional
 arguments to @ref glfwCreateWindow.
+
 
 #### Hard and soft constraints {#window_hints_hard}
 
-Some window hints are hard constraints. These must match the available
-capabilities _exactly_ for window and context creation to succeed. Hints
+Some window hints are hard constraints.  These must match the available
+capabilities _exactly_ for window and context creation to succeed.  Hints
 that are not hard constraints are matched as closely as possible, but the
 resulting context and framebuffer may differ from what these hints requested.
 
 The following hints are always hard constraints:
-
 - @ref GLFW_STEREO
 - @ref GLFW_DOUBLEBUFFER
 - [GLFW_CLIENT_API](@ref GLFW_CLIENT_API_hint)
@@ -167,109 +173,110 @@ The following hints are always hard constraints:
 
 The following additional hints are hard constraints when requesting an OpenGL
 context, but are ignored when requesting an OpenGL ES context:
-
 - [GLFW_OPENGL_FORWARD_COMPAT](@ref GLFW_OPENGL_FORWARD_COMPAT_hint)
 - [GLFW_OPENGL_PROFILE](@ref GLFW_OPENGL_PROFILE_hint)
+
 
 #### Window related hints {#window_hints_wnd}
 
 @anchor GLFW_RESIZABLE_hint
-**GLFW_RESIZABLE** specifies whether the windowed mode window will be resizable
-_by the user_. The window will still be resizable using the @ref
-glfwSetWindowSize function. Possible values are `GLFW_TRUE` and `GLFW_FALSE`.
+__GLFW_RESIZABLE__ specifies whether the windowed mode window will be resizable
+_by the user_.  The window will still be resizable using the @ref
+glfwSetWindowSize function.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.
 This hint is ignored for full screen and undecorated windows.
 
 @anchor GLFW_VISIBLE_hint
-**GLFW_VISIBLE** specifies whether the windowed mode window will be initially
-visible. Possible values are `GLFW_TRUE` and `GLFW_FALSE`. This hint is
+__GLFW_VISIBLE__ specifies whether the windowed mode window will be initially
+visible.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  This hint is
 ignored for full screen windows.
 
 @anchor GLFW_DECORATED_hint
-**GLFW_DECORATED** specifies whether the windowed mode window will have window
-decorations such as a border, a close widget, etc. An undecorated window will
+__GLFW_DECORATED__ specifies whether the windowed mode window will have window
+decorations such as a border, a close widget, etc.  An undecorated window will
 not be resizable by the user but will still allow the user to generate close
-events on some platforms. Possible values are `GLFW_TRUE` and `GLFW_FALSE`.
+events on some platforms.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.
 This hint is ignored for full screen windows.
 
 @anchor GLFW_FOCUSED_hint
-**GLFW_FOCUSED** specifies whether the windowed mode window will be given input
-focus when created. Possible values are `GLFW_TRUE` and `GLFW_FALSE`. This
+__GLFW_FOCUSED__ specifies whether the windowed mode window will be given input
+focus when created.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  This
 hint is ignored for full screen and initially hidden windows.
 
 @anchor GLFW_AUTO_ICONIFY_hint
-**GLFW_AUTO_ICONIFY** specifies whether the full screen window will
+__GLFW_AUTO_ICONIFY__ specifies whether the full screen window will
 automatically iconify and restore the previous video mode on input focus loss.
-Possible values are `GLFW_TRUE` and `GLFW_FALSE`. This hint is ignored for
+Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  This hint is ignored for
 windowed mode windows.
 
 @anchor GLFW_FLOATING_hint
-**GLFW_FLOATING** specifies whether the windowed mode window will be floating
-above other regular windows, also called topmost or always-on-top. This is
+__GLFW_FLOATING__ specifies whether the windowed mode window will be floating
+above other regular windows, also called topmost or always-on-top.  This is
 intended primarily for debugging purposes and cannot be used to implement proper
-full screen windows. Possible values are `GLFW_TRUE` and `GLFW_FALSE`. This
+full screen windows.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  This
 hint is ignored for full screen windows.
 
 @anchor GLFW_MAXIMIZED_hint
-**GLFW_MAXIMIZED** specifies whether the windowed mode window will be maximized
-when created. Possible values are `GLFW_TRUE` and `GLFW_FALSE`. This hint is
+__GLFW_MAXIMIZED__ specifies whether the windowed mode window will be maximized
+when created.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  This hint is
 ignored for full screen windows.
 
 @anchor GLFW_CENTER_CURSOR_hint
-**GLFW_CENTER_CURSOR** specifies whether the cursor should be centered over
-newly created full screen windows. Possible values are `GLFW_TRUE` and
-`GLFW_FALSE`. This hint is ignored for windowed mode windows.
+__GLFW_CENTER_CURSOR__ specifies whether the cursor should be centered over
+newly created full screen windows.  Possible values are `GLFW_TRUE` and
+`GLFW_FALSE`.  This hint is ignored for windowed mode windows.
 
 @anchor GLFW_TRANSPARENT_FRAMEBUFFER_hint
-**GLFW_TRANSPARENT_FRAMEBUFFER** specifies whether the window framebuffer will
-be transparent. If enabled and supported by the system, the window framebuffer
-alpha channel will be used to combine the framebuffer with the background. This
-does not affect window decorations. Possible values are `GLFW_TRUE` and
+__GLFW_TRANSPARENT_FRAMEBUFFER__ specifies whether the window framebuffer will
+be transparent.  If enabled and supported by the system, the window framebuffer
+alpha channel will be used to combine the framebuffer with the background.  This
+does not affect window decorations.  Possible values are `GLFW_TRUE` and
 `GLFW_FALSE`.
 
 @anchor GLFW_FOCUS_ON_SHOW_hint
-**GLFW_FOCUS_ON_SHOW** specifies whether the window will be given input
+__GLFW_FOCUS_ON_SHOW__ specifies whether the window will be given input
 focus when @ref glfwShowWindow is called. Possible values are `GLFW_TRUE` and
 `GLFW_FALSE`.
 
 @anchor GLFW_SCALE_TO_MONITOR
-**GLFW_SCALE_TO_MONITOR** specified whether the window content area should be
-resized based on [content scale](@ref window_scale) changes. This can be
+__GLFW_SCALE_TO_MONITOR__ specified whether the window content area should be
+resized based on [content scale](@ref window_scale) changes.  This can be
 because of a global user settings change or because the window was moved to
 a monitor with different scale settings.
 
 This hint only has an effect on platforms where screen coordinates and pixels
-always map 1:1, such as Windows and X11. On platforms like macOS the resolution
+always map 1:1, such as Windows and X11.  On platforms like macOS the resolution
 of the framebuffer can change independently of the window size.
 
 @anchor GLFW_SCALE_FRAMEBUFFER_hint
 @anchor GLFW_COCOA_RETINA_FRAMEBUFFER_hint
-**GLFW_SCALE_FRAMEBUFFER** specifies whether the framebuffer should be resized
-based on [content scale](@ref window_scale) changes. This can be
+__GLFW_SCALE_FRAMEBUFFER__ specifies whether the framebuffer should be resized
+based on [content scale](@ref window_scale) changes.  This can be
 because of a global user settings change or because the window was moved to
 a monitor with different scale settings.
 
 This hint only has an effect on platforms where screen coordinates can be scaled
-relative to pixel coordinates, such as macOS and Wayland. On platforms like
+relative to pixel coordinates, such as macOS and Wayland.  On platforms like
 Windows and X11 the framebuffer and window content area sizes always map 1:1.
 
-This is the new name, introduced in GLFW 3.4. The older
-`GLFW_COCOA_RETINA_FRAMEBUFFER` name is also available for compatibility. Both
+This is the new name, introduced in GLFW 3.4.  The older
+`GLFW_COCOA_RETINA_FRAMEBUFFER` name is also available for compatibility.  Both
 names modify the same hint value.
 
 @anchor GLFW_MOUSE_PASSTHROUGH_hint
-**GLFW_MOUSE_PASSTHROUGH** specifies whether the window is transparent to mouse
+__GLFW_MOUSE_PASSTHROUGH__ specifies whether the window is transparent to mouse
 input, letting any mouse events pass through to whatever window is behind it.
-This is only supported for undecorated windows. Decorated windows with this
-enabled will behave differently between platforms. Possible values are
+This is only supported for undecorated windows.  Decorated windows with this
+enabled will behave differently between platforms.  Possible values are
 `GLFW_TRUE` and `GLFW_FALSE`.
 
 @anchor GLFW_POSITION_X
 @anchor GLFW_POSITION_Y
-**GLFW_POSITION_X** and **GLFW_POSITION_Y** specify the desired initial position
-of the window. The window manager may modify or ignore these coordinates. If
+__GLFW_POSITION_X__ and __GLFW_POSITION_Y__ specify the desired initial position
+of the window.  The window manager may modify or ignore these coordinates.  If
 either or both of these hints are set to `GLFW_ANY_POSITION` then the window
 manager will position the window where it thinks the user will prefer it.
 Possible values are any valid screen coordinates and `GLFW_ANY_POSITION`.
+
 
 #### Framebuffer related hints {#window_hints_fb}
 
@@ -279,97 +286,99 @@ Possible values are any valid screen coordinates and `GLFW_ANY_POSITION`.
 @anchor GLFW_ALPHA_BITS
 @anchor GLFW_DEPTH_BITS
 @anchor GLFW_STENCIL_BITS
-**GLFW_RED_BITS**, **GLFW_GREEN_BITS**, **GLFW_BLUE_BITS**, **GLFW_ALPHA_BITS**,
-**GLFW_DEPTH_BITS** and **GLFW_STENCIL_BITS** specify the desired bit depths of
-the various components of the default framebuffer. A value of `GLFW_DONT_CARE`
+__GLFW_RED_BITS__, __GLFW_GREEN_BITS__, __GLFW_BLUE_BITS__, __GLFW_ALPHA_BITS__,
+__GLFW_DEPTH_BITS__ and __GLFW_STENCIL_BITS__ specify the desired bit depths of
+the various components of the default framebuffer.  A value of `GLFW_DONT_CARE`
 means the application has no preference.
 
 @anchor GLFW_ACCUM_RED_BITS
 @anchor GLFW_ACCUM_GREEN_BITS
 @anchor GLFW_ACCUM_BLUE_BITS
 @anchor GLFW_ACCUM_ALPHA_BITS
-**GLFW_ACCUM_RED_BITS**, **GLFW_ACCUM_GREEN_BITS**, **GLFW_ACCUM_BLUE_BITS** and
-**GLFW_ACCUM_ALPHA_BITS** specify the desired bit depths of the various
-components of the accumulation buffer. A value of `GLFW_DONT_CARE` means the
+__GLFW_ACCUM_RED_BITS__, __GLFW_ACCUM_GREEN_BITS__, __GLFW_ACCUM_BLUE_BITS__ and
+__GLFW_ACCUM_ALPHA_BITS__ specify the desired bit depths of the various
+components of the accumulation buffer.  A value of `GLFW_DONT_CARE` means the
 application has no preference.
 
 Accumulation buffers are a legacy OpenGL feature and should not be used in new
 code.
 
 @anchor GLFW_AUX_BUFFERS
-**GLFW_AUX_BUFFERS** specifies the desired number of auxiliary buffers. A value
+__GLFW_AUX_BUFFERS__ specifies the desired number of auxiliary buffers.  A value
 of `GLFW_DONT_CARE` means the application has no preference.
 
 Auxiliary buffers are a legacy OpenGL feature and should not be used in new
 code.
 
 @anchor GLFW_STEREO
-**GLFW_STEREO** specifies whether to use OpenGL stereoscopic rendering.
-Possible values are `GLFW_TRUE` and `GLFW_FALSE`. This is a hard constraint.
+__GLFW_STEREO__ specifies whether to use OpenGL stereoscopic rendering.
+Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  This is a hard constraint.
 
 @anchor GLFW_SAMPLES
-**GLFW_SAMPLES** specifies the desired number of samples to use for
-multisampling. Zero disables multisampling. A value of `GLFW_DONT_CARE` means
+__GLFW_SAMPLES__ specifies the desired number of samples to use for
+multisampling.  Zero disables multisampling.  A value of `GLFW_DONT_CARE` means
 the application has no preference.
 
 @anchor GLFW_SRGB_CAPABLE
-**GLFW_SRGB_CAPABLE** specifies whether the framebuffer should be sRGB capable.
+__GLFW_SRGB_CAPABLE__ specifies whether the framebuffer should be sRGB capable.
 Possible values are `GLFW_TRUE` and `GLFW_FALSE`.
 
-@note **OpenGL:** If enabled and supported by the system, the
-`GL_FRAMEBUFFER_SRGB` enable will control sRGB rendering. By default, sRGB
+@note __OpenGL:__ If enabled and supported by the system, the
+`GL_FRAMEBUFFER_SRGB` enable will control sRGB rendering.  By default, sRGB
 rendering will be disabled.
 
-@note **OpenGL ES:** If enabled and supported by the system, the context will
+@note __OpenGL ES:__ If enabled and supported by the system, the context will
 always have sRGB rendering enabled.
 
 @anchor GLFW_DOUBLEBUFFER
 @anchor GLFW_DOUBLEBUFFER_hint
-**GLFW_DOUBLEBUFFER** specifies whether the framebuffer should be double
-buffered. You nearly always want to use double buffering. This is a hard
-constraint. Possible values are `GLFW_TRUE` and `GLFW_FALSE`.
+__GLFW_DOUBLEBUFFER__ specifies whether the framebuffer should be double
+buffered.  You nearly always want to use double buffering.  This is a hard
+constraint.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.
+
 
 #### Monitor related hints {#window_hints_mtr}
 
 @anchor GLFW_REFRESH_RATE
-**GLFW_REFRESH_RATE** specifies the desired refresh rate for full screen
-windows. A value of `GLFW_DONT_CARE` means the highest available refresh rate
-will be used. This hint is ignored for windowed mode windows.
+__GLFW_REFRESH_RATE__ specifies the desired refresh rate for full screen
+windows.  A value of `GLFW_DONT_CARE` means the highest available refresh rate
+will be used.  This hint is ignored for windowed mode windows.
+
 
 #### Context related hints {#window_hints_ctx}
 
 @anchor GLFW_CLIENT_API_hint
-**GLFW_CLIENT_API** specifies which client API to create the context for.
+__GLFW_CLIENT_API__ specifies which client API to create the context for.
 Possible values are `GLFW_OPENGL_API`, `GLFW_OPENGL_ES_API` and `GLFW_NO_API`.
 This is a hard constraint.
 
 @anchor GLFW_CONTEXT_CREATION_API_hint
-**GLFW_CONTEXT_CREATION_API** specifies which context creation API to use to
-create the context. Possible values are `GLFW_NATIVE_CONTEXT_API`,
-`GLFW_EGL_CONTEXT_API` and `GLFW_OSMESA_CONTEXT_API`. This is a hard
-constraint. If no client API is requested, this hint is ignored.
+__GLFW_CONTEXT_CREATION_API__ specifies which context creation API to use to
+create the context.  Possible values are `GLFW_NATIVE_CONTEXT_API`,
+`GLFW_EGL_CONTEXT_API` and `GLFW_OSMESA_CONTEXT_API`.  This is a hard
+constraint.  If no client API is requested, this hint is ignored.
 
 An [extension loader library](@ref context_glext_auto) that assumes it knows
 which API was used to create the current context may fail if you change this
-hint. This can be resolved by having it load functions via @ref
+hint.  This can be resolved by having it load functions via @ref
 glfwGetProcAddress.
 
-@note **Wayland:** The EGL API _is_ the native context creation API, so this hint
+@note __Wayland:__ The EGL API _is_ the native context creation API, so this hint
 will have no effect.
 
-@note **X11:** On some Linux systems, creating contexts via both the native and EGL
-APIs in a single process will cause the application to segfault. Stick to one
+@note __X11:__ On some Linux systems, creating contexts via both the native and EGL
+APIs in a single process will cause the application to segfault.  Stick to one
 API or the other on Linux for now.
 
-@note **OSMesa:** As its name implies, an OpenGL context created with OSMesa
-does not update the window contents when its buffers are swapped. Use OpenGL
+@note __OSMesa:__ As its name implies, an OpenGL context created with OSMesa
+does not update the window contents when its buffers are swapped.  Use OpenGL
 functions or the OSMesa native access functions @ref glfwGetOSMesaColorBuffer
 and @ref glfwGetOSMesaDepthBuffer to retrieve the framebuffer contents.
 
 @anchor GLFW_CONTEXT_VERSION_MAJOR_hint
 @anchor GLFW_CONTEXT_VERSION_MINOR_hint
-**GLFW_CONTEXT_VERSION_MAJOR** and **GLFW_CONTEXT_VERSION_MINOR** specify the
-client API version that the created context must be compatible with. The exact
+__GLFW_CONTEXT_VERSION_MAJOR__ and __GLFW_CONTEXT_VERSION_MINOR__ specify the
+client API version that the created context must be compatible with.  The exact
 behavior of these hints depend on the requested client API.
 
 While there is no way to ask the driver for a context of the highest supported
@@ -379,35 +388,35 @@ context, which is the default for these hints.
 Do not confuse these hints with @ref GLFW_VERSION_MAJOR and @ref
 GLFW_VERSION_MINOR, which provide the API version of the GLFW header.
 
-@note **OpenGL:** These hints are not hard constraints, but creation will fail
-if the OpenGL version of the created context is less than the one requested. It
+@note __OpenGL:__ These hints are not hard constraints, but creation will fail
+if the OpenGL version of the created context is less than the one requested.  It
 is therefore perfectly safe to use the default of version 1.0 for legacy code
 and you will still get backwards-compatible contexts of version 3.0 and above
 when available.
 
-@note **OpenGL ES:** These hints are not hard constraints, but creation will
+@note __OpenGL ES:__ These hints are not hard constraints, but creation will
 fail if the OpenGL ES version of the created context is less than the one
-requested. Additionally, OpenGL ES 1.x cannot be returned if 2.0 or later was
-requested, and vice versa. This is because OpenGL ES 3.x is backward compatible
+requested.  Additionally, OpenGL ES 1.x cannot be returned if 2.0 or later was
+requested, and vice versa.  This is because OpenGL ES 3.x is backward compatible
 with 2.0, but OpenGL ES 2.0 is not backward compatible with 1.x.
 
-@note **macOS:** The OS only supports core profile contexts for OpenGL versions 3.2
-and later. Before creating an OpenGL context of version 3.2 or later you must
+@note __macOS:__ The OS only supports core profile contexts for OpenGL versions 3.2
+and later.  Before creating an OpenGL context of version 3.2 or later you must
 set the [GLFW_OPENGL_PROFILE](@ref GLFW_OPENGL_PROFILE_hint) hint accordingly.
 OpenGL 3.0 and 3.1 contexts are not supported at all on macOS.
 
 @anchor GLFW_OPENGL_FORWARD_COMPAT_hint
-**GLFW_OPENGL_FORWARD_COMPAT** specifies whether the OpenGL context should be
+__GLFW_OPENGL_FORWARD_COMPAT__ specifies whether the OpenGL context should be
 forward-compatible, i.e. one where all functionality deprecated in the requested
-version of OpenGL is removed. This must only be used if the requested OpenGL
-version is 3.0 or above. If OpenGL ES is requested, this hint is ignored.
+version of OpenGL is removed.  This must only be used if the requested OpenGL
+version is 3.0 or above.  If OpenGL ES is requested, this hint is ignored.
 
 Forward-compatibility is described in detail in the
 [OpenGL Reference Manual](https://www.opengl.org/registry/).
 
 @anchor GLFW_CONTEXT_DEBUG_hint
 @anchor GLFW_OPENGL_DEBUG_CONTEXT_hint
-**GLFW_CONTEXT_DEBUG** specifies whether the context should be created in debug
+__GLFW_CONTEXT_DEBUG__ specifies whether the context should be created in debug
 mode, which may provide additional error and diagnostic reporting functionality.
 Possible values are `GLFW_TRUE` and `GLFW_FALSE`.
 
@@ -416,34 +425,34 @@ Debug contexts for OpenGL and OpenGL ES are described in detail by the
 
 [GL_KHR_debug]: https://www.khronos.org/registry/OpenGL/extensions/KHR/KHR_debug.txt
 
-@note `GLFW_CONTEXT_DEBUG` is the new name introduced in GLFW 3.4. The older
+@note `GLFW_CONTEXT_DEBUG` is the new name introduced in GLFW 3.4.  The older
 `GLFW_OPENGL_DEBUG_CONTEXT` name is also available for compatibility.
 
 @anchor GLFW_OPENGL_PROFILE_hint
-**GLFW_OPENGL_PROFILE** specifies which OpenGL profile to create the context
-for. Possible values are one of `GLFW_OPENGL_CORE_PROFILE` or
+__GLFW_OPENGL_PROFILE__ specifies which OpenGL profile to create the context
+for.  Possible values are one of `GLFW_OPENGL_CORE_PROFILE` or
 `GLFW_OPENGL_COMPAT_PROFILE`, or `GLFW_OPENGL_ANY_PROFILE` to not request
-a specific profile. If requesting an OpenGL version below 3.2,
-`GLFW_OPENGL_ANY_PROFILE` must be used. If OpenGL ES is requested, this hint
+a specific profile.  If requesting an OpenGL version below 3.2,
+`GLFW_OPENGL_ANY_PROFILE` must be used.  If OpenGL ES is requested, this hint
 is ignored.
 
 OpenGL profiles are described in detail in the
 [OpenGL Reference Manual](https://www.opengl.org/registry/).
 
 @anchor GLFW_CONTEXT_ROBUSTNESS_hint
-**GLFW_CONTEXT_ROBUSTNESS** specifies the robustness strategy to be used by the
-context. This can be one of `GLFW_NO_RESET_NOTIFICATION` or
+__GLFW_CONTEXT_ROBUSTNESS__ specifies the robustness strategy to be used by the
+context.  This can be one of `GLFW_NO_RESET_NOTIFICATION` or
 `GLFW_LOSE_CONTEXT_ON_RESET`, or `GLFW_NO_ROBUSTNESS` to not request
 a robustness strategy.
 
 @anchor GLFW_CONTEXT_RELEASE_BEHAVIOR_hint
-**GLFW_CONTEXT_RELEASE_BEHAVIOR** specifies the release behavior to be
-used by the context. Possible values are one of `GLFW_ANY_RELEASE_BEHAVIOR`,
-`GLFW_RELEASE_BEHAVIOR_FLUSH` or `GLFW_RELEASE_BEHAVIOR_NONE`. If the
+__GLFW_CONTEXT_RELEASE_BEHAVIOR__ specifies the release behavior to be
+used by the context.  Possible values are one of `GLFW_ANY_RELEASE_BEHAVIOR`,
+`GLFW_RELEASE_BEHAVIOR_FLUSH` or `GLFW_RELEASE_BEHAVIOR_NONE`.  If the
 behavior is `GLFW_ANY_RELEASE_BEHAVIOR`, the default behavior of the context
-creation API will be used. If the behavior is `GLFW_RELEASE_BEHAVIOR_FLUSH`,
+creation API will be used.  If the behavior is `GLFW_RELEASE_BEHAVIOR_FLUSH`,
 the pipeline will be flushed whenever the context is released from being the
-current one. If the behavior is `GLFW_RELEASE_BEHAVIOR_NONE`, the pipeline will
+current one.  If the behavior is `GLFW_RELEASE_BEHAVIOR_NONE`, the pipeline will
 not be flushed on release.
 
 Context release behaviors are described in detail by the
@@ -452,8 +461,8 @@ Context release behaviors are described in detail by the
 [GL_KHR_context_flush_control]: https://www.opengl.org/registry/specs/KHR/context_flush_control.txt
 
 @anchor GLFW_CONTEXT_NO_ERROR_hint
-**GLFW_CONTEXT_NO_ERROR** specifies whether errors should be generated by the
-context. Possible values are `GLFW_TRUE` and `GLFW_FALSE`. If enabled,
+__GLFW_CONTEXT_NO_ERROR__ specifies whether errors should be generated by the
+context.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  If enabled,
 situations that would have generated errors instead cause undefined behavior.
 
 The no error mode for OpenGL and OpenGL ES is described in detail by the
@@ -461,34 +470,36 @@ The no error mode for OpenGL and OpenGL ES is described in detail by the
 
 [GL_KHR_no_error]: https://www.opengl.org/registry/specs/KHR/no_error.txt
 
+
 #### Win32 specific hints {#window_hints_win32}
 
 @anchor GLFW_WIN32_KEYBOARD_MENU_hint
-**GLFW_WIN32_KEYBOARD_MENU** specifies whether to allow access to the window
-menu via the Alt+Space and Alt-and-then-Space keyboard shortcuts. This is
+__GLFW_WIN32_KEYBOARD_MENU__ specifies whether to allow access to the window
+menu via the Alt+Space and Alt-and-then-Space keyboard shortcuts.  This is
 ignored on other platforms.
 
 @anchor GLFW_WIN32_SHOWDEFAULT_hint
-**GLFW_WIN32_SHOWDEFAULT** specifies whether to show the window the way
+__GLFW_WIN32_SHOWDEFAULT__ specifies whether to show the window the way
 specified in the program's `STARTUPINFO` when it is shown for the first time.
 This is the same information as the `Run` option in the shortcut properties
-window. If this information was not specified when the program was started,
-GLFW behaves as if this hint was set to `GLFW_FALSE`. Possible values are
-`GLFW_TRUE` and `GLFW_FALSE`. This is ignored on other platforms.
+window.  If this information was not specified when the program was started,
+GLFW behaves as if this hint was set to `GLFW_FALSE`.  Possible values are
+`GLFW_TRUE` and `GLFW_FALSE`.  This is ignored on other platforms.
+
 
 #### macOS specific hints {#window_hints_osx}
 
 @anchor GLFW_COCOA_FRAME_NAME_hint
-**GLFW_COCOA_FRAME_NAME** specifies the UTF-8 encoded name to use for autosaving
-the window frame, or if empty disables frame autosaving for the window. This is
-ignored on other platforms. This is set with @ref glfwWindowHintString.
+__GLFW_COCOA_FRAME_NAME__ specifies the UTF-8 encoded name to use for autosaving
+the window frame, or if empty disables frame autosaving for the window.  This is
+ignored on other platforms.  This is set with @ref glfwWindowHintString.
 
 @anchor GLFW_COCOA_GRAPHICS_SWITCHING_hint
-**GLFW_COCOA_GRAPHICS_SWITCHING** specifies whether to in Automatic Graphics
+__GLFW_COCOA_GRAPHICS_SWITCHING__ specifies whether to in Automatic Graphics
 Switching, i.e. to allow the system to choose the integrated GPU for the OpenGL
 context and move it between GPUs if necessary or whether to force it to always
-run on the discrete GPU. This only affects systems with both integrated and
-discrete GPUs. Possible values are `GLFW_TRUE` and `GLFW_FALSE`. This is
+run on the discrete GPU.  This only affects systems with both integrated and
+discrete GPUs.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  This is
 ignored on other platforms.
 
 Simpler programs and tools may want to enable this to save power, while games
@@ -499,19 +510,21 @@ A bundled application that wishes to participate in Automatic Graphics Switching
 should also declare this in its `Info.plist` by setting the
 `NSSupportsAutomaticGraphicsSwitching` key to `true`.
 
+
 #### Wayland specific window hints {#window_hints_wayland}
 
 @anchor GLFW_WAYLAND_APP_ID_hint
-**GLFW_WAYLAND_APP_ID** specifies the Wayland app_id for a window, used
+__GLFW_WAYLAND_APP_ID__ specifies the Wayland app_id for a window, used
 by window managers to identify types of windows. This is set with
 @ref glfwWindowHintString.
+
 
 #### X11 specific window hints {#window_hints_x11}
 
 @anchor GLFW_X11_CLASS_NAME_hint
 @anchor GLFW_X11_INSTANCE_NAME_hint
-**GLFW_X11_CLASS_NAME** and **GLFW_X11_INSTANCE_NAME** specifies the desired
-ASCII encoded class and instance parts of the ICCCM `WM_CLASS` window property. Both
+__GLFW_X11_CLASS_NAME__ and __GLFW_X11_INSTANCE_NAME__ specifies the desired
+ASCII encoded class and instance parts of the ICCCM `WM_CLASS` window property.  Both
 hints need to be set to something other than an empty string for them to take effect.
 These are set with @ref glfwWindowHintString.
 
@@ -520,70 +533,73 @@ These are set with @ref glfwWindowHintString.
 
 #### Supported and default values {#window_hints_values}
 
-| Window hint                   | Default value               | Supported values                                                                           |
-| ----------------------------- | --------------------------- | ------------------------------------------------------------------------------------------ |
-| GLFW_RESIZABLE                | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
-| GLFW_VISIBLE                  | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
-| GLFW_DECORATED                | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
-| GLFW_FOCUSED                  | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
-| GLFW_AUTO_ICONIFY             | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
-| GLFW_FLOATING                 | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
-| GLFW_MAXIMIZED                | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
-| GLFW_CENTER_CURSOR            | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
-| GLFW_TRANSPARENT_FRAMEBUFFER  | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
-| GLFW_FOCUS_ON_SHOW            | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
-| GLFW_SCALE_TO_MONITOR         | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
-| GLFW_SCALE_FRAMEBUFFER        | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
-| GLFW_MOUSE_PASSTHROUGH        | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
-| GLFW_POSITION_X               | `GLFW_ANY_POSITION`         | Any valid screen x-coordinate or `GLFW_ANY_POSITION`                                       |
-| GLFW_POSITION_Y               | `GLFW_ANY_POSITION`         | Any valid screen y-coordinate or `GLFW_ANY_POSITION`                                       |
-| GLFW_RED_BITS                 | 8                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`                                                         |
-| GLFW_GREEN_BITS               | 8                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`                                                         |
-| GLFW_BLUE_BITS                | 8                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`                                                         |
-| GLFW_ALPHA_BITS               | 8                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`                                                         |
-| GLFW_DEPTH_BITS               | 24                          | 0 to `INT_MAX` or `GLFW_DONT_CARE`                                                         |
-| GLFW_STENCIL_BITS             | 8                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`                                                         |
-| GLFW_ACCUM_RED_BITS           | 0                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`                                                         |
-| GLFW_ACCUM_GREEN_BITS         | 0                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`                                                         |
-| GLFW_ACCUM_BLUE_BITS          | 0                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`                                                         |
-| GLFW_ACCUM_ALPHA_BITS         | 0                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`                                                         |
-| GLFW_AUX_BUFFERS              | 0                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`                                                         |
-| GLFW_SAMPLES                  | 0                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`                                                         |
-| GLFW_REFRESH_RATE             | `GLFW_DONT_CARE`            | 0 to `INT_MAX` or `GLFW_DONT_CARE`                                                         |
-| GLFW_STEREO                   | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
-| GLFW_SRGB_CAPABLE             | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
-| GLFW_DOUBLEBUFFER             | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
-| GLFW_CLIENT_API               | `GLFW_OPENGL_API`           | `GLFW_OPENGL_API`, `GLFW_OPENGL_ES_API` or `GLFW_NO_API`                                   |
-| GLFW_CONTEXT_CREATION_API     | `GLFW_NATIVE_CONTEXT_API`   | `GLFW_NATIVE_CONTEXT_API`, `GLFW_EGL_CONTEXT_API` or `GLFW_OSMESA_CONTEXT_API`             |
-| GLFW_CONTEXT_VERSION_MAJOR    | 1                           | Any valid major version number of the chosen client API                                    |
-| GLFW_CONTEXT_VERSION_MINOR    | 0                           | Any valid minor version number of the chosen client API                                    |
-| GLFW_CONTEXT_ROBUSTNESS       | `GLFW_NO_ROBUSTNESS`        | `GLFW_NO_ROBUSTNESS`, `GLFW_NO_RESET_NOTIFICATION` or `GLFW_LOSE_CONTEXT_ON_RESET`         |
-| GLFW_CONTEXT_RELEASE_BEHAVIOR | `GLFW_ANY_RELEASE_BEHAVIOR` | `GLFW_ANY_RELEASE_BEHAVIOR`, `GLFW_RELEASE_BEHAVIOR_FLUSH` or `GLFW_RELEASE_BEHAVIOR_NONE` |
-| GLFW_OPENGL_FORWARD_COMPAT    | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
-| GLFW_CONTEXT_DEBUG            | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
-| GLFW_OPENGL_PROFILE           | `GLFW_OPENGL_ANY_PROFILE`   | `GLFW_OPENGL_ANY_PROFILE`, `GLFW_OPENGL_COMPAT_PROFILE` or `GLFW_OPENGL_CORE_PROFILE`      |
-| GLFW_WIN32_KEYBOARD_MENU      | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
-| GLFW_WIN32_SHOWDEFAULT        | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
-| GLFW_COCOA_FRAME_NAME         | `""`                        | A UTF-8 encoded frame autosave name                                                        |
-| GLFW_COCOA_GRAPHICS_SWITCHING | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`                                                                |
-| GLFW_WAYLAND_APP_ID           | `""`                        | An ASCII encoded Wayland `app_id` name                                                     |
-| GLFW_X11_CLASS_NAME           | `""`                        | An ASCII encoded `WM_CLASS` class name                                                     |
-| GLFW_X11_INSTANCE_NAME        | `""`                        | An ASCII encoded `WM_CLASS` instance name                                                  |
+Window hint                   | Default value               | Supported values
+----------------------------- | --------------------------- | ----------------
+GLFW_RESIZABLE                | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`
+GLFW_VISIBLE                  | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`
+GLFW_DECORATED                | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`
+GLFW_FOCUSED                  | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`
+GLFW_AUTO_ICONIFY             | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`
+GLFW_FLOATING                 | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
+GLFW_MAXIMIZED                | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
+GLFW_CENTER_CURSOR            | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`
+GLFW_TRANSPARENT_FRAMEBUFFER  | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
+GLFW_FOCUS_ON_SHOW            | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`
+GLFW_SCALE_TO_MONITOR         | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
+GLFW_SCALE_FRAMEBUFFER        | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`
+GLFW_MOUSE_PASSTHROUGH        | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
+GLFW_POSITION_X               | `GLFW_ANY_POSITION`         | Any valid screen x-coordinate or `GLFW_ANY_POSITION`
+GLFW_POSITION_Y               | `GLFW_ANY_POSITION`         | Any valid screen y-coordinate or `GLFW_ANY_POSITION`
+GLFW_RED_BITS                 | 8                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`
+GLFW_GREEN_BITS               | 8                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`
+GLFW_BLUE_BITS                | 8                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`
+GLFW_ALPHA_BITS               | 8                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`
+GLFW_DEPTH_BITS               | 24                          | 0 to `INT_MAX` or `GLFW_DONT_CARE`
+GLFW_STENCIL_BITS             | 8                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`
+GLFW_ACCUM_RED_BITS           | 0                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`
+GLFW_ACCUM_GREEN_BITS         | 0                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`
+GLFW_ACCUM_BLUE_BITS          | 0                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`
+GLFW_ACCUM_ALPHA_BITS         | 0                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`
+GLFW_AUX_BUFFERS              | 0                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`
+GLFW_SAMPLES                  | 0                           | 0 to `INT_MAX` or `GLFW_DONT_CARE`
+GLFW_REFRESH_RATE             | `GLFW_DONT_CARE`            | 0 to `INT_MAX` or `GLFW_DONT_CARE`
+GLFW_STEREO                   | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
+GLFW_SRGB_CAPABLE             | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
+GLFW_DOUBLEBUFFER             | `GLFW_TRUE`                 | `GLFW_TRUE` or `GLFW_FALSE`
+GLFW_CLIENT_API               | `GLFW_OPENGL_API`           | `GLFW_OPENGL_API`, `GLFW_OPENGL_ES_API` or `GLFW_NO_API`
+GLFW_CONTEXT_CREATION_API     | `GLFW_NATIVE_CONTEXT_API`   | `GLFW_NATIVE_CONTEXT_API`, `GLFW_EGL_CONTEXT_API` or `GLFW_OSMESA_CONTEXT_API`
+GLFW_CONTEXT_VERSION_MAJOR    | 1                           | Any valid major version number of the chosen client API
+GLFW_CONTEXT_VERSION_MINOR    | 0                           | Any valid minor version number of the chosen client API
+GLFW_CONTEXT_ROBUSTNESS       | `GLFW_NO_ROBUSTNESS`        | `GLFW_NO_ROBUSTNESS`, `GLFW_NO_RESET_NOTIFICATION` or `GLFW_LOSE_CONTEXT_ON_RESET`
+GLFW_CONTEXT_RELEASE_BEHAVIOR | `GLFW_ANY_RELEASE_BEHAVIOR` | `GLFW_ANY_RELEASE_BEHAVIOR`, `GLFW_RELEASE_BEHAVIOR_FLUSH` or `GLFW_RELEASE_BEHAVIOR_NONE`
+GLFW_OPENGL_FORWARD_COMPAT    | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
+GLFW_CONTEXT_DEBUG            | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
+GLFW_OPENGL_PROFILE           | `GLFW_OPENGL_ANY_PROFILE`   | `GLFW_OPENGL_ANY_PROFILE`, `GLFW_OPENGL_COMPAT_PROFILE` or `GLFW_OPENGL_CORE_PROFILE`
+GLFW_WIN32_KEYBOARD_MENU      | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
+GLFW_WIN32_SHOWDEFAULT        | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
+GLFW_COCOA_FRAME_NAME         | `""`                        | A UTF-8 encoded frame autosave name
+GLFW_COCOA_GRAPHICS_SWITCHING | `GLFW_FALSE`                | `GLFW_TRUE` or `GLFW_FALSE`
+GLFW_WAYLAND_APP_ID           | `""`                        | An ASCII encoded Wayland `app_id` name
+GLFW_X11_CLASS_NAME           | `""`                        | An ASCII encoded `WM_CLASS` class name
+GLFW_X11_INSTANCE_NAME        | `""`                        | An ASCII encoded `WM_CLASS` instance name
+
 
 ## Window event processing {#window_events}
 
 See @ref events.
+
 
 ## Window properties and events {#window_properties}
 
 ### User pointer {#window_userptr}
 
 Each window has a user pointer that can be set with @ref
-glfwSetWindowUserPointer and queried with @ref glfwGetWindowUserPointer. This
+glfwSetWindowUserPointer and queried with @ref glfwGetWindowUserPointer.  This
 can be used for any purpose you need and will not be modified by GLFW throughout
 the life-time of the window.
 
 The initial value of the pointer is `NULL`.
+
 
 ### Window closing and close flag {#window_close}
 
@@ -593,7 +609,7 @@ The window is however not actually destroyed and, unless you watch for this
 state change, nothing further happens.
 
 The current state of the close flag is returned by @ref glfwWindowShouldClose
-and can be set or cleared directly with @ref glfwSetWindowShouldClose. A common
+and can be set or cleared directly with @ref glfwSetWindowShouldClose.  A common
 pattern is to use the close flag as a main loop condition.
 
 ```c
@@ -625,20 +641,21 @@ void window_close_callback(GLFWwindow* window)
 }
 ```
 
+
 ### Window size {#window_size}
 
-The size of a window can be changed with @ref glfwSetWindowSize. For windowed
+The size of a window can be changed with @ref glfwSetWindowSize.  For windowed
 mode windows, this sets the size, in
 [screen coordinates](@ref coordinate_systems) of the _content area_ or _content
-area_ of the window. The window system may impose limits on window size.
+area_ of the window.  The window system may impose limits on window size.
 
 ```c
 glfwSetWindowSize(window, 640, 480);
 ```
 
 For full screen windows, the specified size becomes the new resolution of the
-window's desired video mode. The video mode most closely matching the new
-desired video mode is set immediately. The window is resized to fit the
+window's desired video mode.  The video mode most closely matching the new
+desired video mode is set immediately.  The window is resized to fit the
 resolution of the set video mode.
 
 If you wish to be notified when a window is resized, whether by the user, the
@@ -666,12 +683,12 @@ glfwGetWindowSize(window, &width, &height);
 ```
 
 @note Do not pass the window size to `glViewport` or other pixel-based OpenGL
-calls. The window size is in screen coordinates, not pixels. Use the
+calls.  The window size is in screen coordinates, not pixels.  Use the
 [framebuffer size](@ref window_fbsize), which is in pixels, for pixel-based
 calls.
 
 The above functions work with the size of the content area, but decorated
-windows typically have title bars and window frames around this rectangle. You
+windows typically have title bars and window frames around this rectangle.  You
 can retrieve the extents of these with @ref glfwGetWindowFrameSize.
 
 ```c
@@ -680,15 +697,16 @@ glfwGetWindowFrameSize(window, &left, &top, &right, &bottom);
 ```
 
 The returned values are the distances, in screen coordinates, from the edges of
-the content area to the corresponding edges of the full window. As they are
+the content area to the corresponding edges of the full window.  As they are
 distances and not coordinates, they are always zero or positive.
+
 
 ### Framebuffer size {#window_fbsize}
 
 While the size of a window is measured in screen coordinates, OpenGL works with
-pixels. The size you pass into `glViewport`, for example, should be in pixels.
+pixels.  The size you pass into `glViewport`, for example, should be in pixels.
 On some machines screen coordinates and pixels are the same, but on others they
-will not be. There is a second set of functions to retrieve the size, in
+will not be.  There is a second set of functions to retrieve the size, in
 pixels, of the framebuffer of a window.
 
 If you wish to be notified when the framebuffer of a window is resized, whether
@@ -720,6 +738,7 @@ glViewport(0, 0, width, height);
 The size of a framebuffer may change independently of the size of a window, for
 example if the window is dragged between a regular monitor and a high-DPI one.
 
+
 ### Window content scale {#window_scale}
 
 The content scale for a window can be retrieved with @ref
@@ -731,15 +750,15 @@ glfwGetWindowContentScale(window, &xscale, &yscale);
 ```
 
 The content scale can be thought of as the ratio between the current DPI and the
-platform's default DPI. It is intended to be a scaling factor to apply to the
-pixel dimensions of text and other UI elements. If the dimensions scaled by
+platform's default DPI.  It is intended to be a scaling factor to apply to the
+pixel dimensions of text and other UI elements.  If the dimensions scaled by
 this factor looks appropriate on your machine then it should appear at
 a reasonable size on other machines with different DPI and scaling settings.
 
 This relies on the DPI and scaling settings on both machines being appropriate.
 
 The content scale may depend on both the monitor resolution and pixel density
-and on user settings like DPI or a scaling percentage. It may be very different
+and on user settings like DPI or a scaling percentage.  It may be very different
 from the raw DPI calculated from the physical size and current resolution.
 
 On systems where each monitors can have its own content scale, the window
@@ -765,26 +784,27 @@ void window_content_scale_callback(GLFWwindow* window, float xscale, float yscal
 
 On platforms where pixels and screen coordinates always map 1:1, the window
 will need to be resized to appear the same size when it is moved to a monitor
-with a different content scale. To have this done automatically both when the
+with a different content scale.  To have this done automatically both when the
 window is created and when its content scale later changes, set the @ref
 GLFW_SCALE_TO_MONITOR window hint.
 
 On platforms where pixels do not necessarily equal screen coordinates, the
 framebuffer will instead need to be sized to provide a full resolution image
-for the window. When the window moves between monitors with different content
+for the window.  When the window moves between monitors with different content
 scales, the window size will remain the same but the framebuffer size will
-change. This is done automatically by default. To disable this resizing, set
+change.  This is done automatically by default.  To disable this resizing, set
 the @ref GLFW_SCALE_FRAMEBUFFER window hint.
 
-Both of these hints also apply when the window is created. Every window starts
-out with a content scale of one. A window with one or both of these hints set
+Both of these hints also apply when the window is created.  Every window starts
+out with a content scale of one.  A window with one or both of these hints set
 will adapt to the appropriate scale in the process of being created, set up and
 shown.
+
 
 ### Window size limits {#window_sizelimits}
 
 The minimum and maximum size of the content area of a windowed mode window can
-be enforced with @ref glfwSetWindowSizeLimits. The user may resize the window
+be enforced with @ref glfwSetWindowSizeLimits.  The user may resize the window
 to any size and aspect ratio within the specified limits, unless the aspect
 ratio is also set.
 
@@ -802,7 +822,7 @@ glfwSetWindowSizeLimits(window, 640, 480, GLFW_DONT_CARE, GLFW_DONT_CARE);
 To disable size limits for a window, set them all to `GLFW_DONT_CARE`.
 
 The aspect ratio of the content area of a windowed mode window can be enforced
-with @ref glfwSetWindowAspectRatio. The user may resize the window freely
+with @ref glfwSetWindowAspectRatio.  The user may resize the window freely
 unless size limits are also set, but the size will be constrained to maintain
 the aspect ratio.
 
@@ -811,7 +831,7 @@ glfwSetWindowAspectRatio(window, 16, 9);
 ```
 
 The aspect ratio is specified as a numerator and denominator, corresponding to
-the width and height, respectively. If you want a window to maintain its
+the width and height, respectively.  If you want a window to maintain its
 current aspect ratio, use its current size as the ratio.
 
 ```c
@@ -826,11 +846,12 @@ To disable the aspect ratio limit for a window, set both terms to
 You can have both size limits and aspect ratio set for a window, but the results
 are undefined if they conflict.
 
+
 ### Window position {#window_pos}
 
 By default, the window manager chooses the position of new windowed mode
 windows, based on its size and which monitor the user appears to be working on.
-This is most often the right choice. If you need to create a window at
+This is most often the right choice.  If you need to create a window at
 a specific position, you can set the desired position with the @ref
 GLFW_POSITION_X and @ref GLFW_POSITION_Y window hints.
 
@@ -842,7 +863,7 @@ glfwWindowHint(GLFW_POSITION_Y, 83);
 To restore the previous behavior, set these hints to `GLFW_ANY_POSITION`.
 
 The position of a windowed mode window can be changed with @ref
-glfwSetWindowPos. This moves the window so that the upper-left corner of its
+glfwSetWindowPos.  This moves the window so that the upper-left corner of its
 content area has the specified [screen coordinates](@ref coordinate_systems).
 The window system may put limitations on window placement.
 
@@ -874,16 +895,17 @@ int xpos, ypos;
 glfwGetWindowPos(window, &xpos, &ypos);
 ```
 
-@note **Wayland:** An applications cannot know the positions of its windows or
-whether one has been moved. The @ref GLFW_POSITION_X and @ref GLFW_POSITION_Y
-window hints are ignored. The @ref glfwGetWindowPos and @ref glfwSetWindowPos
-functions emit @ref GLFW_FEATURE_UNAVAILABLE. The window position callback will
+@note __Wayland:__ An applications cannot know the positions of its windows or
+whether one has been moved.  The @ref GLFW_POSITION_X and @ref GLFW_POSITION_Y
+window hints are ignored.  The @ref glfwGetWindowPos and @ref glfwSetWindowPos
+functions emit @ref GLFW_FEATURE_UNAVAILABLE.  The window position callback will
 not be called.
+
 
 ### Window title {#window_title}
 
 All GLFW windows have a title, although undecorated or full screen windows may
-not display it or only display it in a task bar or similar interface. You can
+not display it or only display it in a task bar or similar interface.  You can
 set a new UTF-8 encoded window title with @ref glfwSetWindowTitle.
 
 ```c
@@ -914,7 +936,7 @@ const char* title = glfwGetWindowTitle(window);
 
 ### Window icon {#window_icon}
 
-Decorated windows have icons on some platforms. You can set this icon by
+Decorated windows have icons on some platforms.  You can set this icon by
 specifying a list of candidate images with @ref glfwSetWindowIcon.
 
 ```c
@@ -926,7 +948,7 @@ glfwSetWindowIcon(window, 2, images);
 ```
 
 The image data is 32-bit, little-endian, non-premultiplied RGBA, i.e. eight bits
-per channel with the red channel first. The pixels are arranged canonically as
+per channel with the red channel first.  The pixels are arranged canonically as
 sequential rows, starting from the top-left corner.
 
 To revert to the default window icon, pass in an empty image array.
@@ -935,9 +957,10 @@ To revert to the default window icon, pass in an empty image array.
 glfwSetWindowIcon(window, 0, NULL);
 ```
 
+
 ### Window monitor {#window_monitor}
 
-Full screen windows are associated with a specific monitor. You can get the
+Full screen windows are associated with a specific monitor.  You can get the
 handle for this monitor with @ref glfwGetWindowMonitor.
 
 ```c
@@ -946,13 +969,13 @@ GLFWmonitor* monitor = glfwGetWindowMonitor(window);
 
 This monitor handle is one of those returned by @ref glfwGetMonitors.
 
-For windowed mode windows, this function returns `NULL`. This is how to tell
+For windowed mode windows, this function returns `NULL`.  This is how to tell
 full screen windows from windowed mode windows.
 
 You can move windows between monitors or between full screen and windowed mode
-with @ref glfwSetWindowMonitor. When making a window full screen on the same or
+with @ref glfwSetWindowMonitor.  When making a window full screen on the same or
 on a different monitor, specify the desired monitor, resolution and refresh
-rate. The position arguments are ignored.
+rate.  The position arguments are ignored.
 
 ```c
 const GLFWvidmode* mode = glfwGetVideoMode(monitor);
@@ -960,7 +983,7 @@ const GLFWvidmode* mode = glfwGetVideoMode(monitor);
 glfwSetWindowMonitor(window, monitor, 0, 0, mode->width, mode->height, mode->refreshRate);
 ```
 
-When making the window windowed, specify the desired position and size. The
+When making the window windowed, specify the desired position and size.  The
 refresh rate argument is ignored.
 
 ```c
@@ -968,9 +991,10 @@ glfwSetWindowMonitor(window, NULL, xpos, ypos, width, height, 0);
 ```
 
 This restores any previous window settings such as whether it is decorated,
-floating, resizable, has size or aspect ratio limits, etc.. To restore a window
+floating, resizable, has size or aspect ratio limits, etc..  To restore a window
 that was originally windowed to its original size and position, save these
 before making it full screen and then pass them in as above.
+
 
 ### Window iconification {#window_iconify}
 
@@ -983,7 +1007,7 @@ glfwIconifyWindow(window);
 When a full screen window is iconified, the original video mode of its monitor
 is restored until the user or application restores the window.
 
-Iconified windows can be restored with @ref glfwRestoreWindow. This function
+Iconified windows can be restored with @ref glfwRestoreWindow.  This function
 also restores windows from maximization.
 
 ```c
@@ -1022,11 +1046,12 @@ You can also get the current iconification state with @ref glfwGetWindowAttrib.
 int iconified = glfwGetWindowAttrib(window, GLFW_ICONIFIED);
 ```
 
-@note **Wayland:** An application cannot know if any of its windows have been
-iconified or restore one from iconification. The @ref glfwRestoreWindow
+@note __Wayland:__ An application cannot know if any of its windows have been
+iconified or restore one from iconification.  The @ref glfwRestoreWindow
 function can only restore windows from maximization and the iconify callback
-will not be called. The [GLFW_ICONIFIED](@ref GLFW_ICONIFIED_attrib) attribute
-will be false. The @ref glfwIconifyWindow function works normally.
+will not be called.  The [GLFW_ICONIFIED](@ref GLFW_ICONIFIED_attrib) attribute
+will be false.  The @ref glfwIconifyWindow function works normally.
+
 
 ### Window maximization {#window_maximize}
 
@@ -1039,7 +1064,7 @@ glfwMaximizeWindow(window);
 Full screen windows cannot be maximized and passing a full screen window to this
 function does nothing.
 
-Maximized windows can be restored with @ref glfwRestoreWindow. This function
+Maximized windows can be restored with @ref glfwRestoreWindow.  This function
 also restores windows from iconification.
 
 ```c
@@ -1075,13 +1100,14 @@ You can also get the current maximization state with @ref glfwGetWindowAttrib.
 int maximized = glfwGetWindowAttrib(window, GLFW_MAXIMIZED);
 ```
 
-By default, newly created windows are not maximized. You can change this
+By default, newly created windows are not maximized.  You can change this
 behavior by setting the [GLFW_MAXIMIZED](@ref GLFW_MAXIMIZED_hint) window hint
 before creating the window.
 
 ```c
 glfwWindowHint(GLFW_MAXIMIZED, GLFW_TRUE);
 ```
+
 
 ### Window visibility {#window_hide}
 
@@ -1092,7 +1118,7 @@ glfwHideWindow(window);
 ```
 
 This makes the window completely invisible to the user, including removing it
-from the task bar, dock or window list. Full screen windows cannot be hidden
+from the task bar, dock or window list.  Full screen windows cannot be hidden
 and calling @ref glfwHideWindow on a full screen window does nothing.
 
 Hidden windows can be shown with @ref glfwShowWindow.
@@ -1112,7 +1138,7 @@ You can also get the current visibility state with @ref glfwGetWindowAttrib.
 int visible = glfwGetWindowAttrib(window, GLFW_VISIBLE);
 ```
 
-By default, newly created windows are visible. You can change this behavior by
+By default, newly created windows are visible.  You can change this behavior by
 setting the [GLFW_VISIBLE](@ref GLFW_VISIBLE_hint) window hint before creating
 the window.
 
@@ -1120,9 +1146,10 @@ the window.
 glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
 ```
 
-Windows created hidden are completely invisible to the user until shown. This
+Windows created hidden are completely invisible to the user until shown.  This
 can be useful if you need to set up your window further before showing it, for
 example moving it to a specific location.
+
 
 ### Window input focus {#window_focus}
 
@@ -1134,7 +1161,7 @@ glfwFocusWindow(window);
 ```
 
 Keep in mind that it can be very disruptive to the user when a window is forced
-to the top. For a less disruptive way of getting the user's attention, see
+to the top.  For a less disruptive way of getting the user's attention, see
 [attention requests](@ref window_attention).
 
 If you wish to be notified when a window gains or loses input focus, whether by
@@ -1166,13 +1193,14 @@ You can also get the current input focus state with @ref glfwGetWindowAttrib.
 int focused = glfwGetWindowAttrib(window, GLFW_FOCUSED);
 ```
 
-By default, newly created windows are given input focus. You can change this
+By default, newly created windows are given input focus.  You can change this
 behavior by setting the [GLFW_FOCUSED](@ref GLFW_FOCUSED_hint) window hint
 before creating the window.
 
 ```c
 glfwWindowHint(GLFW_FOCUSED, GLFW_FALSE);
 ```
+
 
 ### Window attention request {#window_attention}
 
@@ -1184,8 +1212,9 @@ glfwRequestWindowAttention(window);
 ```
 
 The system will highlight the specified window, or on platforms where this is
-not supported, the application as a whole. Once the user has given it
+not supported, the application as a whole.  Once the user has given it
 attention, the system will automatically end the request.
+
 
 ### Window damage and refresh {#window_refresh}
 
@@ -1211,10 +1240,11 @@ void window_refresh_callback(GLFWwindow* window)
 window contents are saved off-screen, this callback might only be called when
 the window or framebuffer is resized.
 
+
 ### Window transparency {#window_transparency}
 
 GLFW supports two kinds of transparency for windows; framebuffer transparency
-and whole window transparency. A single window may not use both methods. The
+and whole window transparency.  A single window may not use both methods.  The
 results of doing this are undefined.
 
 Both methods require the platform to support it and not every version of every
@@ -1230,8 +1260,8 @@ glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_TRUE);
 ```
 
 If supported by the system, the window content area will be composited with the
-background using the framebuffer per-pixel alpha channel. This requires desktop
-compositing to be enabled on the system. It does not affect window decorations.
+background using the framebuffer per-pixel alpha channel.  This requires desktop
+compositing to be enabled on the system.  It does not affect window decorations.
 
 You can check whether the window framebuffer was successfully made transparent
 with the
@@ -1255,7 +1285,7 @@ glfwSetWindowOpacity(window, 0.5f);
 ```
 
 The opacity (or alpha) value is a positive finite number between zero and one,
-where 0 (zero) is fully transparent and 1 (one) is fully opaque. The initial
+where 0 (zero) is fully transparent and 1 (one) is fully opaque.  The initial
 opacity value for newly created windows is 1.
 
 The current opacity of a window can be queried with @ref glfwGetWindowOpacity.
@@ -1274,12 +1304,13 @@ If you want to use either of these transparency methods to display a temporary
 overlay like for example a notification, the @ref GLFW_FLOATING and @ref
 GLFW_MOUSE_PASSTHROUGH window hints and attributes may be useful.
 
+
 ### Window attributes {#window_attribs}
 
 Windows have a number of attributes that can be returned using @ref
-glfwGetWindowAttrib. Some reflect state that may change as a result of user
+glfwGetWindowAttrib.  Some reflect state that may change as a result of user
 interaction, (e.g. whether it has input focus), while others reflect inherent
-properties of the window (e.g. what kind of border it has). Some are related to
+properties of the window (e.g. what kind of border it has).  Some are related to
 the window and others to its OpenGL or OpenGL ES context.
 
 ```c
@@ -1300,89 +1331,92 @@ changed with @ref glfwSetWindowAttrib.
 glfwSetWindowAttrib(window, GLFW_RESIZABLE, GLFW_FALSE);
 ```
 
+
+
 #### Window related attributes {#window_attribs_wnd}
 
 @anchor GLFW_FOCUSED_attrib
-**GLFW_FOCUSED** indicates whether the specified window has input focus. See
+__GLFW_FOCUSED__ indicates whether the specified window has input focus.  See
 @ref window_focus for details.
 
 @anchor GLFW_ICONIFIED_attrib
-**GLFW_ICONIFIED** indicates whether the specified window is iconified.
+__GLFW_ICONIFIED__ indicates whether the specified window is iconified.
 See @ref window_iconify for details.
 
 @anchor GLFW_MAXIMIZED_attrib
-**GLFW_MAXIMIZED** indicates whether the specified window is maximized. See
+__GLFW_MAXIMIZED__ indicates whether the specified window is maximized.  See
 @ref window_maximize for details.
 
 @anchor GLFW_HOVERED_attrib
-**GLFW_HOVERED** indicates whether the cursor is currently directly over the
-content area of the window, with no other windows between. See @ref
+__GLFW_HOVERED__ indicates whether the cursor is currently directly over the
+content area of the window, with no other windows between.  See @ref
 cursor_enter for details.
 
 @anchor GLFW_VISIBLE_attrib
-**GLFW_VISIBLE** indicates whether the specified window is visible. See @ref
+__GLFW_VISIBLE__ indicates whether the specified window is visible.  See @ref
 window_hide for details.
 
 @anchor GLFW_RESIZABLE_attrib
-**GLFW_RESIZABLE** indicates whether the specified window is resizable _by the
-user_. This can be set before creation with the
+__GLFW_RESIZABLE__ indicates whether the specified window is resizable _by the
+user_.  This can be set before creation with the
 [GLFW_RESIZABLE](@ref GLFW_RESIZABLE_hint) window hint or after with @ref
 glfwSetWindowAttrib.
 
 @anchor GLFW_DECORATED_attrib
-**GLFW_DECORATED** indicates whether the specified window has decorations such
-as a border, a close widget, etc. This can be set before creation with the
+__GLFW_DECORATED__ indicates whether the specified window has decorations such
+as a border, a close widget, etc.  This can be set before creation with the
 [GLFW_DECORATED](@ref GLFW_DECORATED_hint) window hint or after with @ref
 glfwSetWindowAttrib.
 
 @anchor GLFW_AUTO_ICONIFY_attrib
-**GLFW_AUTO_ICONIFY** indicates whether the specified full screen window is
-iconified on focus loss, a close widget, etc. This can be set before creation
+__GLFW_AUTO_ICONIFY__ indicates whether the specified full screen window is
+iconified on focus loss, a close widget, etc.  This can be set before creation
 with the [GLFW_AUTO_ICONIFY](@ref GLFW_AUTO_ICONIFY_hint) window hint or after
 with @ref glfwSetWindowAttrib.
 
 @anchor GLFW_FLOATING_attrib
-**GLFW_FLOATING** indicates whether the specified window is floating, also
-called topmost or always-on-top. This can be set before creation with the
+__GLFW_FLOATING__ indicates whether the specified window is floating, also
+called topmost or always-on-top.  This can be set before creation with the
 [GLFW_FLOATING](@ref GLFW_FLOATING_hint) window hint or after with @ref
 glfwSetWindowAttrib.
 
 @anchor GLFW_TRANSPARENT_FRAMEBUFFER_attrib
-**GLFW_TRANSPARENT_FRAMEBUFFER** indicates whether the specified window has
+__GLFW_TRANSPARENT_FRAMEBUFFER__ indicates whether the specified window has
 a transparent framebuffer, i.e. the window contents is composited with the
-background using the window framebuffer alpha channel. See @ref
+background using the window framebuffer alpha channel.  See @ref
 window_transparency for details.
 
 @anchor GLFW_FOCUS_ON_SHOW_attrib
-**GLFW_FOCUS_ON_SHOW** specifies whether the window will be given input
+__GLFW_FOCUS_ON_SHOW__ specifies whether the window will be given input
 focus when @ref glfwShowWindow is called. This can be set before creation
 with the [GLFW_FOCUS_ON_SHOW](@ref GLFW_FOCUS_ON_SHOW_hint) window hint or
 after with @ref glfwSetWindowAttrib.
 
 @anchor GLFW_MOUSE_PASSTHROUGH_attrib
-**GLFW_MOUSE_PASSTHROUGH** specifies whether the window is transparent to mouse
+__GLFW_MOUSE_PASSTHROUGH__ specifies whether the window is transparent to mouse
 input, letting any mouse events pass through to whatever window is behind it.
 This can be set before creation with the
 [GLFW_MOUSE_PASSTHROUGH](@ref GLFW_MOUSE_PASSTHROUGH_hint) window hint or after
-with @ref glfwSetWindowAttrib. This is only supported for undecorated windows.
+with @ref glfwSetWindowAttrib.  This is only supported for undecorated windows.
 Decorated windows with this enabled will behave differently between platforms.
+
 
 #### Context related attributes {#window_attribs_ctx}
 
 @anchor GLFW_CLIENT_API_attrib
-**GLFW_CLIENT_API** indicates the client API provided by the window's context;
+__GLFW_CLIENT_API__ indicates the client API provided by the window's context;
 either `GLFW_OPENGL_API`, `GLFW_OPENGL_ES_API` or `GLFW_NO_API`.
 
 @anchor GLFW_CONTEXT_CREATION_API_attrib
-**GLFW_CONTEXT_CREATION_API** indicates the context creation API used to create
+__GLFW_CONTEXT_CREATION_API__ indicates the context creation API used to create
 the window's context; either `GLFW_NATIVE_CONTEXT_API`, `GLFW_EGL_CONTEXT_API`
 or `GLFW_OSMESA_CONTEXT_API`.
 
 @anchor GLFW_CONTEXT_VERSION_MAJOR_attrib
 @anchor GLFW_CONTEXT_VERSION_MINOR_attrib
 @anchor GLFW_CONTEXT_REVISION_attrib
-**GLFW_CONTEXT_VERSION_MAJOR**, **GLFW_CONTEXT_VERSION_MINOR** and
-**GLFW_CONTEXT_REVISION** indicate the client API version of the window's
+__GLFW_CONTEXT_VERSION_MAJOR__, __GLFW_CONTEXT_VERSION_MINOR__ and
+__GLFW_CONTEXT_REVISION__ indicate the client API version of the window's
 context.
 
 @note Do not confuse these attributes with `GLFW_VERSION_MAJOR`,
@@ -1390,71 +1424,72 @@ context.
 of the GLFW header.
 
 @anchor GLFW_OPENGL_FORWARD_COMPAT_attrib
-**GLFW_OPENGL_FORWARD_COMPAT** is `GLFW_TRUE` if the window's context is an
+__GLFW_OPENGL_FORWARD_COMPAT__ is `GLFW_TRUE` if the window's context is an
 OpenGL forward-compatible one, or `GLFW_FALSE` otherwise.
 
 @anchor GLFW_CONTEXT_DEBUG_attrib
 @anchor GLFW_OPENGL_DEBUG_CONTEXT_attrib
-**GLFW_CONTEXT_DEBUG** is `GLFW_TRUE` if the window's context is in debug
+__GLFW_CONTEXT_DEBUG__ is `GLFW_TRUE` if the window's context is in debug
 mode, or `GLFW_FALSE` otherwise.
 
-This is the new name, introduced in GLFW 3.4. The older
+This is the new name, introduced in GLFW 3.4.  The older
 `GLFW_OPENGL_DEBUG_CONTEXT` name is also available for compatibility.
 
 @anchor GLFW_OPENGL_PROFILE_attrib
-**GLFW_OPENGL_PROFILE** indicates the OpenGL profile used by the context. This
+__GLFW_OPENGL_PROFILE__ indicates the OpenGL profile used by the context.  This
 is `GLFW_OPENGL_CORE_PROFILE` or `GLFW_OPENGL_COMPAT_PROFILE` if the context
 uses a known profile, or `GLFW_OPENGL_ANY_PROFILE` if the OpenGL profile is
-unknown or the context is an OpenGL ES context. Note that the returned profile
+unknown or the context is an OpenGL ES context.  Note that the returned profile
 may not match the profile bits of the context flags, as GLFW will try other
 means of detecting the profile when no bits are set.
 
 @anchor GLFW_CONTEXT_RELEASE_BEHAVIOR_attrib
-**GLFW_CONTEXT_RELEASE_BEHAVIOR** indicates the release used by the context.
+__GLFW_CONTEXT_RELEASE_BEHAVIOR__ indicates the release used by the context.
 Possible values are one of `GLFW_ANY_RELEASE_BEHAVIOR`,
-`GLFW_RELEASE_BEHAVIOR_FLUSH` or `GLFW_RELEASE_BEHAVIOR_NONE`. If the
+`GLFW_RELEASE_BEHAVIOR_FLUSH` or `GLFW_RELEASE_BEHAVIOR_NONE`.  If the
 behavior is `GLFW_ANY_RELEASE_BEHAVIOR`, the default behavior of the context
-creation API will be used. If the behavior is `GLFW_RELEASE_BEHAVIOR_FLUSH`,
+creation API will be used.  If the behavior is `GLFW_RELEASE_BEHAVIOR_FLUSH`,
 the pipeline will be flushed whenever the context is released from being the
-current one. If the behavior is `GLFW_RELEASE_BEHAVIOR_NONE`, the pipeline will
+current one.  If the behavior is `GLFW_RELEASE_BEHAVIOR_NONE`, the pipeline will
 not be flushed on release.
 
 @anchor GLFW_CONTEXT_NO_ERROR_attrib
-**GLFW_CONTEXT_NO_ERROR** indicates whether errors are generated by the context.
-Possible values are `GLFW_TRUE` and `GLFW_FALSE`. If enabled, situations that
+__GLFW_CONTEXT_NO_ERROR__ indicates whether errors are generated by the context.
+Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  If enabled, situations that
 would have generated errors instead cause undefined behavior.
 
 @anchor GLFW_CONTEXT_ROBUSTNESS_attrib
-**GLFW_CONTEXT_ROBUSTNESS** indicates the robustness strategy used by the
-context. This is `GLFW_LOSE_CONTEXT_ON_RESET` or `GLFW_NO_RESET_NOTIFICATION`
+__GLFW_CONTEXT_ROBUSTNESS__ indicates the robustness strategy used by the
+context.  This is `GLFW_LOSE_CONTEXT_ON_RESET` or `GLFW_NO_RESET_NOTIFICATION`
 if the window's context supports robustness, or `GLFW_NO_ROBUSTNESS` otherwise.
+
 
 #### Framebuffer related attributes {#window_attribs_fb}
 
 GLFW does not expose most attributes of the default framebuffer (i.e. the
 framebuffer attached to the window) as these can be queried directly with either
-OpenGL, OpenGL ES or Vulkan. The one exception is
+OpenGL, OpenGL ES or Vulkan.  The one exception is
 [GLFW_DOUBLEBUFFER](@ref GLFW_DOUBLEBUFFER_attrib), as this is not provided by
 OpenGL ES.
 
 If you are using version 3.0 or later of OpenGL or OpenGL ES, the
 `glGetFramebufferAttachmentParameteriv` function can be used to retrieve the
 number of bits for the red, green, blue, alpha, depth and stencil buffer
-channels. Otherwise, the `glGetIntegerv` function can be used.
+channels.  Otherwise, the `glGetIntegerv` function can be used.
 
-The number of MSAA samples are always retrieved with `glGetIntegerv`. For
+The number of MSAA samples are always retrieved with `glGetIntegerv`.  For
 contexts supporting framebuffer objects, the number of samples of the currently
 bound framebuffer is returned.
 
-| Attribute    | glGetIntegerv     | glGetFramebufferAttachmentParameteriv    |
-| ------------ | ----------------- | ---------------------------------------- |
-| Red bits     | `GL_RED_BITS`     | `GL_FRAMEBUFFER_ATTACHMENT_RED_SIZE`     |
-| Green bits   | `GL_GREEN_BITS`   | `GL_FRAMEBUFFER_ATTACHMENT_GREEN_SIZE`   |
-| Blue bits    | `GL_BLUE_BITS`    | `GL_FRAMEBUFFER_ATTACHMENT_BLUE_SIZE`    |
-| Alpha bits   | `GL_ALPHA_BITS`   | `GL_FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE`   |
-| Depth bits   | `GL_DEPTH_BITS`   | `GL_FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE`   |
-| Stencil bits | `GL_STENCIL_BITS` | `GL_FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE` |
-| MSAA samples | `GL_SAMPLES`      | _Not provided by this function_          |
+Attribute    | glGetIntegerv     | glGetFramebufferAttachmentParameteriv
+------------ | ----------------- | -------------------------------------
+Red bits     | `GL_RED_BITS`     | `GL_FRAMEBUFFER_ATTACHMENT_RED_SIZE`
+Green bits   | `GL_GREEN_BITS`   | `GL_FRAMEBUFFER_ATTACHMENT_GREEN_SIZE`
+Blue bits    | `GL_BLUE_BITS`    | `GL_FRAMEBUFFER_ATTACHMENT_BLUE_SIZE`
+Alpha bits   | `GL_ALPHA_BITS`   | `GL_FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE`
+Depth bits   | `GL_DEPTH_BITS`   | `GL_FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE`
+Stencil bits | `GL_STENCIL_BITS` | `GL_FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE`
+MSAA samples | `GL_SAMPLES`      | _Not provided by this function_
 
 When calling `glGetFramebufferAttachmentParameteriv`, the red, green, blue and
 alpha sizes are queried from the `GL_BACK_LEFT`, while the depth and stencil
@@ -1462,25 +1497,26 @@ sizes are queried from the `GL_DEPTH` and `GL_STENCIL` attachments,
 respectively.
 
 @anchor GLFW_DOUBLEBUFFER_attrib
-**GLFW_DOUBLEBUFFER** indicates whether the specified window is double-buffered
-when rendering with OpenGL or OpenGL ES. This can be set before creation with
+__GLFW_DOUBLEBUFFER__ indicates whether the specified window is double-buffered
+when rendering with OpenGL or OpenGL ES.  This can be set before creation with
 the [GLFW_DOUBLEBUFFER](@ref GLFW_DOUBLEBUFFER_hint) window hint.
+
 
 ## Buffer swapping {#buffer_swap}
 
-GLFW windows are by default double buffered. That means that you have two
-rendering buffers; a front buffer and a back buffer. The front buffer is
+GLFW windows are by default double buffered.  That means that you have two
+rendering buffers; a front buffer and a back buffer.  The front buffer is
 the one being displayed and the back buffer the one you render to.
 
 When the entire frame has been rendered, it is time to swap the back and the
 front buffers in order to display what has been rendered and begin rendering
-a new frame. This is done with @ref glfwSwapBuffers.
+a new frame.  This is done with @ref glfwSwapBuffers.
 
 ```c
 glfwSwapBuffers(window);
 ```
 
-Sometimes it can be useful to select when the buffer swap will occur. With the
+Sometimes it can be useful to select when the buffer swap will occur.  With the
 function @ref glfwSwapInterval it is possible to select the minimum number of
 monitor refreshes the driver should wait from the time @ref glfwSwapBuffers was
 called before swapping the buffers:
@@ -1490,10 +1526,10 @@ glfwSwapInterval(1);
 ```
 
 If the interval is zero, the swap will take place immediately when @ref
-glfwSwapBuffers is called without waiting for a refresh. Otherwise at least
-interval retraces will pass between each buffer swap. Using a swap interval of
+glfwSwapBuffers is called without waiting for a refresh.  Otherwise at least
+interval retraces will pass between each buffer swap.  Using a swap interval of
 zero can be useful for benchmarking purposes, when it is not desirable to
-measure the time it takes to wait for the vertical retrace. However, a swap
+measure the time it takes to wait for the vertical retrace.  However, a swap
 interval of one lets you avoid tearing.
 
 Note that this may not work on all machines, as some drivers have
@@ -1503,5 +1539,5 @@ requests.
 A context that supports either the `WGL_EXT_swap_control_tear` or the
 `GLX_EXT_swap_control_tear` extension also accepts _negative_ swap intervals,
 which allows the driver to swap immediately even if a frame arrives a little bit
-late. This trades the risk of visible tears for greater framerate stability.
+late.  This trades the risk of visible tears for greater framerate stability.
 You can check for these extensions with @ref glfwExtensionSupported.

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -1125,6 +1125,10 @@ extern "C" {
  *  [window hint](@ref GLFW_X11_CLASS_NAME_hint).
  */
 #define GLFW_X11_INSTANCE_NAME      0x00024002
+/*! @brief X11 specific
+ *  [window hint](@ref GLFW_X11_OVERRIDE_REDIRECT_hint).
+ */
+#define GLFW_X11_OVERRIDE_REDIRECT  0x00024003
 #define GLFW_WIN32_KEYBOARD_MENU    0x00025001
 /*! @brief Win32 specific [window hint](@ref GLFW_WIN32_SHOWDEFAULT_hint).
  */
@@ -1135,10 +1139,6 @@ extern "C" {
  *  Allows specification of the Wayland app_id.
  */
 #define GLFW_WAYLAND_APP_ID         0x00026001
-/*! @brief X11 specific
- *  [window hint](@ref GLFW_X11_OVERRIDE_REDIRECT_hint).
- */
-#define GLFW_X11_OVERRIDE_REDIRECT 0x00026002
 /*! @} */
 
 #define GLFW_NO_API                          0

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -33,6 +33,7 @@
 extern "C" {
 #endif
 
+
 /*************************************************************************
  * Doxygen documentation
  *************************************************************************/
@@ -84,15 +85,15 @@ extern "C" {
  *  information, see the @ref window_guide.
  */
 
+
 /*************************************************************************
  * Compiler- and platform-specific preprocessor work
  *************************************************************************/
 
 /* If we are we on Windows, we want a single define for it.
  */
-#if !defined(_WIN32) &&                                                        \
-    (defined(__WIN32__) || defined(WIN32) || defined(__MINGW32__))
-#define _WIN32
+#if !defined(_WIN32) && (defined(__WIN32__) || defined(WIN32) || defined(__MINGW32__))
+ #define _WIN32
 #endif /* _WIN32 */
 
 /* Include because most Windows GLU headers need wchar_t and
@@ -107,7 +108,7 @@ extern "C" {
 #include <stdint.h>
 
 #if defined(GLFW_INCLUDE_VULKAN)
-#include <vulkan/vulkan.h>
+  #include <vulkan/vulkan.h>
 #endif /* Vulkan header */
 
 /* The Vulkan header may have indirectly included windows.h (because of
@@ -118,151 +119,158 @@ extern "C" {
  * all platforms.  Additionally, the Windows OpenGL header needs APIENTRY.
  */
 #if !defined(APIENTRY)
-#if defined(_WIN32)
-#define APIENTRY __stdcall
-#else
-#define APIENTRY
-#endif
-#define GLFW_APIENTRY_DEFINED
+ #if defined(_WIN32)
+  #define APIENTRY __stdcall
+ #else
+  #define APIENTRY
+ #endif
+ #define GLFW_APIENTRY_DEFINED
 #endif /* APIENTRY */
 
 /* Some Windows OpenGL headers need this.
  */
 #if !defined(WINGDIAPI) && defined(_WIN32)
-#define WINGDIAPI __declspec(dllimport)
-#define GLFW_WINGDIAPI_DEFINED
+ #define WINGDIAPI __declspec(dllimport)
+ #define GLFW_WINGDIAPI_DEFINED
 #endif /* WINGDIAPI */
 
 /* Some Windows GLU headers need this.
  */
 #if !defined(CALLBACK) && defined(_WIN32)
-#define CALLBACK __stdcall
-#define GLFW_CALLBACK_DEFINED
+ #define CALLBACK __stdcall
+ #define GLFW_CALLBACK_DEFINED
 #endif /* CALLBACK */
 
 /* Include the chosen OpenGL or OpenGL ES headers.
  */
 #if defined(GLFW_INCLUDE_ES1)
 
-#include <GLES/gl.h>
-#if defined(GLFW_INCLUDE_GLEXT)
-#include <GLES/glext.h>
-#endif
+ #include <GLES/gl.h>
+ #if defined(GLFW_INCLUDE_GLEXT)
+  #include <GLES/glext.h>
+ #endif
 
 #elif defined(GLFW_INCLUDE_ES2)
 
-#include <GLES2/gl2.h>
-#if defined(GLFW_INCLUDE_GLEXT)
-#include <GLES2/gl2ext.h>
-#endif
+ #include <GLES2/gl2.h>
+ #if defined(GLFW_INCLUDE_GLEXT)
+  #include <GLES2/gl2ext.h>
+ #endif
 
 #elif defined(GLFW_INCLUDE_ES3)
 
-#include <GLES3/gl3.h>
-#if defined(GLFW_INCLUDE_GLEXT)
-#include <GLES2/gl2ext.h>
-#endif
+ #include <GLES3/gl3.h>
+ #if defined(GLFW_INCLUDE_GLEXT)
+  #include <GLES2/gl2ext.h>
+ #endif
 
 #elif defined(GLFW_INCLUDE_ES31)
 
-#include <GLES3/gl31.h>
-#if defined(GLFW_INCLUDE_GLEXT)
-#include <GLES2/gl2ext.h>
-#endif
+ #include <GLES3/gl31.h>
+ #if defined(GLFW_INCLUDE_GLEXT)
+  #include <GLES2/gl2ext.h>
+ #endif
 
 #elif defined(GLFW_INCLUDE_ES32)
 
-#include <GLES3/gl32.h>
-#if defined(GLFW_INCLUDE_GLEXT)
-#include <GLES2/gl2ext.h>
-#endif
+ #include <GLES3/gl32.h>
+ #if defined(GLFW_INCLUDE_GLEXT)
+  #include <GLES2/gl2ext.h>
+ #endif
 
 #elif defined(GLFW_INCLUDE_GLCOREARB)
 
-#if defined(__APPLE__)
+ #if defined(__APPLE__)
 
-#include <OpenGL/gl3.h>
-#if defined(GLFW_INCLUDE_GLEXT)
-#include <OpenGL/gl3ext.h>
-#endif /*GLFW_INCLUDE_GLEXT*/
+  #include <OpenGL/gl3.h>
+  #if defined(GLFW_INCLUDE_GLEXT)
+   #include <OpenGL/gl3ext.h>
+  #endif /*GLFW_INCLUDE_GLEXT*/
 
-#else /*__APPLE__*/
+ #else /*__APPLE__*/
 
-#include <GL/glcorearb.h>
-#if defined(GLFW_INCLUDE_GLEXT)
-#include <GL/glext.h>
-#endif
+  #include <GL/glcorearb.h>
+  #if defined(GLFW_INCLUDE_GLEXT)
+   #include <GL/glext.h>
+  #endif
 
-#endif /*__APPLE__*/
+ #endif /*__APPLE__*/
 
 #elif defined(GLFW_INCLUDE_GLU)
 
-#if defined(__APPLE__)
+ #if defined(__APPLE__)
 
-#if defined(GLFW_INCLUDE_GLU)
-#include <OpenGL/glu.h>
-#endif
+  #if defined(GLFW_INCLUDE_GLU)
+   #include <OpenGL/glu.h>
+  #endif
 
-#else /*__APPLE__*/
+ #else /*__APPLE__*/
 
-#if defined(GLFW_INCLUDE_GLU)
-#include <GL/glu.h>
-#endif
+  #if defined(GLFW_INCLUDE_GLU)
+   #include <GL/glu.h>
+  #endif
 
-#endif /*__APPLE__*/
+ #endif /*__APPLE__*/
 
-#elif !defined(GLFW_INCLUDE_NONE) && !defined(__gl_h_) &&                      \
-    !defined(__gles1_gl_h_) && !defined(__gles2_gl2_h_) &&                     \
-    !defined(__gles2_gl3_h_) && !defined(__gles2_gl31_h_) &&                   \
-    !defined(__gles2_gl32_h_) && !defined(__gl_glcorearb_h_) &&                \
-    !defined(__gl2_h_) /*legacy*/ && !defined(__gl3_h_) /*legacy*/ &&          \
-    !defined(__gl31_h_) /*legacy*/ && !defined(__gl32_h_) /*legacy*/ &&        \
-    !defined(__glcorearb_h_) /*legacy*/ &&                                     \
-    !defined(__GL_H__) /*non-standard*/ &&                                     \
-    !defined(__gltypes_h_) /*non-standard*/ &&                                 \
-    !defined(__glee_h_) /*non-standard*/
+#elif !defined(GLFW_INCLUDE_NONE) && \
+      !defined(__gl_h_) && \
+      !defined(__gles1_gl_h_) && \
+      !defined(__gles2_gl2_h_) && \
+      !defined(__gles2_gl3_h_) && \
+      !defined(__gles2_gl31_h_) && \
+      !defined(__gles2_gl32_h_) && \
+      !defined(__gl_glcorearb_h_) && \
+      !defined(__gl2_h_) /*legacy*/ && \
+      !defined(__gl3_h_) /*legacy*/ && \
+      !defined(__gl31_h_) /*legacy*/ && \
+      !defined(__gl32_h_) /*legacy*/ && \
+      !defined(__glcorearb_h_) /*legacy*/ && \
+      !defined(__GL_H__) /*non-standard*/ && \
+      !defined(__gltypes_h_) /*non-standard*/ && \
+      !defined(__glee_h_) /*non-standard*/
 
-#if defined(__APPLE__)
+ #if defined(__APPLE__)
 
-#if !defined(GLFW_INCLUDE_GLEXT)
-#define GL_GLEXT_LEGACY
-#endif
-#include <OpenGL/gl.h>
+  #if !defined(GLFW_INCLUDE_GLEXT)
+   #define GL_GLEXT_LEGACY
+  #endif
+  #include <OpenGL/gl.h>
 
-#else /*__APPLE__*/
+ #else /*__APPLE__*/
 
-#include <GL/gl.h>
-#if defined(GLFW_INCLUDE_GLEXT)
-#include <GL/glext.h>
-#endif
+  #include <GL/gl.h>
+  #if defined(GLFW_INCLUDE_GLEXT)
+   #include <GL/glext.h>
+  #endif
 
-#endif /*__APPLE__*/
+ #endif /*__APPLE__*/
 
 #endif /* OpenGL and OpenGL ES headers */
 
 #if defined(GLFW_DLL) && defined(_GLFW_BUILD_DLL)
-/* GLFW_DLL must be defined by applications that are linking against the DLL
- * version of the GLFW library.  _GLFW_BUILD_DLL is defined by the GLFW
- * configuration header when compiling the DLL version of the library.
- */
-#error "You must not have both GLFW_DLL and _GLFW_BUILD_DLL defined"
+ /* GLFW_DLL must be defined by applications that are linking against the DLL
+  * version of the GLFW library.  _GLFW_BUILD_DLL is defined by the GLFW
+  * configuration header when compiling the DLL version of the library.
+  */
+ #error "You must not have both GLFW_DLL and _GLFW_BUILD_DLL defined"
 #endif
 
 /* GLFWAPI is used to declare public API functions for export
  * from the DLL / shared library / dynamic library.
  */
 #if defined(_WIN32) && defined(_GLFW_BUILD_DLL)
-/* We are building GLFW as a Win32 DLL */
-#define GLFWAPI __declspec(dllexport)
+ /* We are building GLFW as a Win32 DLL */
+ #define GLFWAPI __declspec(dllexport)
 #elif defined(_WIN32) && defined(GLFW_DLL)
-/* We are calling a GLFW Win32 DLL */
-#define GLFWAPI __declspec(dllimport)
+ /* We are calling a GLFW Win32 DLL */
+ #define GLFWAPI __declspec(dllimport)
 #elif defined(__GNUC__) && defined(_GLFW_BUILD_DLL)
-/* We are building GLFW as a Unix shared library */
-#define GLFWAPI __attribute__((visibility("default")))
+ /* We are building GLFW as a Unix shared library */
+ #define GLFWAPI __attribute__((visibility("default")))
 #else
-#define GLFWAPI
+ #define GLFWAPI
 #endif
+
 
 /*************************************************************************
  * GLFW API tokens
@@ -276,21 +284,21 @@ extern "C" {
  *  API is changed in non-compatible ways.
  *  @ingroup init
  */
-#define GLFW_VERSION_MAJOR 3
+#define GLFW_VERSION_MAJOR          3
 /*! @brief The minor version number of the GLFW header.
  *
  *  The minor version number of the GLFW header.  This is incremented when
  *  features are added to the API but it remains backward-compatible.
  *  @ingroup init
  */
-#define GLFW_VERSION_MINOR 6
+#define GLFW_VERSION_MINOR          6
 /*! @brief The revision number of the GLFW header.
  *
  *  The revision number of the GLFW header.  This is incremented when a bug fix
  *  release is made that does not contain any API changes.
  *  @ingroup init
  */
-#define GLFW_VERSION_REVISION 0
+#define GLFW_VERSION_REVISION       0
 /*! @} */
 
 /*! @brief One.
@@ -301,7 +309,7 @@ extern "C" {
  *
  *  @ingroup init
  */
-#define GLFW_TRUE 1
+#define GLFW_TRUE                   1
 /*! @brief Zero.
  *
  *  This is only semantic sugar for the number 0.  You can instead use `0` or
@@ -310,7 +318,7 @@ extern "C" {
  *
  *  @ingroup init
  */
-#define GLFW_FALSE 0
+#define GLFW_FALSE                  0
 
 /*! @name Key and button actions
  *  @{ */
@@ -320,21 +328,21 @@ extern "C" {
  *
  *  @ingroup input
  */
-#define GLFW_RELEASE 0
+#define GLFW_RELEASE                0
 /*! @brief The key or mouse button was pressed.
  *
  *  The key or mouse button was pressed.
  *
  *  @ingroup input
  */
-#define GLFW_PRESS 1
+#define GLFW_PRESS                  1
 /*! @brief The key was held down until it repeated.
  *
  *  The key was held down until it repeated.
  *
  *  @ingroup input
  */
-#define GLFW_REPEAT 2
+#define GLFW_REPEAT                 2
 /*! @} */
 
 /*! @defgroup hat_state Joystick hat states
@@ -344,19 +352,19 @@ extern "C" {
  *
  *  @ingroup input
  *  @{ */
-#define GLFW_HAT_CENTERED 0
-#define GLFW_HAT_UP 1
-#define GLFW_HAT_RIGHT 2
-#define GLFW_HAT_DOWN 4
-#define GLFW_HAT_LEFT 8
-#define GLFW_HAT_RIGHT_UP (GLFW_HAT_RIGHT | GLFW_HAT_UP)
-#define GLFW_HAT_RIGHT_DOWN (GLFW_HAT_RIGHT | GLFW_HAT_DOWN)
-#define GLFW_HAT_LEFT_UP (GLFW_HAT_LEFT | GLFW_HAT_UP)
-#define GLFW_HAT_LEFT_DOWN (GLFW_HAT_LEFT | GLFW_HAT_DOWN)
+#define GLFW_HAT_CENTERED           0
+#define GLFW_HAT_UP                 1
+#define GLFW_HAT_RIGHT              2
+#define GLFW_HAT_DOWN               4
+#define GLFW_HAT_LEFT               8
+#define GLFW_HAT_RIGHT_UP           (GLFW_HAT_RIGHT | GLFW_HAT_UP)
+#define GLFW_HAT_RIGHT_DOWN         (GLFW_HAT_RIGHT | GLFW_HAT_DOWN)
+#define GLFW_HAT_LEFT_UP            (GLFW_HAT_LEFT  | GLFW_HAT_UP)
+#define GLFW_HAT_LEFT_DOWN          (GLFW_HAT_LEFT  | GLFW_HAT_DOWN)
 
 /*! @ingroup input
  */
-#define GLFW_KEY_UNKNOWN -1
+#define GLFW_KEY_UNKNOWN            -1
 
 /*! @} */
 
@@ -385,130 +393,130 @@ extern "C" {
  */
 
 /* Printable keys */
-#define GLFW_KEY_SPACE 32
-#define GLFW_KEY_APOSTROPHE 39 /* ' */
-#define GLFW_KEY_COMMA 44      /* , */
-#define GLFW_KEY_MINUS 45      /* - */
-#define GLFW_KEY_PERIOD 46     /* . */
-#define GLFW_KEY_SLASH 47      /* / */
-#define GLFW_KEY_0 48
-#define GLFW_KEY_1 49
-#define GLFW_KEY_2 50
-#define GLFW_KEY_3 51
-#define GLFW_KEY_4 52
-#define GLFW_KEY_5 53
-#define GLFW_KEY_6 54
-#define GLFW_KEY_7 55
-#define GLFW_KEY_8 56
-#define GLFW_KEY_9 57
-#define GLFW_KEY_SEMICOLON 59 /* ; */
-#define GLFW_KEY_EQUAL 61     /* = */
-#define GLFW_KEY_A 65
-#define GLFW_KEY_B 66
-#define GLFW_KEY_C 67
-#define GLFW_KEY_D 68
-#define GLFW_KEY_E 69
-#define GLFW_KEY_F 70
-#define GLFW_KEY_G 71
-#define GLFW_KEY_H 72
-#define GLFW_KEY_I 73
-#define GLFW_KEY_J 74
-#define GLFW_KEY_K 75
-#define GLFW_KEY_L 76
-#define GLFW_KEY_M 77
-#define GLFW_KEY_N 78
-#define GLFW_KEY_O 79
-#define GLFW_KEY_P 80
-#define GLFW_KEY_Q 81
-#define GLFW_KEY_R 82
-#define GLFW_KEY_S 83
-#define GLFW_KEY_T 84
-#define GLFW_KEY_U 85
-#define GLFW_KEY_V 86
-#define GLFW_KEY_W 87
-#define GLFW_KEY_X 88
-#define GLFW_KEY_Y 89
-#define GLFW_KEY_Z 90
-#define GLFW_KEY_LEFT_BRACKET 91  /* [ */
-#define GLFW_KEY_BACKSLASH 92     /* \ */
-#define GLFW_KEY_RIGHT_BRACKET 93 /* ] */
-#define GLFW_KEY_GRAVE_ACCENT 96  /* ` */
-#define GLFW_KEY_WORLD_1 161      /* non-US #1 */
-#define GLFW_KEY_WORLD_2 162      /* non-US #2 */
+#define GLFW_KEY_SPACE              32
+#define GLFW_KEY_APOSTROPHE         39  /* ' */
+#define GLFW_KEY_COMMA              44  /* , */
+#define GLFW_KEY_MINUS              45  /* - */
+#define GLFW_KEY_PERIOD             46  /* . */
+#define GLFW_KEY_SLASH              47  /* / */
+#define GLFW_KEY_0                  48
+#define GLFW_KEY_1                  49
+#define GLFW_KEY_2                  50
+#define GLFW_KEY_3                  51
+#define GLFW_KEY_4                  52
+#define GLFW_KEY_5                  53
+#define GLFW_KEY_6                  54
+#define GLFW_KEY_7                  55
+#define GLFW_KEY_8                  56
+#define GLFW_KEY_9                  57
+#define GLFW_KEY_SEMICOLON          59  /* ; */
+#define GLFW_KEY_EQUAL              61  /* = */
+#define GLFW_KEY_A                  65
+#define GLFW_KEY_B                  66
+#define GLFW_KEY_C                  67
+#define GLFW_KEY_D                  68
+#define GLFW_KEY_E                  69
+#define GLFW_KEY_F                  70
+#define GLFW_KEY_G                  71
+#define GLFW_KEY_H                  72
+#define GLFW_KEY_I                  73
+#define GLFW_KEY_J                  74
+#define GLFW_KEY_K                  75
+#define GLFW_KEY_L                  76
+#define GLFW_KEY_M                  77
+#define GLFW_KEY_N                  78
+#define GLFW_KEY_O                  79
+#define GLFW_KEY_P                  80
+#define GLFW_KEY_Q                  81
+#define GLFW_KEY_R                  82
+#define GLFW_KEY_S                  83
+#define GLFW_KEY_T                  84
+#define GLFW_KEY_U                  85
+#define GLFW_KEY_V                  86
+#define GLFW_KEY_W                  87
+#define GLFW_KEY_X                  88
+#define GLFW_KEY_Y                  89
+#define GLFW_KEY_Z                  90
+#define GLFW_KEY_LEFT_BRACKET       91  /* [ */
+#define GLFW_KEY_BACKSLASH          92  /* \ */
+#define GLFW_KEY_RIGHT_BRACKET      93  /* ] */
+#define GLFW_KEY_GRAVE_ACCENT       96  /* ` */
+#define GLFW_KEY_WORLD_1            161 /* non-US #1 */
+#define GLFW_KEY_WORLD_2            162 /* non-US #2 */
 
 /* Function keys */
-#define GLFW_KEY_ESCAPE 256
-#define GLFW_KEY_ENTER 257
-#define GLFW_KEY_TAB 258
-#define GLFW_KEY_BACKSPACE 259
-#define GLFW_KEY_INSERT 260
-#define GLFW_KEY_DELETE 261
-#define GLFW_KEY_RIGHT 262
-#define GLFW_KEY_LEFT 263
-#define GLFW_KEY_DOWN 264
-#define GLFW_KEY_UP 265
-#define GLFW_KEY_PAGE_UP 266
-#define GLFW_KEY_PAGE_DOWN 267
-#define GLFW_KEY_HOME 268
-#define GLFW_KEY_END 269
-#define GLFW_KEY_CAPS_LOCK 280
-#define GLFW_KEY_SCROLL_LOCK 281
-#define GLFW_KEY_NUM_LOCK 282
-#define GLFW_KEY_PRINT_SCREEN 283
-#define GLFW_KEY_PAUSE 284
-#define GLFW_KEY_F1 290
-#define GLFW_KEY_F2 291
-#define GLFW_KEY_F3 292
-#define GLFW_KEY_F4 293
-#define GLFW_KEY_F5 294
-#define GLFW_KEY_F6 295
-#define GLFW_KEY_F7 296
-#define GLFW_KEY_F8 297
-#define GLFW_KEY_F9 298
-#define GLFW_KEY_F10 299
-#define GLFW_KEY_F11 300
-#define GLFW_KEY_F12 301
-#define GLFW_KEY_F13 302
-#define GLFW_KEY_F14 303
-#define GLFW_KEY_F15 304
-#define GLFW_KEY_F16 305
-#define GLFW_KEY_F17 306
-#define GLFW_KEY_F18 307
-#define GLFW_KEY_F19 308
-#define GLFW_KEY_F20 309
-#define GLFW_KEY_F21 310
-#define GLFW_KEY_F22 311
-#define GLFW_KEY_F23 312
-#define GLFW_KEY_F24 313
-#define GLFW_KEY_F25 314
-#define GLFW_KEY_KP_0 320
-#define GLFW_KEY_KP_1 321
-#define GLFW_KEY_KP_2 322
-#define GLFW_KEY_KP_3 323
-#define GLFW_KEY_KP_4 324
-#define GLFW_KEY_KP_5 325
-#define GLFW_KEY_KP_6 326
-#define GLFW_KEY_KP_7 327
-#define GLFW_KEY_KP_8 328
-#define GLFW_KEY_KP_9 329
-#define GLFW_KEY_KP_DECIMAL 330
-#define GLFW_KEY_KP_DIVIDE 331
-#define GLFW_KEY_KP_MULTIPLY 332
-#define GLFW_KEY_KP_SUBTRACT 333
-#define GLFW_KEY_KP_ADD 334
-#define GLFW_KEY_KP_ENTER 335
-#define GLFW_KEY_KP_EQUAL 336
-#define GLFW_KEY_LEFT_SHIFT 340
-#define GLFW_KEY_LEFT_CONTROL 341
-#define GLFW_KEY_LEFT_ALT 342
-#define GLFW_KEY_LEFT_SUPER 343
-#define GLFW_KEY_RIGHT_SHIFT 344
-#define GLFW_KEY_RIGHT_CONTROL 345
-#define GLFW_KEY_RIGHT_ALT 346
-#define GLFW_KEY_RIGHT_SUPER 347
-#define GLFW_KEY_MENU 348
+#define GLFW_KEY_ESCAPE             256
+#define GLFW_KEY_ENTER              257
+#define GLFW_KEY_TAB                258
+#define GLFW_KEY_BACKSPACE          259
+#define GLFW_KEY_INSERT             260
+#define GLFW_KEY_DELETE             261
+#define GLFW_KEY_RIGHT              262
+#define GLFW_KEY_LEFT               263
+#define GLFW_KEY_DOWN               264
+#define GLFW_KEY_UP                 265
+#define GLFW_KEY_PAGE_UP            266
+#define GLFW_KEY_PAGE_DOWN          267
+#define GLFW_KEY_HOME               268
+#define GLFW_KEY_END                269
+#define GLFW_KEY_CAPS_LOCK          280
+#define GLFW_KEY_SCROLL_LOCK        281
+#define GLFW_KEY_NUM_LOCK           282
+#define GLFW_KEY_PRINT_SCREEN       283
+#define GLFW_KEY_PAUSE              284
+#define GLFW_KEY_F1                 290
+#define GLFW_KEY_F2                 291
+#define GLFW_KEY_F3                 292
+#define GLFW_KEY_F4                 293
+#define GLFW_KEY_F5                 294
+#define GLFW_KEY_F6                 295
+#define GLFW_KEY_F7                 296
+#define GLFW_KEY_F8                 297
+#define GLFW_KEY_F9                 298
+#define GLFW_KEY_F10                299
+#define GLFW_KEY_F11                300
+#define GLFW_KEY_F12                301
+#define GLFW_KEY_F13                302
+#define GLFW_KEY_F14                303
+#define GLFW_KEY_F15                304
+#define GLFW_KEY_F16                305
+#define GLFW_KEY_F17                306
+#define GLFW_KEY_F18                307
+#define GLFW_KEY_F19                308
+#define GLFW_KEY_F20                309
+#define GLFW_KEY_F21                310
+#define GLFW_KEY_F22                311
+#define GLFW_KEY_F23                312
+#define GLFW_KEY_F24                313
+#define GLFW_KEY_F25                314
+#define GLFW_KEY_KP_0               320
+#define GLFW_KEY_KP_1               321
+#define GLFW_KEY_KP_2               322
+#define GLFW_KEY_KP_3               323
+#define GLFW_KEY_KP_4               324
+#define GLFW_KEY_KP_5               325
+#define GLFW_KEY_KP_6               326
+#define GLFW_KEY_KP_7               327
+#define GLFW_KEY_KP_8               328
+#define GLFW_KEY_KP_9               329
+#define GLFW_KEY_KP_DECIMAL         330
+#define GLFW_KEY_KP_DIVIDE          331
+#define GLFW_KEY_KP_MULTIPLY        332
+#define GLFW_KEY_KP_SUBTRACT        333
+#define GLFW_KEY_KP_ADD             334
+#define GLFW_KEY_KP_ENTER           335
+#define GLFW_KEY_KP_EQUAL           336
+#define GLFW_KEY_LEFT_SHIFT         340
+#define GLFW_KEY_LEFT_CONTROL       341
+#define GLFW_KEY_LEFT_ALT           342
+#define GLFW_KEY_LEFT_SUPER         343
+#define GLFW_KEY_RIGHT_SHIFT        344
+#define GLFW_KEY_RIGHT_CONTROL      345
+#define GLFW_KEY_RIGHT_ALT          346
+#define GLFW_KEY_RIGHT_SUPER        347
+#define GLFW_KEY_MENU               348
 
-#define GLFW_KEY_LAST GLFW_KEY_MENU
+#define GLFW_KEY_LAST               GLFW_KEY_MENU
 
 /*! @} */
 
@@ -524,34 +532,34 @@ extern "C" {
  *
  *  If this bit is set one or more Shift keys were held down.
  */
-#define GLFW_MOD_SHIFT 0x0001
+#define GLFW_MOD_SHIFT           0x0001
 /*! @brief If this bit is set one or more Control keys were held down.
  *
  *  If this bit is set one or more Control keys were held down.
  */
-#define GLFW_MOD_CONTROL 0x0002
+#define GLFW_MOD_CONTROL         0x0002
 /*! @brief If this bit is set one or more Alt keys were held down.
  *
  *  If this bit is set one or more Alt keys were held down.
  */
-#define GLFW_MOD_ALT 0x0004
+#define GLFW_MOD_ALT             0x0004
 /*! @brief If this bit is set one or more Super keys were held down.
  *
  *  If this bit is set one or more Super keys were held down.
  */
-#define GLFW_MOD_SUPER 0x0008
+#define GLFW_MOD_SUPER           0x0008
 /*! @brief If this bit is set the Caps Lock key is enabled.
  *
  *  If this bit is set the Caps Lock key is enabled and the @ref
  *  GLFW_LOCK_KEY_MODS input mode is set.
  */
-#define GLFW_MOD_CAPS_LOCK 0x0010
+#define GLFW_MOD_CAPS_LOCK       0x0010
 /*! @brief If this bit is set the Num Lock key is enabled.
  *
  *  If this bit is set the Num Lock key is enabled and the @ref
  *  GLFW_LOCK_KEY_MODS input mode is set.
  */
-#define GLFW_MOD_NUM_LOCK 0x0020
+#define GLFW_MOD_NUM_LOCK        0x0020
 
 /*! @} */
 
@@ -562,18 +570,18 @@ extern "C" {
  *
  *  @ingroup input
  *  @{ */
-#define GLFW_MOUSE_BUTTON_1 0
-#define GLFW_MOUSE_BUTTON_2 1
-#define GLFW_MOUSE_BUTTON_3 2
-#define GLFW_MOUSE_BUTTON_4 3
-#define GLFW_MOUSE_BUTTON_5 4
-#define GLFW_MOUSE_BUTTON_6 5
-#define GLFW_MOUSE_BUTTON_7 6
-#define GLFW_MOUSE_BUTTON_8 7
-#define GLFW_MOUSE_BUTTON_LAST GLFW_MOUSE_BUTTON_8
-#define GLFW_MOUSE_BUTTON_LEFT GLFW_MOUSE_BUTTON_1
-#define GLFW_MOUSE_BUTTON_RIGHT GLFW_MOUSE_BUTTON_2
-#define GLFW_MOUSE_BUTTON_MIDDLE GLFW_MOUSE_BUTTON_3
+#define GLFW_MOUSE_BUTTON_1         0
+#define GLFW_MOUSE_BUTTON_2         1
+#define GLFW_MOUSE_BUTTON_3         2
+#define GLFW_MOUSE_BUTTON_4         3
+#define GLFW_MOUSE_BUTTON_5         4
+#define GLFW_MOUSE_BUTTON_6         5
+#define GLFW_MOUSE_BUTTON_7         6
+#define GLFW_MOUSE_BUTTON_8         7
+#define GLFW_MOUSE_BUTTON_LAST      GLFW_MOUSE_BUTTON_8
+#define GLFW_MOUSE_BUTTON_LEFT      GLFW_MOUSE_BUTTON_1
+#define GLFW_MOUSE_BUTTON_RIGHT     GLFW_MOUSE_BUTTON_2
+#define GLFW_MOUSE_BUTTON_MIDDLE    GLFW_MOUSE_BUTTON_3
 /*! @} */
 
 /*! @defgroup joysticks Joysticks
@@ -583,23 +591,23 @@ extern "C" {
  *
  *  @ingroup input
  *  @{ */
-#define GLFW_JOYSTICK_1 0
-#define GLFW_JOYSTICK_2 1
-#define GLFW_JOYSTICK_3 2
-#define GLFW_JOYSTICK_4 3
-#define GLFW_JOYSTICK_5 4
-#define GLFW_JOYSTICK_6 5
-#define GLFW_JOYSTICK_7 6
-#define GLFW_JOYSTICK_8 7
-#define GLFW_JOYSTICK_9 8
-#define GLFW_JOYSTICK_10 9
-#define GLFW_JOYSTICK_11 10
-#define GLFW_JOYSTICK_12 11
-#define GLFW_JOYSTICK_13 12
-#define GLFW_JOYSTICK_14 13
-#define GLFW_JOYSTICK_15 14
-#define GLFW_JOYSTICK_16 15
-#define GLFW_JOYSTICK_LAST GLFW_JOYSTICK_16
+#define GLFW_JOYSTICK_1             0
+#define GLFW_JOYSTICK_2             1
+#define GLFW_JOYSTICK_3             2
+#define GLFW_JOYSTICK_4             3
+#define GLFW_JOYSTICK_5             4
+#define GLFW_JOYSTICK_6             5
+#define GLFW_JOYSTICK_7             6
+#define GLFW_JOYSTICK_8             7
+#define GLFW_JOYSTICK_9             8
+#define GLFW_JOYSTICK_10            9
+#define GLFW_JOYSTICK_11            10
+#define GLFW_JOYSTICK_12            11
+#define GLFW_JOYSTICK_13            12
+#define GLFW_JOYSTICK_14            13
+#define GLFW_JOYSTICK_15            14
+#define GLFW_JOYSTICK_16            15
+#define GLFW_JOYSTICK_LAST          GLFW_JOYSTICK_16
 /*! @} */
 
 /*! @defgroup gamepad_buttons Gamepad buttons
@@ -609,27 +617,27 @@ extern "C" {
  *
  *  @ingroup input
  *  @{ */
-#define GLFW_GAMEPAD_BUTTON_A 0
-#define GLFW_GAMEPAD_BUTTON_B 1
-#define GLFW_GAMEPAD_BUTTON_X 2
-#define GLFW_GAMEPAD_BUTTON_Y 3
-#define GLFW_GAMEPAD_BUTTON_LEFT_BUMPER 4
-#define GLFW_GAMEPAD_BUTTON_RIGHT_BUMPER 5
-#define GLFW_GAMEPAD_BUTTON_BACK 6
-#define GLFW_GAMEPAD_BUTTON_START 7
-#define GLFW_GAMEPAD_BUTTON_GUIDE 8
-#define GLFW_GAMEPAD_BUTTON_LEFT_THUMB 9
-#define GLFW_GAMEPAD_BUTTON_RIGHT_THUMB 10
-#define GLFW_GAMEPAD_BUTTON_DPAD_UP 11
-#define GLFW_GAMEPAD_BUTTON_DPAD_RIGHT 12
-#define GLFW_GAMEPAD_BUTTON_DPAD_DOWN 13
-#define GLFW_GAMEPAD_BUTTON_DPAD_LEFT 14
-#define GLFW_GAMEPAD_BUTTON_LAST GLFW_GAMEPAD_BUTTON_DPAD_LEFT
+#define GLFW_GAMEPAD_BUTTON_A               0
+#define GLFW_GAMEPAD_BUTTON_B               1
+#define GLFW_GAMEPAD_BUTTON_X               2
+#define GLFW_GAMEPAD_BUTTON_Y               3
+#define GLFW_GAMEPAD_BUTTON_LEFT_BUMPER     4
+#define GLFW_GAMEPAD_BUTTON_RIGHT_BUMPER    5
+#define GLFW_GAMEPAD_BUTTON_BACK            6
+#define GLFW_GAMEPAD_BUTTON_START           7
+#define GLFW_GAMEPAD_BUTTON_GUIDE           8
+#define GLFW_GAMEPAD_BUTTON_LEFT_THUMB      9
+#define GLFW_GAMEPAD_BUTTON_RIGHT_THUMB     10
+#define GLFW_GAMEPAD_BUTTON_DPAD_UP         11
+#define GLFW_GAMEPAD_BUTTON_DPAD_RIGHT      12
+#define GLFW_GAMEPAD_BUTTON_DPAD_DOWN       13
+#define GLFW_GAMEPAD_BUTTON_DPAD_LEFT       14
+#define GLFW_GAMEPAD_BUTTON_LAST            GLFW_GAMEPAD_BUTTON_DPAD_LEFT
 
-#define GLFW_GAMEPAD_BUTTON_CROSS GLFW_GAMEPAD_BUTTON_A
-#define GLFW_GAMEPAD_BUTTON_CIRCLE GLFW_GAMEPAD_BUTTON_B
-#define GLFW_GAMEPAD_BUTTON_SQUARE GLFW_GAMEPAD_BUTTON_X
-#define GLFW_GAMEPAD_BUTTON_TRIANGLE GLFW_GAMEPAD_BUTTON_Y
+#define GLFW_GAMEPAD_BUTTON_CROSS       GLFW_GAMEPAD_BUTTON_A
+#define GLFW_GAMEPAD_BUTTON_CIRCLE      GLFW_GAMEPAD_BUTTON_B
+#define GLFW_GAMEPAD_BUTTON_SQUARE      GLFW_GAMEPAD_BUTTON_X
+#define GLFW_GAMEPAD_BUTTON_TRIANGLE    GLFW_GAMEPAD_BUTTON_Y
 /*! @} */
 
 /*! @defgroup gamepad_axes Gamepad axes
@@ -639,13 +647,13 @@ extern "C" {
  *
  *  @ingroup input
  *  @{ */
-#define GLFW_GAMEPAD_AXIS_LEFT_X 0
-#define GLFW_GAMEPAD_AXIS_LEFT_Y 1
-#define GLFW_GAMEPAD_AXIS_RIGHT_X 2
-#define GLFW_GAMEPAD_AXIS_RIGHT_Y 3
-#define GLFW_GAMEPAD_AXIS_LEFT_TRIGGER 4
+#define GLFW_GAMEPAD_AXIS_LEFT_X        0
+#define GLFW_GAMEPAD_AXIS_LEFT_Y        1
+#define GLFW_GAMEPAD_AXIS_RIGHT_X       2
+#define GLFW_GAMEPAD_AXIS_RIGHT_Y       3
+#define GLFW_GAMEPAD_AXIS_LEFT_TRIGGER  4
 #define GLFW_GAMEPAD_AXIS_RIGHT_TRIGGER 5
-#define GLFW_GAMEPAD_AXIS_LAST GLFW_GAMEPAD_AXIS_RIGHT_TRIGGER
+#define GLFW_GAMEPAD_AXIS_LAST          GLFW_GAMEPAD_AXIS_RIGHT_TRIGGER
 /*! @} */
 
 /*! @defgroup errors Error codes
@@ -661,7 +669,7 @@ extern "C" {
  *
  *  @analysis Yay.
  */
-#define GLFW_NO_ERROR 0
+#define GLFW_NO_ERROR               0
 /*! @brief GLFW has not been initialized.
  *
  *  This occurs if a GLFW function was called that must not be called unless the
@@ -670,7 +678,7 @@ extern "C" {
  *  @analysis Application programmer error.  Initialize GLFW before calling any
  *  function that requires initialization.
  */
-#define GLFW_NOT_INITIALIZED 0x00010001
+#define GLFW_NOT_INITIALIZED        0x00010001
 /*! @brief No context is current for this thread.
  *
  *  This occurs if a GLFW function was called that needs and operates on the
@@ -680,7 +688,7 @@ extern "C" {
  *  @analysis Application programmer error.  Ensure a context is current before
  *  calling functions that require a current context.
  */
-#define GLFW_NO_CURRENT_CONTEXT 0x00010002
+#define GLFW_NO_CURRENT_CONTEXT     0x00010002
 /*! @brief One of the arguments to the function was an invalid enum value.
  *
  *  One of the arguments to the function was an invalid enum value, for example
@@ -688,7 +696,7 @@ extern "C" {
  *
  *  @analysis Application programmer error.  Fix the offending call.
  */
-#define GLFW_INVALID_ENUM 0x00010003
+#define GLFW_INVALID_ENUM           0x00010003
 /*! @brief One of the arguments to the function was an invalid value.
  *
  *  One of the arguments to the function was an invalid value, for example
@@ -699,7 +707,7 @@ extern "C" {
  *
  *  @analysis Application programmer error.  Fix the offending call.
  */
-#define GLFW_INVALID_VALUE 0x00010004
+#define GLFW_INVALID_VALUE          0x00010004
 /*! @brief A memory allocation failed.
  *
  *  A memory allocation failed.
@@ -707,7 +715,7 @@ extern "C" {
  *  @analysis A bug in GLFW or the underlying operating system.  Report the bug
  *  to our [issue tracker](https://github.com/glfw/glfw/issues).
  */
-#define GLFW_OUT_OF_MEMORY 0x00010005
+#define GLFW_OUT_OF_MEMORY          0x00010005
 /*! @brief GLFW could not find support for the requested API on the system.
  *
  *  GLFW could not find support for the requested API on the system.
@@ -723,7 +731,7 @@ extern "C" {
  *  EGL, OpenGL and OpenGL ES libraries do not interface with the Nvidia binary
  *  driver.  Older graphics drivers do not support Vulkan.
  */
-#define GLFW_API_UNAVAILABLE 0x00010006
+#define GLFW_API_UNAVAILABLE        0x00010006
 /*! @brief The requested OpenGL or OpenGL ES version is not available.
  *
  *  The requested OpenGL or OpenGL ES version (including any requested context
@@ -740,7 +748,7 @@ extern "C" {
  *  not @ref GLFW_INVALID_VALUE, because GLFW cannot know what future versions
  *  will exist.
  */
-#define GLFW_VERSION_UNAVAILABLE 0x00010007
+#define GLFW_VERSION_UNAVAILABLE    0x00010007
 /*! @brief A platform-specific error occurred that does not match any of the
  *  more specific categories.
  *
@@ -751,7 +759,7 @@ extern "C" {
  *  system or its drivers, or a lack of required resources.  Report the issue to
  *  our [issue tracker](https://github.com/glfw/glfw/issues).
  */
-#define GLFW_PLATFORM_ERROR 0x00010008
+#define GLFW_PLATFORM_ERROR         0x00010008
 /*! @brief The requested format is not supported or available.
  *
  *  If emitted during window creation, the requested pixel format is not
@@ -770,7 +778,7 @@ extern "C" {
  *  If emitted when querying the clipboard, ignore the error or report it to
  *  the user, as appropriate.
  */
-#define GLFW_FORMAT_UNAVAILABLE 0x00010009
+#define GLFW_FORMAT_UNAVAILABLE     0x00010009
 /*! @brief The specified window does not have an OpenGL or OpenGL ES context.
  *
  *  A window that does not have an OpenGL or OpenGL ES context was passed to
@@ -778,7 +786,7 @@ extern "C" {
  *
  *  @analysis Application programmer error.  Fix the offending call.
  */
-#define GLFW_NO_WINDOW_CONTEXT 0x0001000A
+#define GLFW_NO_WINDOW_CONTEXT      0x0001000A
 /*! @brief The specified cursor shape is not available.
  *
  *  The specified standard cursor shape is not available, either because the
@@ -789,7 +797,7 @@ extern "C" {
  *  [standard cursor shape](@ref shapes) or create a
  *  [custom cursor](@ref cursor_custom).
  */
-#define GLFW_CURSOR_UNAVAILABLE 0x0001000B
+#define GLFW_CURSOR_UNAVAILABLE     0x0001000B
 /*! @brief The requested feature is not provided by the platform.
  *
  *  The requested feature is not provided by the platform, so GLFW is unable to
@@ -803,11 +811,10 @@ extern "C" {
  *  A function call that emits this error has no effect other than the error and
  *  updating any existing out parameters.
  */
-#define GLFW_FEATURE_UNAVAILABLE 0x0001000C
+#define GLFW_FEATURE_UNAVAILABLE    0x0001000C
 /*! @brief The requested feature is not implemented for the platform.
  *
- *  The requested feature has not yet been implemented in GLFW for this
- * platform.
+ *  The requested feature has not yet been implemented in GLFW for this platform.
  *
  *  @analysis An incomplete implementation of GLFW for this platform, hopefully
  *  fixed in a future release.  The error can be ignored unless the feature is
@@ -817,30 +824,29 @@ extern "C" {
  *  A function call that emits this error has no effect other than the error and
  *  updating any existing out parameters.
  */
-#define GLFW_FEATURE_UNIMPLEMENTED 0x0001000D
+#define GLFW_FEATURE_UNIMPLEMENTED  0x0001000D
 /*! @brief Platform unavailable or no matching platform was found.
  *
- *  If emitted during initialization, no matching platform was found.  If the
- * @ref GLFW_PLATFORM init hint was set to `GLFW_ANY_PLATFORM`, GLFW could not
- * detect any of the platforms supported by this library binary, except for the
- * Null platform.  If the init hint was set to a specific platform, it is either
- * not supported by this library binary or GLFW was not able to detect it.
+ *  If emitted during initialization, no matching platform was found.  If the @ref
+ *  GLFW_PLATFORM init hint was set to `GLFW_ANY_PLATFORM`, GLFW could not detect any of
+ *  the platforms supported by this library binary, except for the Null platform.  If the
+ *  init hint was set to a specific platform, it is either not supported by this library
+ *  binary or GLFW was not able to detect it.
  *
- *  If emitted by a native access function, GLFW was initialized for a different
- * platform than the function is for.
+ *  If emitted by a native access function, GLFW was initialized for a different platform
+ *  than the function is for.
  *
- *  @analysis Failure to detect any platform usually only happens on non-macOS
- * Unix systems, either when no window system is running or the program was run
- * from a terminal that does not have the necessary environment variables.  Fall
- * back to a different platform if possible or notify the user that no usable
- * platform was detected.
+ *  @analysis Failure to detect any platform usually only happens on non-macOS Unix
+ *  systems, either when no window system is running or the program was run from
+ *  a terminal that does not have the necessary environment variables.  Fall back to
+ *  a different platform if possible or notify the user that no usable platform was
+ *  detected.
  *
- *  Failure to detect a specific platform may have the same cause as above or be
- * because support for that platform was not compiled in.  Call @ref
- * glfwPlatformSupported to check whether a specific platform is supported by a
- * library binary.
+ *  Failure to detect a specific platform may have the same cause as above or be because
+ *  support for that platform was not compiled in.  Call @ref glfwPlatformSupported to
+ *  check whether a specific platform is supported by a library binary.
  */
-#define GLFW_PLATFORM_UNAVAILABLE 0x0001000E
+#define GLFW_PLATFORM_UNAVAILABLE   0x0001000E
 /*! @} */
 
 /*! @addtogroup window
@@ -850,53 +856,53 @@ extern "C" {
  *  Input focus [window hint](@ref GLFW_FOCUSED_hint) or
  *  [window attribute](@ref GLFW_FOCUSED_attrib).
  */
-#define GLFW_FOCUSED 0x00020001
+#define GLFW_FOCUSED                0x00020001
 /*! @brief Window iconification window attribute
  *
  *  Window iconification [window attribute](@ref GLFW_ICONIFIED_attrib).
  */
-#define GLFW_ICONIFIED 0x00020002
+#define GLFW_ICONIFIED              0x00020002
 /*! @brief Window resize-ability window hint and attribute
  *
  *  Window resize-ability [window hint](@ref GLFW_RESIZABLE_hint) and
  *  [window attribute](@ref GLFW_RESIZABLE_attrib).
  */
-#define GLFW_RESIZABLE 0x00020003
+#define GLFW_RESIZABLE              0x00020003
 /*! @brief Window visibility window hint and attribute
  *
  *  Window visibility [window hint](@ref GLFW_VISIBLE_hint) and
  *  [window attribute](@ref GLFW_VISIBLE_attrib).
  */
-#define GLFW_VISIBLE 0x00020004
+#define GLFW_VISIBLE                0x00020004
 /*! @brief Window decoration window hint and attribute
  *
  *  Window decoration [window hint](@ref GLFW_DECORATED_hint) and
  *  [window attribute](@ref GLFW_DECORATED_attrib).
  */
-#define GLFW_DECORATED 0x00020005
+#define GLFW_DECORATED              0x00020005
 /*! @brief Window auto-iconification window hint and attribute
  *
  *  Window auto-iconification [window hint](@ref GLFW_AUTO_ICONIFY_hint) and
  *  [window attribute](@ref GLFW_AUTO_ICONIFY_attrib).
  */
-#define GLFW_AUTO_ICONIFY 0x00020006
+#define GLFW_AUTO_ICONIFY           0x00020006
 /*! @brief Window decoration window hint and attribute
  *
  *  Window decoration [window hint](@ref GLFW_FLOATING_hint) and
  *  [window attribute](@ref GLFW_FLOATING_attrib).
  */
-#define GLFW_FLOATING 0x00020007
+#define GLFW_FLOATING               0x00020007
 /*! @brief Window maximization window hint and attribute
  *
  *  Window maximization [window hint](@ref GLFW_MAXIMIZED_hint) and
  *  [window attribute](@ref GLFW_MAXIMIZED_attrib).
  */
-#define GLFW_MAXIMIZED 0x00020008
+#define GLFW_MAXIMIZED              0x00020008
 /*! @brief Cursor centering window hint
  *
  *  Cursor centering [window hint](@ref GLFW_CENTER_CURSOR_hint).
  */
-#define GLFW_CENTER_CURSOR 0x00020009
+#define GLFW_CENTER_CURSOR          0x00020009
 /*! @brief Window framebuffer transparency hint and attribute
  *
  *  Window framebuffer transparency
@@ -908,170 +914,168 @@ extern "C" {
  *
  *  Mouse cursor hover [window attribute](@ref GLFW_HOVERED_attrib).
  */
-#define GLFW_HOVERED 0x0002000B
+#define GLFW_HOVERED                0x0002000B
 /*! @brief Input focus on calling show window hint and attribute
  *
  *  Input focus [window hint](@ref GLFW_FOCUS_ON_SHOW_hint) or
  *  [window attribute](@ref GLFW_FOCUS_ON_SHOW_attrib).
  */
-#define GLFW_FOCUS_ON_SHOW 0x0002000C
+#define GLFW_FOCUS_ON_SHOW          0x0002000C
 
 /*! @brief Mouse input transparency window hint and attribute
  *
  *  Mouse input transparency [window hint](@ref GLFW_MOUSE_PASSTHROUGH_hint) or
  *  [window attribute](@ref GLFW_MOUSE_PASSTHROUGH_attrib).
  */
-#define GLFW_MOUSE_PASSTHROUGH 0x0002000D
+#define GLFW_MOUSE_PASSTHROUGH      0x0002000D
 
 /*! @brief Initial position x-coordinate window hint.
  *
  *  Initial position x-coordinate [window hint](@ref GLFW_POSITION_X).
  */
-#define GLFW_POSITION_X 0x0002000E
+#define GLFW_POSITION_X             0x0002000E
 
 /*! @brief Initial position y-coordinate window hint.
  *
  *  Initial position y-coordinate [window hint](@ref GLFW_POSITION_Y).
  */
-#define GLFW_POSITION_Y 0x0002000F
+#define GLFW_POSITION_Y             0x0002000F
 
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_RED_BITS).
  */
-#define GLFW_RED_BITS 0x00021001
+#define GLFW_RED_BITS               0x00021001
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_GREEN_BITS).
  */
-#define GLFW_GREEN_BITS 0x00021002
+#define GLFW_GREEN_BITS             0x00021002
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_BLUE_BITS).
  */
-#define GLFW_BLUE_BITS 0x00021003
+#define GLFW_BLUE_BITS              0x00021003
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_ALPHA_BITS).
  */
-#define GLFW_ALPHA_BITS 0x00021004
+#define GLFW_ALPHA_BITS             0x00021004
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_DEPTH_BITS).
  */
-#define GLFW_DEPTH_BITS 0x00021005
+#define GLFW_DEPTH_BITS             0x00021005
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_STENCIL_BITS).
  */
-#define GLFW_STENCIL_BITS 0x00021006
+#define GLFW_STENCIL_BITS           0x00021006
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_ACCUM_RED_BITS).
  */
-#define GLFW_ACCUM_RED_BITS 0x00021007
+#define GLFW_ACCUM_RED_BITS         0x00021007
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_ACCUM_GREEN_BITS).
  */
-#define GLFW_ACCUM_GREEN_BITS 0x00021008
+#define GLFW_ACCUM_GREEN_BITS       0x00021008
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_ACCUM_BLUE_BITS).
  */
-#define GLFW_ACCUM_BLUE_BITS 0x00021009
+#define GLFW_ACCUM_BLUE_BITS        0x00021009
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_ACCUM_ALPHA_BITS).
  */
-#define GLFW_ACCUM_ALPHA_BITS 0x0002100A
+#define GLFW_ACCUM_ALPHA_BITS       0x0002100A
 /*! @brief Framebuffer auxiliary buffer hint.
  *
  *  Framebuffer auxiliary buffer [hint](@ref GLFW_AUX_BUFFERS).
  */
-#define GLFW_AUX_BUFFERS 0x0002100B
+#define GLFW_AUX_BUFFERS            0x0002100B
 /*! @brief OpenGL stereoscopic rendering hint.
  *
  *  OpenGL stereoscopic rendering [hint](@ref GLFW_STEREO).
  */
-#define GLFW_STEREO 0x0002100C
+#define GLFW_STEREO                 0x0002100C
 /*! @brief Framebuffer MSAA samples hint.
  *
  *  Framebuffer MSAA samples [hint](@ref GLFW_SAMPLES).
  */
-#define GLFW_SAMPLES 0x0002100D
+#define GLFW_SAMPLES                0x0002100D
 /*! @brief Framebuffer sRGB hint.
  *
  *  Framebuffer sRGB [hint](@ref GLFW_SRGB_CAPABLE).
  */
-#define GLFW_SRGB_CAPABLE 0x0002100E
+#define GLFW_SRGB_CAPABLE           0x0002100E
 /*! @brief Monitor refresh rate hint.
  *
  *  Monitor refresh rate [hint](@ref GLFW_REFRESH_RATE).
  */
-#define GLFW_REFRESH_RATE 0x0002100F
+#define GLFW_REFRESH_RATE           0x0002100F
 /*! @brief Framebuffer double buffering hint and attribute.
  *
  *  Framebuffer double buffering [hint](@ref GLFW_DOUBLEBUFFER_hint) and
  *  [attribute](@ref GLFW_DOUBLEBUFFER_attrib).
  */
-#define GLFW_DOUBLEBUFFER 0x00021010
+#define GLFW_DOUBLEBUFFER           0x00021010
 
 /*! @brief Context client API hint and attribute.
  *
  *  Context client API [hint](@ref GLFW_CLIENT_API_hint) and
  *  [attribute](@ref GLFW_CLIENT_API_attrib).
  */
-#define GLFW_CLIENT_API 0x00022001
+#define GLFW_CLIENT_API             0x00022001
 /*! @brief Context client API major version hint and attribute.
  *
- *  Context client API major version [hint](@ref
- * GLFW_CONTEXT_VERSION_MAJOR_hint) and [attribute](@ref
- * GLFW_CONTEXT_VERSION_MAJOR_attrib).
+ *  Context client API major version [hint](@ref GLFW_CONTEXT_VERSION_MAJOR_hint)
+ *  and [attribute](@ref GLFW_CONTEXT_VERSION_MAJOR_attrib).
  */
-#define GLFW_CONTEXT_VERSION_MAJOR 0x00022002
+#define GLFW_CONTEXT_VERSION_MAJOR  0x00022002
 /*! @brief Context client API minor version hint and attribute.
  *
- *  Context client API minor version [hint](@ref
- * GLFW_CONTEXT_VERSION_MINOR_hint) and [attribute](@ref
- * GLFW_CONTEXT_VERSION_MINOR_attrib).
+ *  Context client API minor version [hint](@ref GLFW_CONTEXT_VERSION_MINOR_hint)
+ *  and [attribute](@ref GLFW_CONTEXT_VERSION_MINOR_attrib).
  */
-#define GLFW_CONTEXT_VERSION_MINOR 0x00022003
+#define GLFW_CONTEXT_VERSION_MINOR  0x00022003
 /*! @brief Context client API revision number attribute.
  *
  *  Context client API revision number
  *  [attribute](@ref GLFW_CONTEXT_REVISION_attrib).
  */
-#define GLFW_CONTEXT_REVISION 0x00022004
+#define GLFW_CONTEXT_REVISION       0x00022004
 /*! @brief Context robustness hint and attribute.
  *
  *  Context client API revision number [hint](@ref GLFW_CONTEXT_ROBUSTNESS_hint)
  *  and [attribute](@ref GLFW_CONTEXT_ROBUSTNESS_attrib).
  */
-#define GLFW_CONTEXT_ROBUSTNESS 0x00022005
+#define GLFW_CONTEXT_ROBUSTNESS     0x00022005
 /*! @brief OpenGL forward-compatibility hint and attribute.
  *
  *  OpenGL forward-compatibility [hint](@ref GLFW_OPENGL_FORWARD_COMPAT_hint)
  *  and [attribute](@ref GLFW_OPENGL_FORWARD_COMPAT_attrib).
  */
-#define GLFW_OPENGL_FORWARD_COMPAT 0x00022006
+#define GLFW_OPENGL_FORWARD_COMPAT  0x00022006
 /*! @brief Debug mode context hint and attribute.
  *
  *  Debug mode context [hint](@ref GLFW_CONTEXT_DEBUG_hint) and
  *  [attribute](@ref GLFW_CONTEXT_DEBUG_attrib).
  */
-#define GLFW_CONTEXT_DEBUG 0x00022007
+#define GLFW_CONTEXT_DEBUG          0x00022007
 /*! @brief Legacy name for compatibility.
  *
  *  This is an alias for compatibility with earlier versions.
  */
-#define GLFW_OPENGL_DEBUG_CONTEXT GLFW_CONTEXT_DEBUG
+#define GLFW_OPENGL_DEBUG_CONTEXT   GLFW_CONTEXT_DEBUG
 /*! @brief OpenGL profile hint and attribute.
  *
  *  OpenGL profile [hint](@ref GLFW_OPENGL_PROFILE_hint) and
  *  [attribute](@ref GLFW_OPENGL_PROFILE_attrib).
  */
-#define GLFW_OPENGL_PROFILE 0x00022008
+#define GLFW_OPENGL_PROFILE         0x00022008
 /*! @brief Context flush-on-release hint and attribute.
  *
  *  Context flush-on-release [hint](@ref GLFW_CONTEXT_RELEASE_BEHAVIOR_hint) and
@@ -1083,21 +1087,21 @@ extern "C" {
  *  Context error suppression [hint](@ref GLFW_CONTEXT_NO_ERROR_hint) and
  *  [attribute](@ref GLFW_CONTEXT_NO_ERROR_attrib).
  */
-#define GLFW_CONTEXT_NO_ERROR 0x0002200A
+#define GLFW_CONTEXT_NO_ERROR       0x0002200A
 /*! @brief Context creation API hint and attribute.
  *
  *  Context creation API [hint](@ref GLFW_CONTEXT_CREATION_API_hint) and
  *  [attribute](@ref GLFW_CONTEXT_CREATION_API_attrib).
  */
-#define GLFW_CONTEXT_CREATION_API 0x0002200B
+#define GLFW_CONTEXT_CREATION_API   0x0002200B
 /*! @brief Window content area scaling window
  *  [window hint](@ref GLFW_SCALE_TO_MONITOR).
  */
-#define GLFW_SCALE_TO_MONITOR 0x0002200C
+#define GLFW_SCALE_TO_MONITOR       0x0002200C
 /*! @brief Window framebuffer scaling
  *  [window hint](@ref GLFW_SCALE_FRAMEBUFFER_hint).
  */
-#define GLFW_SCALE_FRAMEBUFFER 0x0002200D
+#define GLFW_SCALE_FRAMEBUFFER      0x0002200D
 /*! @brief Legacy name for compatibility.
  *
  *  This is an alias for the
@@ -1108,7 +1112,7 @@ extern "C" {
 /*! @brief macOS specific
  *  [window hint](@ref GLFW_COCOA_FRAME_NAME_hint).
  */
-#define GLFW_COCOA_FRAME_NAME 0x00023002
+#define GLFW_COCOA_FRAME_NAME         0x00023002
 /*! @brief macOS specific
  *  [window hint](@ref GLFW_COCOA_GRAPHICS_SWITCHING_hint).
  */
@@ -1116,71 +1120,71 @@ extern "C" {
 /*! @brief X11 specific
  *  [window hint](@ref GLFW_X11_CLASS_NAME_hint).
  */
-#define GLFW_X11_CLASS_NAME 0x00024001
+#define GLFW_X11_CLASS_NAME         0x00024001
 /*! @brief X11 specific
  *  [window hint](@ref GLFW_X11_CLASS_NAME_hint).
  */
-#define GLFW_X11_INSTANCE_NAME 0x00024002
-#define GLFW_WIN32_KEYBOARD_MENU 0x00025001
+#define GLFW_X11_INSTANCE_NAME      0x00024002
+#define GLFW_WIN32_KEYBOARD_MENU    0x00025001
 /*! @brief Win32 specific [window hint](@ref GLFW_WIN32_SHOWDEFAULT_hint).
  */
-#define GLFW_WIN32_SHOWDEFAULT 0x00025002
+#define GLFW_WIN32_SHOWDEFAULT      0x00025002
 /*! @brief Wayland specific
  *  [window hint](@ref GLFW_WAYLAND_APP_ID_hint).
  *
  *  Allows specification of the Wayland app_id.
  */
-#define GLFW_WAYLAND_APP_ID 0x00026001
+#define GLFW_WAYLAND_APP_ID         0x00026001
 /*! @brief X11 specific
  *  [window hint](@ref GLFW_X11_OVERRIDE_REDIRECT_hint).
  */
 #define GLFW_X11_OVERRIDE_REDIRECT 0x00026002
 /*! @} */
 
-#define GLFW_NO_API 0
-#define GLFW_OPENGL_API 0x00030001
-#define GLFW_OPENGL_ES_API 0x00030002
+#define GLFW_NO_API                          0
+#define GLFW_OPENGL_API             0x00030001
+#define GLFW_OPENGL_ES_API          0x00030002
 
-#define GLFW_NO_ROBUSTNESS 0
-#define GLFW_NO_RESET_NOTIFICATION 0x00031001
-#define GLFW_LOSE_CONTEXT_ON_RESET 0x00031002
+#define GLFW_NO_ROBUSTNESS                   0
+#define GLFW_NO_RESET_NOTIFICATION  0x00031001
+#define GLFW_LOSE_CONTEXT_ON_RESET  0x00031002
 
-#define GLFW_OPENGL_ANY_PROFILE 0
-#define GLFW_OPENGL_CORE_PROFILE 0x00032001
-#define GLFW_OPENGL_COMPAT_PROFILE 0x00032002
+#define GLFW_OPENGL_ANY_PROFILE              0
+#define GLFW_OPENGL_CORE_PROFILE    0x00032001
+#define GLFW_OPENGL_COMPAT_PROFILE  0x00032002
 
-#define GLFW_CURSOR 0x00033001
-#define GLFW_STICKY_KEYS 0x00033002
-#define GLFW_STICKY_MOUSE_BUTTONS 0x00033003
-#define GLFW_LOCK_KEY_MODS 0x00033004
-#define GLFW_RAW_MOUSE_MOTION 0x00033005
+#define GLFW_CURSOR                  0x00033001
+#define GLFW_STICKY_KEYS             0x00033002
+#define GLFW_STICKY_MOUSE_BUTTONS    0x00033003
+#define GLFW_LOCK_KEY_MODS           0x00033004
+#define GLFW_RAW_MOUSE_MOTION        0x00033005
 #define GLFW_UNLIMITED_MOUSE_BUTTONS 0x00033006
 
-#define GLFW_CURSOR_NORMAL 0x00034001
-#define GLFW_CURSOR_HIDDEN 0x00034002
-#define GLFW_CURSOR_DISABLED 0x00034003
-#define GLFW_CURSOR_CAPTURED 0x00034004
+#define GLFW_CURSOR_NORMAL          0x00034001
+#define GLFW_CURSOR_HIDDEN          0x00034002
+#define GLFW_CURSOR_DISABLED        0x00034003
+#define GLFW_CURSOR_CAPTURED        0x00034004
 
-#define GLFW_ANY_RELEASE_BEHAVIOR 0
+#define GLFW_ANY_RELEASE_BEHAVIOR            0
 #define GLFW_RELEASE_BEHAVIOR_FLUSH 0x00035001
-#define GLFW_RELEASE_BEHAVIOR_NONE 0x00035002
+#define GLFW_RELEASE_BEHAVIOR_NONE  0x00035002
 
-#define GLFW_NATIVE_CONTEXT_API 0x00036001
-#define GLFW_EGL_CONTEXT_API 0x00036002
-#define GLFW_OSMESA_CONTEXT_API 0x00036003
+#define GLFW_NATIVE_CONTEXT_API     0x00036001
+#define GLFW_EGL_CONTEXT_API        0x00036002
+#define GLFW_OSMESA_CONTEXT_API     0x00036003
 
-#define GLFW_ANGLE_PLATFORM_TYPE_NONE 0x00037001
-#define GLFW_ANGLE_PLATFORM_TYPE_OPENGL 0x00037002
+#define GLFW_ANGLE_PLATFORM_TYPE_NONE    0x00037001
+#define GLFW_ANGLE_PLATFORM_TYPE_OPENGL  0x00037002
 #define GLFW_ANGLE_PLATFORM_TYPE_OPENGLES 0x00037003
-#define GLFW_ANGLE_PLATFORM_TYPE_D3D9 0x00037004
-#define GLFW_ANGLE_PLATFORM_TYPE_D3D11 0x00037005
-#define GLFW_ANGLE_PLATFORM_TYPE_VULKAN 0x00037007
-#define GLFW_ANGLE_PLATFORM_TYPE_METAL 0x00037008
+#define GLFW_ANGLE_PLATFORM_TYPE_D3D9    0x00037004
+#define GLFW_ANGLE_PLATFORM_TYPE_D3D11   0x00037005
+#define GLFW_ANGLE_PLATFORM_TYPE_VULKAN  0x00037007
+#define GLFW_ANGLE_PLATFORM_TYPE_METAL   0x00037008
 
-#define GLFW_WAYLAND_PREFER_LIBDECOR 0x00038001
-#define GLFW_WAYLAND_DISABLE_LIBDECOR 0x00038002
+#define GLFW_WAYLAND_PREFER_LIBDECOR    0x00038001
+#define GLFW_WAYLAND_DISABLE_LIBDECOR   0x00038002
 
-#define GLFW_ANY_POSITION 0x80000000
+#define GLFW_ANY_POSITION           0x80000000
 
 /*! @defgroup shapes Standard cursor shapes
  *  @brief Standard system cursor shapes.
@@ -1195,34 +1199,34 @@ extern "C" {
  *
  *  The regular arrow cursor shape.
  */
-#define GLFW_ARROW_CURSOR 0x00036001
+#define GLFW_ARROW_CURSOR           0x00036001
 /*! @brief The text input I-beam cursor shape.
  *
  *  The text input I-beam cursor shape.
  */
-#define GLFW_IBEAM_CURSOR 0x00036002
+#define GLFW_IBEAM_CURSOR           0x00036002
 /*! @brief The crosshair cursor shape.
  *
  *  The crosshair cursor shape.
  */
-#define GLFW_CROSSHAIR_CURSOR 0x00036003
+#define GLFW_CROSSHAIR_CURSOR       0x00036003
 /*! @brief The pointing hand cursor shape.
  *
  *  The pointing hand cursor shape.
  */
-#define GLFW_POINTING_HAND_CURSOR 0x00036004
+#define GLFW_POINTING_HAND_CURSOR   0x00036004
 /*! @brief The horizontal resize/move arrow shape.
  *
  *  The horizontal resize/move arrow shape.  This is usually a horizontal
  *  double-headed arrow.
  */
-#define GLFW_RESIZE_EW_CURSOR 0x00036005
+#define GLFW_RESIZE_EW_CURSOR       0x00036005
 /*! @brief The vertical resize/move arrow shape.
  *
  *  The vertical resize/move shape.  This is usually a vertical double-headed
  *  arrow.
  */
-#define GLFW_RESIZE_NS_CURSOR 0x00036006
+#define GLFW_RESIZE_NS_CURSOR       0x00036006
 /*! @brief The top-left to bottom-right diagonal resize/move arrow shape.
  *
  *  The top-left to bottom-right diagonal resize/move shape.  This is usually
@@ -1231,13 +1235,13 @@ extern "C" {
  *  @note __macOS:__ This shape is provided by a private system API and may fail
  *  with @ref GLFW_CURSOR_UNAVAILABLE in the future.
  *
- *  @note __Wayland:__ This shape is provided by a newer standard not supported
- * by all cursor themes.
+ *  @note __Wayland:__ This shape is provided by a newer standard not supported by
+ *  all cursor themes.
  *
- *  @note __X11:__ This shape is provided by a newer standard not supported by
- * all cursor themes.
+ *  @note __X11:__ This shape is provided by a newer standard not supported by all
+ *  cursor themes.
  */
-#define GLFW_RESIZE_NWSE_CURSOR 0x00036007
+#define GLFW_RESIZE_NWSE_CURSOR     0x00036007
 /*! @brief The top-right to bottom-left diagonal resize/move arrow shape.
  *
  *  The top-right to bottom-left diagonal resize/move shape.  This is usually
@@ -1246,50 +1250,50 @@ extern "C" {
  *  @note __macOS:__ This shape is provided by a private system API and may fail
  *  with @ref GLFW_CURSOR_UNAVAILABLE in the future.
  *
- *  @note __Wayland:__ This shape is provided by a newer standard not supported
- * by all cursor themes.
+ *  @note __Wayland:__ This shape is provided by a newer standard not supported by
+ *  all cursor themes.
  *
- *  @note __X11:__ This shape is provided by a newer standard not supported by
- * all cursor themes.
+ *  @note __X11:__ This shape is provided by a newer standard not supported by all
+ *  cursor themes.
  */
-#define GLFW_RESIZE_NESW_CURSOR 0x00036008
+#define GLFW_RESIZE_NESW_CURSOR     0x00036008
 /*! @brief The omni-directional resize/move cursor shape.
  *
  *  The omni-directional resize cursor/move shape.  This is usually either
  *  a combined horizontal and vertical double-headed arrow or a grabbing hand.
  */
-#define GLFW_RESIZE_ALL_CURSOR 0x00036009
+#define GLFW_RESIZE_ALL_CURSOR      0x00036009
 /*! @brief The operation-not-allowed shape.
  *
  *  The operation-not-allowed shape.  This is usually a circle with a diagonal
  *  line through it.
  *
- *  @note __Wayland:__ This shape is provided by a newer standard not supported
- * by all cursor themes.
+ *  @note __Wayland:__ This shape is provided by a newer standard not supported by
+ *  all cursor themes.
  *
- *  @note __X11:__ This shape is provided by a newer standard not supported by
- * all cursor themes.
+ *  @note __X11:__ This shape is provided by a newer standard not supported by all
+ *  cursor themes.
  */
-#define GLFW_NOT_ALLOWED_CURSOR 0x0003600A
+#define GLFW_NOT_ALLOWED_CURSOR     0x0003600A
 /*! @brief Legacy name for compatibility.
  *
  *  This is an alias for compatibility with earlier versions.
  */
-#define GLFW_HRESIZE_CURSOR GLFW_RESIZE_EW_CURSOR
+#define GLFW_HRESIZE_CURSOR         GLFW_RESIZE_EW_CURSOR
 /*! @brief Legacy name for compatibility.
  *
  *  This is an alias for compatibility with earlier versions.
  */
-#define GLFW_VRESIZE_CURSOR GLFW_RESIZE_NS_CURSOR
+#define GLFW_VRESIZE_CURSOR         GLFW_RESIZE_NS_CURSOR
 /*! @brief Legacy name for compatibility.
  *
  *  This is an alias for compatibility with earlier versions.
  */
-#define GLFW_HAND_CURSOR GLFW_POINTING_HAND_CURSOR
+#define GLFW_HAND_CURSOR            GLFW_POINTING_HAND_CURSOR
 /*! @} */
 
-#define GLFW_CONNECTED 0x00040001
-#define GLFW_DISCONNECTED 0x00040002
+#define GLFW_CONNECTED              0x00040001
+#define GLFW_DISCONNECTED           0x00040002
 
 /*! @addtogroup init
  *  @{ */
@@ -1297,27 +1301,27 @@ extern "C" {
  *
  *  Joystick hat buttons [init hint](@ref GLFW_JOYSTICK_HAT_BUTTONS).
  */
-#define GLFW_JOYSTICK_HAT_BUTTONS 0x00050001
+#define GLFW_JOYSTICK_HAT_BUTTONS   0x00050001
 /*! @brief ANGLE rendering backend init hint.
  *
  *  ANGLE rendering backend [init hint](@ref GLFW_ANGLE_PLATFORM_TYPE_hint).
  */
-#define GLFW_ANGLE_PLATFORM_TYPE 0x00050002
+#define GLFW_ANGLE_PLATFORM_TYPE    0x00050002
 /*! @brief Platform selection init hint.
  *
  *  Platform selection [init hint](@ref GLFW_PLATFORM).
  */
-#define GLFW_PLATFORM 0x00050003
+#define GLFW_PLATFORM               0x00050003
 /*! @brief macOS specific init hint.
  *
  *  macOS specific [init hint](@ref GLFW_COCOA_CHDIR_RESOURCES_hint).
  */
-#define GLFW_COCOA_CHDIR_RESOURCES 0x00051001
+#define GLFW_COCOA_CHDIR_RESOURCES  0x00051001
 /*! @brief macOS specific init hint.
  *
  *  macOS specific [init hint](@ref GLFW_COCOA_MENUBAR_hint).
  */
-#define GLFW_COCOA_MENUBAR 0x00051002
+#define GLFW_COCOA_MENUBAR          0x00051002
 /*! @brief X11 specific init hint.
  *
  *  X11 specific [init hint](@ref GLFW_X11_XCB_VULKAN_SURFACE_hint).
@@ -1327,7 +1331,7 @@ extern "C" {
  *
  *  Wayland specific [init hint](@ref GLFW_WAYLAND_LIBDECOR_hint).
  */
-#define GLFW_WAYLAND_LIBDECOR 0x00053001
+#define GLFW_WAYLAND_LIBDECOR       0x00053001
 /*! @} */
 
 /*! @addtogroup init
@@ -1336,19 +1340,20 @@ extern "C" {
  *
  *  Hint value for @ref GLFW_PLATFORM that enables automatic platform selection.
  */
-#define GLFW_ANY_PLATFORM 0x00060000
-#define GLFW_PLATFORM_WIN32 0x00060001
-#define GLFW_PLATFORM_COCOA 0x00060002
-#define GLFW_PLATFORM_WAYLAND 0x00060003
-#define GLFW_PLATFORM_X11 0x00060004
-#define GLFW_PLATFORM_NULL 0x00060005
+#define GLFW_ANY_PLATFORM           0x00060000
+#define GLFW_PLATFORM_WIN32         0x00060001
+#define GLFW_PLATFORM_COCOA         0x00060002
+#define GLFW_PLATFORM_WAYLAND       0x00060003
+#define GLFW_PLATFORM_X11           0x00060004
+#define GLFW_PLATFORM_NULL          0x00060005
 /*! @} */
 
 /* Reserved platform define for external Emscripten ports: 0x00060006
  * See https://github.com/pongasoft/emscripten-glfw
  */
 
-#define GLFW_DONT_CARE -1
+#define GLFW_DONT_CARE              -1
+
 
 /*************************************************************************
  * GLFW API types
@@ -1427,23 +1432,23 @@ typedef struct GLFWcursor GLFWcursor;
  *  @endcode
  *
  *  This function must return either a memory block at least `size` bytes long,
- *  or `NULL` if allocation failed.  Note that not all parts of GLFW handle
- * allocation failures gracefully yet.
+ *  or `NULL` if allocation failed.  Note that not all parts of GLFW handle allocation
+ *  failures gracefully yet.
  *
- *  This function must support being called during @ref glfwInit but before the
- * library is flagged as initialized, as well as during @ref glfwTerminate after
- * the library is no longer flagged as initialized.
+ *  This function must support being called during @ref glfwInit but before the library is
+ *  flagged as initialized, as well as during @ref glfwTerminate after the library is no
+ *  longer flagged as initialized.
  *
- *  Any memory allocated via this function will be deallocated via the same
- * allocator during library termination or earlier.
+ *  Any memory allocated via this function will be deallocated via the same allocator
+ *  during library termination or earlier.
  *
- *  Any memory allocated via this function must be suitably aligned for any
- * object type. If you are using C99 or earlier, this alignment is
- * platform-dependent but will be the same as what `malloc` provides.  If you
- * are using C11 or later, this is the value of `alignof(max_align_t)`.
+ *  Any memory allocated via this function must be suitably aligned for any object type.
+ *  If you are using C99 or earlier, this alignment is platform-dependent but will be the
+ *  same as what `malloc` provides.  If you are using C11 or later, this is the value of
+ *  `alignof(max_align_t)`.
  *
- *  The size will always be greater than zero.  Allocations of size zero are
- * filtered out before reaching the custom allocator.
+ *  The size will always be greater than zero.  Allocations of size zero are filtered out
+ *  before reaching the custom allocator.
  *
  *  If this function returns `NULL`, GLFW will emit @ref GLFW_OUT_OF_MEMORY.
  *
@@ -1459,8 +1464,8 @@ typedef struct GLFWcursor GLFWcursor;
  *
  *  @reentrancy This function should not call any GLFW function.
  *
- *  @thread_safety This function must support being called from any thread that
- * calls GLFW functions.
+ *  @thread_safety This function must support being called from any thread that calls GLFW
+ *  functions.
  *
  *  @sa @ref init_allocator
  *  @sa @ref GLFWallocator
@@ -1469,7 +1474,7 @@ typedef struct GLFWcursor GLFWcursor;
  *
  *  @ingroup init
  */
-typedef void *(*GLFWallocatefun)(size_t size, void *user);
+typedef void* (* GLFWallocatefun)(size_t size, void* user);
 
 /*! @brief The function pointer type for memory reallocation callbacks.
  *
@@ -1480,26 +1485,25 @@ typedef void *(*GLFWallocatefun)(size_t size, void *user);
  *  @endcode
  *
  *  This function must return a memory block at least `size` bytes long, or
- *  `NULL` if allocation failed.  Note that not all parts of GLFW handle
- * allocation failures gracefully yet.
+ *  `NULL` if allocation failed.  Note that not all parts of GLFW handle allocation
+ *  failures gracefully yet.
  *
- *  This function must support being called during @ref glfwInit but before the
- * library is flagged as initialized, as well as during @ref glfwTerminate after
- * the library is no longer flagged as initialized.
+ *  This function must support being called during @ref glfwInit but before the library is
+ *  flagged as initialized, as well as during @ref glfwTerminate after the library is no
+ *  longer flagged as initialized.
  *
- *  Any memory allocated via this function will be deallocated via the same
- * allocator during library termination or earlier.
+ *  Any memory allocated via this function will be deallocated via the same allocator
+ *  during library termination or earlier.
  *
- *  Any memory allocated via this function must be suitably aligned for any
- * object type. If you are using C99 or earlier, this alignment is
- * platform-dependent but will be the same as what `realloc` provides.  If you
- * are using C11 or later, this is the value of `alignof(max_align_t)`.
+ *  Any memory allocated via this function must be suitably aligned for any object type.
+ *  If you are using C99 or earlier, this alignment is platform-dependent but will be the
+ *  same as what `realloc` provides.  If you are using C11 or later, this is the value of
+ *  `alignof(max_align_t)`.
  *
- *  The block address will never be `NULL` and the size will always be greater
- * than zero. Reallocations of a block to size zero are converted into
- * deallocations before reaching the custom allocator.  Reallocations of `NULL`
- * to a non-zero size are converted into regular allocations before reaching the
- * custom allocator.
+ *  The block address will never be `NULL` and the size will always be greater than zero.
+ *  Reallocations of a block to size zero are converted into deallocations before reaching
+ *  the custom allocator.  Reallocations of `NULL` to a non-zero size are converted into
+ *  regular allocations before reaching the custom allocator.
  *
  *  If this function returns `NULL`, GLFW will emit @ref GLFW_OUT_OF_MEMORY.
  *
@@ -1516,8 +1520,8 @@ typedef void *(*GLFWallocatefun)(size_t size, void *user);
  *
  *  @reentrancy This function should not call any GLFW function.
  *
- *  @thread_safety This function must support being called from any thread that
- * calls GLFW functions.
+ *  @thread_safety This function must support being called from any thread that calls GLFW
+ *  functions.
  *
  *  @sa @ref init_allocator
  *  @sa @ref GLFWallocator
@@ -1526,7 +1530,7 @@ typedef void *(*GLFWallocatefun)(size_t size, void *user);
  *
  *  @ingroup init
  */
-typedef void *(*GLFWreallocatefun)(void *block, size_t size, void *user);
+typedef void* (* GLFWreallocatefun)(void* block, size_t size, void* user);
 
 /*! @brief The function pointer type for memory deallocation callbacks.
  *
@@ -1539,12 +1543,12 @@ typedef void *(*GLFWreallocatefun)(void *block, size_t size, void *user);
  *  This function may deallocate the specified memory block.  This memory block
  *  will have been allocated with the same allocator.
  *
- *  This function must support being called during @ref glfwInit but before the
- * library is flagged as initialized, as well as during @ref glfwTerminate after
- * the library is no longer flagged as initialized.
+ *  This function must support being called during @ref glfwInit but before the library is
+ *  flagged as initialized, as well as during @ref glfwTerminate after the library is no
+ *  longer flagged as initialized.
  *
- *  The block address will never be `NULL`.  Deallocations of `NULL` are
- * filtered out before reaching the custom allocator.
+ *  The block address will never be `NULL`.  Deallocations of `NULL` are filtered out
+ *  before reaching the custom allocator.
  *
  *  If this function returns `NULL`, GLFW will emit @ref GLFW_OUT_OF_MEMORY.
  *
@@ -1558,8 +1562,8 @@ typedef void *(*GLFWreallocatefun)(void *block, size_t size, void *user);
  *
  *  @reentrancy This function should not call any GLFW function.
  *
- *  @thread_safety This function must support being called from any thread that
- * calls GLFW functions.
+ *  @thread_safety This function must support being called from any thread that calls GLFW
+ *  functions.
  *
  *  @sa @ref init_allocator
  *  @sa @ref GLFWallocator
@@ -1568,7 +1572,7 @@ typedef void *(*GLFWreallocatefun)(void *block, size_t size, void *user);
  *
  *  @ingroup init
  */
-typedef void (*GLFWdeallocatefun)(void *block, void *user);
+typedef void (* GLFWdeallocatefun)(void* block, void* user);
 
 /*! @brief The function pointer type for error callbacks.
  *
@@ -1592,7 +1596,7 @@ typedef void (*GLFWdeallocatefun)(void *block, void *user);
  *
  *  @ingroup init
  */
-typedef void (*GLFWerrorfun)(int error_code, const char *description);
+typedef void (* GLFWerrorfun)(int error_code, const char* description);
 
 /*! @brief The function pointer type for window position callbacks.
  *
@@ -1615,7 +1619,7 @@ typedef void (*GLFWerrorfun)(int error_code, const char *description);
  *
  *  @ingroup window
  */
-typedef void (*GLFWwindowposfun)(GLFWwindow *window, int xpos, int ypos);
+typedef void (* GLFWwindowposfun)(GLFWwindow* window, int xpos, int ypos);
 
 /*! @brief The function pointer type for window size callbacks.
  *
@@ -1637,7 +1641,7 @@ typedef void (*GLFWwindowposfun)(GLFWwindow *window, int xpos, int ypos);
  *
  *  @ingroup window
  */
-typedef void (*GLFWwindowsizefun)(GLFWwindow *window, int width, int height);
+typedef void (* GLFWwindowsizefun)(GLFWwindow* window, int width, int height);
 
 /*! @brief The function pointer type for window close callbacks.
  *
@@ -1657,7 +1661,7 @@ typedef void (*GLFWwindowsizefun)(GLFWwindow *window, int width, int height);
  *
  *  @ingroup window
  */
-typedef void (*GLFWwindowclosefun)(GLFWwindow *window);
+typedef void (* GLFWwindowclosefun)(GLFWwindow* window);
 
 /*! @brief The function pointer type for window content refresh callbacks.
  *
@@ -1677,7 +1681,7 @@ typedef void (*GLFWwindowclosefun)(GLFWwindow *window);
  *
  *  @ingroup window
  */
-typedef void (*GLFWwindowrefreshfun)(GLFWwindow *window);
+typedef void (* GLFWwindowrefreshfun)(GLFWwindow* window);
 
 /*! @brief The function pointer type for window focus callbacks.
  *
@@ -1698,7 +1702,7 @@ typedef void (*GLFWwindowrefreshfun)(GLFWwindow *window);
  *
  *  @ingroup window
  */
-typedef void (*GLFWwindowfocusfun)(GLFWwindow *window, int focused);
+typedef void (* GLFWwindowfocusfun)(GLFWwindow* window, int focused);
 
 /*! @brief The function pointer type for window iconify callbacks.
  *
@@ -1719,7 +1723,7 @@ typedef void (*GLFWwindowfocusfun)(GLFWwindow *window, int focused);
  *
  *  @ingroup window
  */
-typedef void (*GLFWwindowiconifyfun)(GLFWwindow *window, int iconified);
+typedef void (* GLFWwindowiconifyfun)(GLFWwindow* window, int iconified);
 
 /*! @brief The function pointer type for window maximize callbacks.
  *
@@ -1740,7 +1744,7 @@ typedef void (*GLFWwindowiconifyfun)(GLFWwindow *window, int iconified);
  *
  *  @ingroup window
  */
-typedef void (*GLFWwindowmaximizefun)(GLFWwindow *window, int maximized);
+typedef void (* GLFWwindowmaximizefun)(GLFWwindow* window, int maximized);
 
 /*! @brief The function pointer type for framebuffer size callbacks.
  *
@@ -1761,8 +1765,7 @@ typedef void (*GLFWwindowmaximizefun)(GLFWwindow *window, int maximized);
  *
  *  @ingroup window
  */
-typedef void (*GLFWframebuffersizefun)(GLFWwindow *window, int width,
-                                       int height);
+typedef void (* GLFWframebuffersizefun)(GLFWwindow* window, int width, int height);
 
 /*! @brief The function pointer type for window content scale callbacks.
  *
@@ -1783,8 +1786,7 @@ typedef void (*GLFWframebuffersizefun)(GLFWwindow *window, int width,
  *
  *  @ingroup window
  */
-typedef void (*GLFWwindowcontentscalefun)(GLFWwindow *window, float xscale,
-                                          float yscale);
+typedef void (* GLFWwindowcontentscalefun)(GLFWwindow* window, float xscale, float yscale);
 
 /*! @brief The function pointer type for mouse button callbacks.
  *
@@ -1810,8 +1812,7 @@ typedef void (*GLFWwindowcontentscalefun)(GLFWwindow *window, float xscale,
  *
  *  @ingroup input
  */
-typedef void (*GLFWmousebuttonfun)(GLFWwindow *window, int button, int action,
-                                   int mods);
+typedef void (* GLFWmousebuttonfun)(GLFWwindow* window, int button, int action, int mods);
 
 /*! @brief The function pointer type for cursor position callbacks.
  *
@@ -1834,7 +1835,7 @@ typedef void (*GLFWmousebuttonfun)(GLFWwindow *window, int button, int action,
  *
  *  @ingroup input
  */
-typedef void (*GLFWcursorposfun)(GLFWwindow *window, double xpos, double ypos);
+typedef void (* GLFWcursorposfun)(GLFWwindow* window, double xpos, double ypos);
 
 /*! @brief The function pointer type for cursor enter/leave callbacks.
  *
@@ -1855,7 +1856,7 @@ typedef void (*GLFWcursorposfun)(GLFWwindow *window, double xpos, double ypos);
  *
  *  @ingroup input
  */
-typedef void (*GLFWcursorenterfun)(GLFWwindow *window, int entered);
+typedef void (* GLFWcursorenterfun)(GLFWwindow* window, int entered);
 
 /*! @brief The function pointer type for scroll callbacks.
  *
@@ -1876,16 +1877,14 @@ typedef void (*GLFWcursorenterfun)(GLFWwindow *window, int entered);
  *
  *  @ingroup input
  */
-typedef void (*GLFWscrollfun)(GLFWwindow *window, double xoffset,
-                              double yoffset);
+typedef void (* GLFWscrollfun)(GLFWwindow* window, double xoffset, double yoffset);
 
 /*! @brief The function pointer type for keyboard key callbacks.
  *
  *  This is the function pointer type for keyboard key callbacks.  A keyboard
  *  key callback function has the following signature:
  *  @code
- *  void function_name(GLFWwindow* window, int key, int scancode, int action,
- * int mods)
+ *  void function_name(GLFWwindow* window, int key, int scancode, int action, int mods)
  *  @endcode
  *
  *  @param[in] window The window that received the event.
@@ -1904,8 +1903,7 @@ typedef void (*GLFWscrollfun)(GLFWwindow *window, double xoffset,
  *
  *  @ingroup input
  */
-typedef void (*GLFWkeyfun)(GLFWwindow *window, int key, int scancode,
-                           int action, int mods);
+typedef void (* GLFWkeyfun)(GLFWwindow* window, int key, int scancode, int action, int mods);
 
 /*! @brief The function pointer type for Unicode character callbacks.
  *
@@ -1926,7 +1924,7 @@ typedef void (*GLFWkeyfun)(GLFWwindow *window, int key, int scancode,
  *
  *  @ingroup input
  */
-typedef void (*GLFWcharfun)(GLFWwindow *window, unsigned int codepoint);
+typedef void (* GLFWcharfun)(GLFWwindow* window, unsigned int codepoint);
 
 /*! @brief The function pointer type for Unicode character with modifiers
  *  callbacks.
@@ -1953,8 +1951,7 @@ typedef void (*GLFWcharfun)(GLFWwindow *window, unsigned int codepoint);
  *
  *  @ingroup input
  */
-typedef void (*GLFWcharmodsfun)(GLFWwindow *window, unsigned int codepoint,
-                                int mods);
+typedef void (* GLFWcharmodsfun)(GLFWwindow* window, unsigned int codepoint, int mods);
 
 /*! @brief The function pointer type for path drop callbacks.
  *
@@ -1978,8 +1975,7 @@ typedef void (*GLFWcharmodsfun)(GLFWwindow *window, unsigned int codepoint,
  *
  *  @ingroup input
  */
-typedef void (*GLFWdropfun)(GLFWwindow *window, int path_count,
-                            const char *paths[]);
+typedef void (* GLFWdropfun)(GLFWwindow* window, int path_count, const char* paths[]);
 
 /*! @brief The function pointer type for monitor configuration callbacks.
  *
@@ -2000,7 +1996,7 @@ typedef void (*GLFWdropfun)(GLFWwindow *window, int path_count,
  *
  *  @ingroup monitor
  */
-typedef void (*GLFWmonitorfun)(GLFWmonitor *monitor, int event);
+typedef void (* GLFWmonitorfun)(GLFWmonitor* monitor, int event);
 
 /*! @brief The function pointer type for joystick configuration callbacks.
  *
@@ -2021,7 +2017,7 @@ typedef void (*GLFWmonitorfun)(GLFWmonitor *monitor, int event);
  *
  *  @ingroup input
  */
-typedef void (*GLFWjoystickfun)(int jid, int event);
+typedef void (* GLFWjoystickfun)(int jid, int event);
 
 /*! @brief Video mode type.
  *
@@ -2036,25 +2032,26 @@ typedef void (*GLFWjoystickfun)(int jid, int event);
  *
  *  @ingroup monitor
  */
-typedef struct GLFWvidmode {
-  /*! The width, in screen coordinates, of the video mode.
-   */
-  int width;
-  /*! The height, in screen coordinates, of the video mode.
-   */
-  int height;
-  /*! The bit depth of the red channel of the video mode.
-   */
-  int redBits;
-  /*! The bit depth of the green channel of the video mode.
-   */
-  int greenBits;
-  /*! The bit depth of the blue channel of the video mode.
-   */
-  int blueBits;
-  /*! The refresh rate, in Hz, of the video mode.
-   */
-  int refreshRate;
+typedef struct GLFWvidmode
+{
+    /*! The width, in screen coordinates, of the video mode.
+     */
+    int width;
+    /*! The height, in screen coordinates, of the video mode.
+     */
+    int height;
+    /*! The bit depth of the red channel of the video mode.
+     */
+    int redBits;
+    /*! The bit depth of the green channel of the video mode.
+     */
+    int greenBits;
+    /*! The bit depth of the blue channel of the video mode.
+     */
+    int blueBits;
+    /*! The refresh rate, in Hz, of the video mode.
+     */
+    int refreshRate;
 } GLFWvidmode;
 
 /*! @brief Gamma ramp.
@@ -2069,19 +2066,20 @@ typedef struct GLFWvidmode {
  *
  *  @ingroup monitor
  */
-typedef struct GLFWgammaramp {
-  /*! An array of value describing the response of the red channel.
-   */
-  unsigned short *red;
-  /*! An array of value describing the response of the green channel.
-   */
-  unsigned short *green;
-  /*! An array of value describing the response of the blue channel.
-   */
-  unsigned short *blue;
-  /*! The number of elements in each array.
-   */
-  unsigned int size;
+typedef struct GLFWgammaramp
+{
+    /*! An array of value describing the response of the red channel.
+     */
+    unsigned short* red;
+    /*! An array of value describing the response of the green channel.
+     */
+    unsigned short* green;
+    /*! An array of value describing the response of the blue channel.
+     */
+    unsigned short* blue;
+    /*! The number of elements in each array.
+     */
+    unsigned int size;
 } GLFWgammaramp;
 
 /*! @brief Image data.
@@ -2097,16 +2095,17 @@ typedef struct GLFWgammaramp {
  *
  *  @ingroup window
  */
-typedef struct GLFWimage {
-  /*! The width, in pixels, of this image.
-   */
-  int width;
-  /*! The height, in pixels, of this image.
-   */
-  int height;
-  /*! The pixel data of this image, arranged left-to-right, top-to-bottom.
-   */
-  unsigned char *pixels;
+typedef struct GLFWimage
+{
+    /*! The width, in pixels, of this image.
+     */
+    int width;
+    /*! The height, in pixels, of this image.
+     */
+    int height;
+    /*! The pixel data of this image, arranged left-to-right, top-to-bottom.
+     */
+    unsigned char* pixels;
 } GLFWimage;
 
 /*! @brief Gamepad input state
@@ -2120,21 +2119,22 @@ typedef struct GLFWimage {
  *
  *  @ingroup input
  */
-typedef struct GLFWgamepadstate {
-  /*! The states of each [gamepad button](@ref gamepad_buttons), `GLFW_PRESS`
-   *  or `GLFW_RELEASE`.
-   */
-  unsigned char buttons[15];
-  /*! The states of each [gamepad axis](@ref gamepad_axes), in the range -1.0
-   *  to 1.0 inclusive.
-   */
-  float axes[6];
+typedef struct GLFWgamepadstate
+{
+    /*! The states of each [gamepad button](@ref gamepad_buttons), `GLFW_PRESS`
+     *  or `GLFW_RELEASE`.
+     */
+    unsigned char buttons[15];
+    /*! The states of each [gamepad axis](@ref gamepad_axes), in the range -1.0
+     *  to 1.0 inclusive.
+     */
+    float axes[6];
 } GLFWgamepadstate;
 
 /*! @brief Custom heap memory allocator.
  *
- *  This describes a custom heap memory allocator for GLFW.  To set an
- * allocator, pass it to @ref glfwInitAllocator before initializing the library.
+ *  This describes a custom heap memory allocator for GLFW.  To set an allocator, pass it
+ *  to @ref glfwInitAllocator before initializing the library.
  *
  *  @sa @ref init_allocator
  *  @sa @ref glfwInitAllocator
@@ -2143,24 +2143,26 @@ typedef struct GLFWgamepadstate {
  *
  *  @ingroup init
  */
-typedef struct GLFWallocator {
-  /*! The memory allocation function.  See @ref GLFWallocatefun for details
-   * about allocation function.
-   */
-  GLFWallocatefun allocate;
-  /*! The memory reallocation function.  See @ref GLFWreallocatefun for details
-   * about reallocation function.
-   */
-  GLFWreallocatefun reallocate;
-  /*! The memory deallocation function.  See @ref GLFWdeallocatefun for details
-   * about deallocation function.
-   */
-  GLFWdeallocatefun deallocate;
-  /*! The user pointer for this custom allocator.  This value will be passed to
-   * the allocator functions.
-   */
-  void *user;
+typedef struct GLFWallocator
+{
+    /*! The memory allocation function.  See @ref GLFWallocatefun for details about
+     *  allocation function.
+     */
+    GLFWallocatefun allocate;
+    /*! The memory reallocation function.  See @ref GLFWreallocatefun for details about
+     *  reallocation function.
+     */
+    GLFWreallocatefun reallocate;
+    /*! The memory deallocation function.  See @ref GLFWdeallocatefun for details about
+     *  deallocation function.
+     */
+    GLFWdeallocatefun deallocate;
+    /*! The user pointer for this custom allocator.  This value will be passed to the
+     *  allocator functions.
+     */
+    void* user;
 } GLFWallocator;
+
 
 /*************************************************************************
  * GLFW API functions
@@ -2179,9 +2181,9 @@ typedef struct GLFWallocator {
  *  Additional calls to this function after successful initialization but before
  *  termination will return `GLFW_TRUE` immediately.
  *
- *  The @ref GLFW_PLATFORM init hint controls which platforms are considered
- * during initialization.  This also depends on which platforms the library was
- * compiled to support.
+ *  The @ref GLFW_PLATFORM init hint controls which platforms are considered during
+ *  initialization.  This also depends on which platforms the library was compiled to
+ *  support.
  *
  *  @return `GLFW_TRUE` if successful, or `GLFW_FALSE` if an
  *  [error](@ref error_handling) occurred.
@@ -2194,8 +2196,8 @@ typedef struct GLFWallocator {
  *  bundle, if present.  This can be disabled with the @ref
  *  GLFW_COCOA_CHDIR_RESOURCES init hint.
  *
- *  @remark __macOS:__ This function will create the main menu and dock icon for
- * the application.  If GLFW finds a `MainMenu.nib` it is loaded and assumed to
+ *  @remark __macOS:__ This function will create the main menu and dock icon for the
+ *  application.  If GLFW finds a `MainMenu.nib` it is loaded and assumed to
  *  contain a menu bar.  Otherwise a minimal menu bar is created manually with
  *  common commands like Hide, Quit and About.  The About entry opens a minimal
  *  about dialog with information from the application's bundle.  The menu bar
@@ -2300,8 +2302,8 @@ GLFWAPI void glfwInitHint(int hint, int value);
  *  pointer.  If any member is `NULL`, this function will emit @ref
  *  GLFW_INVALID_VALUE and the init allocator will be unchanged.
  *
- *  The functions in the allocator must fulfil a number of requirements.  See
- * the documentation for @ref GLFWallocatefun, @ref GLFWreallocatefun and @ref
+ *  The functions in the allocator must fulfil a number of requirements.  See the
+ *  documentation for @ref GLFWallocatefun, @ref GLFWreallocatefun and @ref
  *  GLFWdeallocatefun for details.
  *
  *  @param[in] allocator The allocator to use at the next initialization, or
@@ -2321,38 +2323,35 @@ GLFWAPI void glfwInitHint(int hint, int value);
  *
  *  @ingroup init
  */
-GLFWAPI void glfwInitAllocator(const GLFWallocator *allocator);
+GLFWAPI void glfwInitAllocator(const GLFWallocator* allocator);
 
 #if defined(VK_VERSION_1_0)
 
 /*! @brief Sets the desired Vulkan `vkGetInstanceProcAddr` function.
  *
- *  This function sets the `vkGetInstanceProcAddr` function that GLFW will use
- * for all Vulkan related entry point queries.
+ *  This function sets the `vkGetInstanceProcAddr` function that GLFW will use for all
+ *  Vulkan related entry point queries.
  *
- *  This feature is mostly useful on macOS, if your copy of the Vulkan loader is
- * in a location where GLFW cannot find it through dynamic loading, or if you
- * are still using the static library version of the loader.
+ *  This feature is mostly useful on macOS, if your copy of the Vulkan loader is in
+ *  a location where GLFW cannot find it through dynamic loading, or if you are still
+ *  using the static library version of the loader.
  *
- *  If set to `NULL`, GLFW will try to load the Vulkan loader dynamically by its
- * standard name and get this function from there.  This is the default
- * behavior.
+ *  If set to `NULL`, GLFW will try to load the Vulkan loader dynamically by its standard
+ *  name and get this function from there.  This is the default behavior.
  *
- *  The standard name of the loader is `vulkan-1.dll` on Windows,
- * `libvulkan.so.1` on Linux and other Unix-like systems and `libvulkan.1.dylib`
- * on macOS.  If your code is also loading it via these names then you probably
- * don't need to use this function.
+ *  The standard name of the loader is `vulkan-1.dll` on Windows, `libvulkan.so.1` on
+ *  Linux and other Unix-like systems and `libvulkan.1.dylib` on macOS.  If your code is
+ *  also loading it via these names then you probably don't need to use this function.
  *
- *  The function address you set is never reset by GLFW, but it only takes
- * effect during initialization.  Once GLFW has been initialized, any updates
- * will be ignored until the library is terminated and initialized again.
+ *  The function address you set is never reset by GLFW, but it only takes effect during
+ *  initialization.  Once GLFW has been initialized, any updates will be ignored until the
+ *  library is terminated and initialized again.
  *
  *  @param[in] loader The address of the function to use, or `NULL`.
  *
  *  @par Loader function signature
  *  @code
- *  PFN_vkVoidFunction vkGetInstanceProcAddr(VkInstance instance, const char*
- * name)
+ *  PFN_vkVoidFunction vkGetInstanceProcAddr(VkInstance instance, const char* name)
  *  @endcode
  *  For more information about this function, see the
  *  [Vulkan Registry](https://www.khronos.org/registry/vulkan/).
@@ -2399,22 +2398,22 @@ GLFWAPI void glfwInitVulkanLoader(PFN_vkGetInstanceProcAddr loader);
  *
  *  @ingroup init
  */
-GLFWAPI void glfwGetVersion(int *major, int *minor, int *rev);
+GLFWAPI void glfwGetVersion(int* major, int* minor, int* rev);
 
 /*! @brief Returns a string describing the compile-time configuration.
  *
  *  This function returns the compile-time generated
- *  [version string](@ref intro_version_string) of the GLFW library binary.  It
- * describes the version, platforms, compiler and any platform or operating
- * system specific compile-time options.  It should not be confused with the
- * OpenGL or OpenGL ES version string, queried with `glGetString`.
+ *  [version string](@ref intro_version_string) of the GLFW library binary.  It describes
+ *  the version, platforms, compiler and any platform or operating system specific
+ *  compile-time options.  It should not be confused with the OpenGL or OpenGL ES version
+ *  string, queried with `glGetString`.
  *
  *  __Do not use the version string__ to parse the GLFW library version.  The
  *  @ref glfwGetVersion function provides the version of the running library
  *  binary in numerical format.
  *
- *  __Do not use the version string__ to parse what platforms are supported. The
- * @ref glfwPlatformSupported function lets you query platform support.
+ *  __Do not use the version string__ to parse what platforms are supported.  The @ref
+ *  glfwPlatformSupported function lets you query platform support.
  *
  *  @return The ASCII encoded GLFW version string.
  *
@@ -2433,7 +2432,7 @@ GLFWAPI void glfwGetVersion(int *major, int *minor, int *rev);
  *
  *  @ingroup init
  */
-GLFWAPI const char *glfwGetVersionString(void);
+GLFWAPI const char* glfwGetVersionString(void);
 
 /*! @brief Returns and clears the last error for the calling thread.
  *
@@ -2443,8 +2442,7 @@ GLFWAPI const char *glfwGetVersionString(void);
  *  call, it returns @ref GLFW_NO_ERROR (zero) and the description pointer is
  *  set to `NULL`.
  *
- *  @param[in] description Where to store the error description pointer, or
- * `NULL`.
+ *  @param[in] description Where to store the error description pointer, or `NULL`.
  *  @return The last error code for the calling thread, or @ref GLFW_NO_ERROR
  *  (zero).
  *
@@ -2465,7 +2463,7 @@ GLFWAPI const char *glfwGetVersionString(void);
  *
  *  @ingroup init
  */
-GLFWAPI int glfwGetError(const char **description);
+GLFWAPI int glfwGetError(const char** description);
 
 /*! @brief Sets the error callback.
  *
@@ -2515,10 +2513,9 @@ GLFWAPI GLFWerrorfun glfwSetErrorCallback(GLFWerrorfun callback);
 
 /*! @brief Returns the currently selected platform.
  *
- *  This function returns the platform that was selected during initialization.
- * The returned value will be one of `GLFW_PLATFORM_WIN32`,
- * `GLFW_PLATFORM_COCOA`, `GLFW_PLATFORM_WAYLAND`, `GLFW_PLATFORM_X11` or
- * `GLFW_PLATFORM_NULL`.
+ *  This function returns the platform that was selected during initialization.  The
+ *  returned value will be one of `GLFW_PLATFORM_WIN32`, `GLFW_PLATFORM_COCOA`,
+ *  `GLFW_PLATFORM_WAYLAND`, `GLFW_PLATFORM_X11` or `GLFW_PLATFORM_NULL`.
  *
  *  @return The currently selected platform, or zero if an error occurred.
  *
@@ -2535,13 +2532,11 @@ GLFWAPI GLFWerrorfun glfwSetErrorCallback(GLFWerrorfun callback);
  */
 GLFWAPI int glfwGetPlatform(void);
 
-/*! @brief Returns whether the library includes support for the specified
- * platform.
+/*! @brief Returns whether the library includes support for the specified platform.
  *
- *  This function returns whether the library was compiled with support for the
- * specified platform.  The platform must be one of `GLFW_PLATFORM_WIN32`,
- * `GLFW_PLATFORM_COCOA`, `GLFW_PLATFORM_WAYLAND`, `GLFW_PLATFORM_X11` or
- * `GLFW_PLATFORM_NULL`.
+ *  This function returns whether the library was compiled with support for the specified
+ *  platform.  The platform must be one of `GLFW_PLATFORM_WIN32`, `GLFW_PLATFORM_COCOA`,
+ *  `GLFW_PLATFORM_WAYLAND`, `GLFW_PLATFORM_X11` or `GLFW_PLATFORM_NULL`.
  *
  *  @param[in] platform The platform to query.
  *  @return `GLFW_TRUE` if the platform is supported, or `GLFW_FALSE` otherwise.
@@ -2588,7 +2583,7 @@ GLFWAPI int glfwPlatformSupported(int platform);
  *
  *  @ingroup monitor
  */
-GLFWAPI GLFWmonitor **glfwGetMonitors(int *count);
+GLFWAPI GLFWmonitor** glfwGetMonitors(int* count);
 
 /*! @brief Returns the primary monitor.
  *
@@ -2612,7 +2607,7 @@ GLFWAPI GLFWmonitor **glfwGetMonitors(int *count);
  *
  *  @ingroup monitor
  */
-GLFWAPI GLFWmonitor *glfwGetPrimaryMonitor(void);
+GLFWAPI GLFWmonitor* glfwGetPrimaryMonitor(void);
 
 /*! @brief Returns the position of the monitor's viewport on the virtual screen.
  *
@@ -2637,7 +2632,7 @@ GLFWAPI GLFWmonitor *glfwGetPrimaryMonitor(void);
  *
  *  @ingroup monitor
  */
-GLFWAPI void glfwGetMonitorPos(GLFWmonitor *monitor, int *xpos, int *ypos);
+GLFWAPI void glfwGetMonitorPos(GLFWmonitor* monitor, int* xpos, int* ypos);
 
 /*! @brief Retrieves the work area of the monitor.
  *
@@ -2668,8 +2663,7 @@ GLFWAPI void glfwGetMonitorPos(GLFWmonitor *monitor, int *xpos, int *ypos);
  *
  *  @ingroup monitor
  */
-GLFWAPI void glfwGetMonitorWorkarea(GLFWmonitor *monitor, int *xpos, int *ypos,
-                                    int *width, int *height);
+GLFWAPI void glfwGetMonitorWorkarea(GLFWmonitor* monitor, int* xpos, int* ypos, int* width, int* height);
 
 /*! @brief Returns the physical size of the monitor.
  *
@@ -2693,9 +2687,8 @@ GLFWAPI void glfwGetMonitorWorkarea(GLFWmonitor *monitor, int *xpos, int *ypos,
  *
  *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
  *
- *  @remark __Win32:__ On Windows 8 and earlier the physical size is calculated
- * from the current resolution and system DPI instead of querying the monitor
- * EDID data.
+ *  @remark __Win32:__ On Windows 8 and earlier the physical size is calculated from
+ *  the current resolution and system DPI instead of querying the monitor EDID data.
  *
  *  @thread_safety This function must only be called from the main thread.
  *
@@ -2705,8 +2698,7 @@ GLFWAPI void glfwGetMonitorWorkarea(GLFWmonitor *monitor, int *xpos, int *ypos,
  *
  *  @ingroup monitor
  */
-GLFWAPI void glfwGetMonitorPhysicalSize(GLFWmonitor *monitor, int *widthMM,
-                                        int *heightMM);
+GLFWAPI void glfwGetMonitorPhysicalSize(GLFWmonitor* monitor, int* widthMM, int* heightMM);
 
 /*! @brief Retrieves the content scale for the specified monitor.
  *
@@ -2741,8 +2733,7 @@ GLFWAPI void glfwGetMonitorPhysicalSize(GLFWmonitor *monitor, int *widthMM,
  *
  *  @ingroup monitor
  */
-GLFWAPI void glfwGetMonitorContentScale(GLFWmonitor *monitor, float *xscale,
-                                        float *yscale);
+GLFWAPI void glfwGetMonitorContentScale(GLFWmonitor* monitor, float* xscale, float* yscale);
 
 /*! @brief Returns the name of the specified monitor.
  *
@@ -2768,7 +2759,7 @@ GLFWAPI void glfwGetMonitorContentScale(GLFWmonitor *monitor, float *xscale,
  *
  *  @ingroup monitor
  */
-GLFWAPI const char *glfwGetMonitorName(GLFWmonitor *monitor);
+GLFWAPI const char* glfwGetMonitorName(GLFWmonitor* monitor);
 
 /*! @brief Sets the user pointer of the specified monitor.
  *
@@ -2794,7 +2785,7 @@ GLFWAPI const char *glfwGetMonitorName(GLFWmonitor *monitor);
  *
  *  @ingroup monitor
  */
-GLFWAPI void glfwSetMonitorUserPointer(GLFWmonitor *monitor, void *pointer);
+GLFWAPI void glfwSetMonitorUserPointer(GLFWmonitor* monitor, void* pointer);
 
 /*! @brief Returns the user pointer of the specified monitor.
  *
@@ -2818,7 +2809,7 @@ GLFWAPI void glfwSetMonitorUserPointer(GLFWmonitor *monitor, void *pointer);
  *
  *  @ingroup monitor
  */
-GLFWAPI void *glfwGetMonitorUserPointer(GLFWmonitor *monitor);
+GLFWAPI void* glfwGetMonitorUserPointer(GLFWmonitor* monitor);
 
 /*! @brief Sets the monitor configuration callback.
  *
@@ -2882,7 +2873,7 @@ GLFWAPI GLFWmonitorfun glfwSetMonitorCallback(GLFWmonitorfun callback);
  *
  *  @ingroup monitor
  */
-GLFWAPI const GLFWvidmode *glfwGetVideoModes(GLFWmonitor *monitor, int *count);
+GLFWAPI const GLFWvidmode* glfwGetVideoModes(GLFWmonitor* monitor, int* count);
 
 /*! @brief Returns the current mode of the specified monitor.
  *
@@ -2910,7 +2901,7 @@ GLFWAPI const GLFWvidmode *glfwGetVideoModes(GLFWmonitor *monitor, int *count);
  *
  *  @ingroup monitor
  */
-GLFWAPI const GLFWvidmode *glfwGetVideoMode(GLFWmonitor *monitor);
+GLFWAPI const GLFWvidmode* glfwGetVideoMode(GLFWmonitor* monitor);
 
 /*! @brief Generates a gamma ramp and sets it for the specified monitor.
  *
@@ -2929,12 +2920,11 @@ GLFWAPI const GLFWvidmode *glfwGetVideoMode(GLFWmonitor *monitor);
  *  @param[in] monitor The monitor whose gamma ramp to set.
  *  @param[in] gamma The desired exponent.
  *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- * GLFW_INVALID_VALUE,
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref GLFW_INVALID_VALUE,
  *  @ref GLFW_PLATFORM_ERROR and @ref GLFW_FEATURE_UNAVAILABLE (see remarks).
  *
- *  @remark __Wayland:__ Monitor gamma is a privileged protocol, so this
- * function cannot be implemented and emits @ref GLFW_FEATURE_UNAVAILABLE.
+ *  @remark __Wayland:__ Monitor gamma is a privileged protocol, so this function
+ *  cannot be implemented and emits @ref GLFW_FEATURE_UNAVAILABLE.
  *
  *  @thread_safety This function must only be called from the main thread.
  *
@@ -2944,7 +2934,7 @@ GLFWAPI const GLFWvidmode *glfwGetVideoMode(GLFWmonitor *monitor);
  *
  *  @ingroup monitor
  */
-GLFWAPI void glfwSetGamma(GLFWmonitor *monitor, float gamma);
+GLFWAPI void glfwSetGamma(GLFWmonitor* monitor, float gamma);
 
 /*! @brief Returns the current gamma ramp for the specified monitor.
  *
@@ -2954,11 +2944,11 @@ GLFWAPI void glfwSetGamma(GLFWmonitor *monitor, float gamma);
  *  @return The current gamma ramp, or `NULL` if an
  *  [error](@ref error_handling) occurred.
  *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- * GLFW_PLATFORM_ERROR and @ref GLFW_FEATURE_UNAVAILABLE (see remarks).
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref GLFW_PLATFORM_ERROR
+ *  and @ref GLFW_FEATURE_UNAVAILABLE (see remarks).
  *
- *  @remark __Wayland:__ Monitor gamma is a privileged protocol, so this
- * function cannot be implemented and emits @ref GLFW_FEATURE_UNAVAILABLE while
+ *  @remark __Wayland:__ Monitor gamma is a privileged protocol, so this function
+ *  cannot be implemented and emits @ref GLFW_FEATURE_UNAVAILABLE while
  *  returning `NULL`.
  *
  *  @pointer_lifetime The returned structure and its arrays are allocated and
@@ -2974,7 +2964,7 @@ GLFWAPI void glfwSetGamma(GLFWmonitor *monitor, float gamma);
  *
  *  @ingroup monitor
  */
-GLFWAPI const GLFWgammaramp *glfwGetGammaRamp(GLFWmonitor *monitor);
+GLFWAPI const GLFWgammaramp* glfwGetGammaRamp(GLFWmonitor* monitor);
 
 /*! @brief Sets the current gamma ramp for the specified monitor.
  *
@@ -2993,16 +2983,16 @@ GLFWAPI const GLFWgammaramp *glfwGetGammaRamp(GLFWmonitor *monitor);
  *  @param[in] monitor The monitor whose gamma ramp to set.
  *  @param[in] ramp The gamma ramp to use.
  *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- * GLFW_PLATFORM_ERROR and @ref GLFW_FEATURE_UNAVAILABLE (see remarks).
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref GLFW_PLATFORM_ERROR
+ *  and @ref GLFW_FEATURE_UNAVAILABLE (see remarks).
  *
  *  @remark The size of the specified gamma ramp should match the size of the
  *  current ramp for that monitor.
  *
  *  @remark __Win32:__ The gamma ramp size must be 256.
  *
- *  @remark __Wayland:__ Monitor gamma is a privileged protocol, so this
- * function cannot be implemented and emits @ref GLFW_FEATURE_UNAVAILABLE.
+ *  @remark __Wayland:__ Monitor gamma is a privileged protocol, so this function
+ *  cannot be implemented and emits @ref GLFW_FEATURE_UNAVAILABLE.
  *
  *  @pointer_lifetime The specified gamma ramp is copied before this function
  *  returns.
@@ -3015,7 +3005,7 @@ GLFWAPI const GLFWgammaramp *glfwGetGammaRamp(GLFWmonitor *monitor);
  *
  *  @ingroup monitor
  */
-GLFWAPI void glfwSetGammaRamp(GLFWmonitor *monitor, const GLFWgammaramp *ramp);
+GLFWAPI void glfwSetGammaRamp(GLFWmonitor* monitor, const GLFWgammaramp* ramp);
 
 /*! @brief Resets all window hints to their default values.
  *
@@ -3107,7 +3097,7 @@ GLFWAPI void glfwWindowHint(int hint, int value);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwWindowHintString(int hint, const char *value);
+GLFWAPI void glfwWindowHintString(int hint, const char* value);
 
 /*! @brief Creates a window and its associated context.
  *
@@ -3180,13 +3170,13 @@ GLFWAPI void glfwWindowHintString(int hint, const char *value);
  *  @remark __Win32:__ Window creation will fail if the Microsoft GDI software
  *  OpenGL implementation is the only one available.
  *
- *  @remark __Win32:__ If the executable has an icon resource named `GLFW_ICON,`
- * it will be set as the initial icon for the window.  If no such icon is
- * present, the `IDI_APPLICATION` icon will be used instead.  To set a different
- * icon, see @ref glfwSetWindowIcon.
+ *  @remark __Win32:__ If the executable has an icon resource named `GLFW_ICON,` it
+ *  will be set as the initial icon for the window.  If no such icon is present,
+ *  the `IDI_APPLICATION` icon will be used instead.  To set a different icon,
+ *  see @ref glfwSetWindowIcon.
  *
- *  @remark __Win32:__ The context to share resources with must not be current
- * on any other thread.
+ *  @remark __Win32:__ The context to share resources with must not be current on
+ *  any other thread.
  *
  *  @remark __macOS:__ The OS only supports core profile contexts for OpenGL
  *  versions 3.2 and later.  Before creating an OpenGL context of version 3.2 or
@@ -3199,8 +3189,7 @@ GLFWAPI void glfwWindowHintString(int hint, const char *value);
  *  For more information on bundles, see the
  *  [Bundle Programming Guide][bundle-guide] in the Mac Developer Library.
  *
- *  [bundle-guide]:
- * https://developer.apple.com/library/mac/documentation/CoreFoundation/Conceptual/CFBundles/
+ *  [bundle-guide]: https://developer.apple.com/library/mac/documentation/CoreFoundation/Conceptual/CFBundles/
  *
  *  @remark __macOS:__  The window frame will not be rendered at full resolution
  *  on Retina displays unless the
@@ -3212,27 +3201,26 @@ GLFWAPI void glfwWindowHintString(int hint, const char *value);
  *  template for this, which can be found as `CMake/Info.plist.in` in the source
  *  tree.
  *
- *  [hidpi-guide]:
- * https://developer.apple.com/library/mac/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Explained/Explained.html
+ *  [hidpi-guide]: https://developer.apple.com/library/mac/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Explained/Explained.html
  *
  *  @remark __macOS:__ When activating frame autosaving with
  *  [GLFW_COCOA_FRAME_NAME](@ref GLFW_COCOA_FRAME_NAME_hint), the specified
  *  window size and position may be overridden by previously saved values.
  *
- *  @remark __Wayland:__ GLFW uses [libdecor][] where available to create its
- * window decorations.  This in turn uses server-side XDG decorations where
- * available and provides high quality client-side decorations on compositors
- * like GNOME. If both XDG decorations and libdecor are unavailable, GLFW falls
- * back to a very simple set of window decorations that only support moving,
- * resizing and the window manager's right-click menu.
+ *  @remark __Wayland:__ GLFW uses [libdecor][] where available to create its window
+ *  decorations.  This in turn uses server-side XDG decorations where available
+ *  and provides high quality client-side decorations on compositors like GNOME.
+ *  If both XDG decorations and libdecor are unavailable, GLFW falls back to
+ *  a very simple set of window decorations that only support moving, resizing
+ *  and the window manager's right-click menu.
  *
  *  [libdecor]: https://gitlab.freedesktop.org/libdecor/libdecor
  *
  *  @remark __X11:__ Some window managers will not respect the placement of
  *  initially hidden windows.
  *
- *  @remark __X11:__ Due to the asynchronous nature of X11, it may take a moment
- * for a window to reach its requested state.  This means you may not be able to
+ *  @remark __X11:__ Due to the asynchronous nature of X11, it may take a moment for
+ *  a window to reach its requested state.  This means you may not be able to
  *  query the final size, position or other attributes directly after window
  *  creation.
  *
@@ -3253,8 +3241,7 @@ GLFWAPI void glfwWindowHintString(int hint, const char *value);
  *
  *  @ingroup window
  */
-GLFWAPI GLFWwindow *glfwCreateWindow(int width, int height, const char *title,
-                                     GLFWmonitor *monitor, GLFWwindow *share);
+GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height, const char* title, GLFWmonitor* monitor, GLFWwindow* share);
 
 /*! @brief Destroys the specified window and its context.
  *
@@ -3283,7 +3270,7 @@ GLFWAPI GLFWwindow *glfwCreateWindow(int width, int height, const char *title,
  *
  *  @ingroup window
  */
-GLFWAPI void glfwDestroyWindow(GLFWwindow *window);
+GLFWAPI void glfwDestroyWindow(GLFWwindow* window);
 
 /*! @brief Checks the close flag of the specified window.
  *
@@ -3303,7 +3290,7 @@ GLFWAPI void glfwDestroyWindow(GLFWwindow *window);
  *
  *  @ingroup window
  */
-GLFWAPI int glfwWindowShouldClose(GLFWwindow *window);
+GLFWAPI int glfwWindowShouldClose(GLFWwindow* window);
 
 /*! @brief Sets the close flag of the specified window.
  *
@@ -3325,7 +3312,7 @@ GLFWAPI int glfwWindowShouldClose(GLFWwindow *window);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwSetWindowShouldClose(GLFWwindow *window, int value);
+GLFWAPI void glfwSetWindowShouldClose(GLFWwindow* window, int value);
 
 /*! @brief Returns the title of the specified window.
  *
@@ -3357,7 +3344,7 @@ GLFWAPI void glfwSetWindowShouldClose(GLFWwindow *window, int value);
  *
  *  @ingroup window
  */
-GLFWAPI const char *glfwGetWindowTitle(GLFWwindow *window);
+GLFWAPI const char* glfwGetWindowTitle(GLFWwindow* window);
 
 /*! @brief Sets the title of the specified window.
  *
@@ -3370,8 +3357,8 @@ GLFWAPI const char *glfwGetWindowTitle(GLFWwindow *window);
  *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
  *  GLFW_PLATFORM_ERROR.
  *
- *  @remark __macOS:__ The window title will not be updated until the next time
- * you process events.
+ *  @remark __macOS:__ The window title will not be updated until the next time you
+ *  process events.
  *
  *  @thread_safety This function must only be called from the main thread.
  *
@@ -3383,7 +3370,7 @@ GLFWAPI const char *glfwGetWindowTitle(GLFWwindow *window);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwSetWindowTitle(GLFWwindow *window, const char *title);
+GLFWAPI void glfwSetWindowTitle(GLFWwindow* window, const char* title);
 
 /*! @brief Sets the icon for the specified window.
  *
@@ -3413,13 +3400,12 @@ GLFWAPI void glfwSetWindowTitle(GLFWwindow *window, const char *title);
  *  @pointer_lifetime The specified image data is copied before this function
  *  returns.
  *
- *  @remark __macOS:__ Regular windows do not have icons on macOS.  This
- * function will emit @ref GLFW_FEATURE_UNAVAILABLE.  The dock icon will be the
- * same as the application bundle's icon.  For more information on bundles, see
- * the [Bundle Programming Guide][bundle-guide] in the Mac Developer Library.
+ *  @remark __macOS:__ Regular windows do not have icons on macOS.  This function
+ *  will emit @ref GLFW_FEATURE_UNAVAILABLE.  The dock icon will be the same as
+ *  the application bundle's icon.  For more information on bundles, see the
+ *  [Bundle Programming Guide][bundle-guide] in the Mac Developer Library.
  *
- *  [bundle-guide]:
- * https://developer.apple.com/library/mac/documentation/CoreFoundation/Conceptual/CFBundles/
+ *  [bundle-guide]: https://developer.apple.com/library/mac/documentation/CoreFoundation/Conceptual/CFBundles/
  *
  *  @remark __Wayland:__ There is no existing protocol to change an icon, the
  *  window will thus inherit the one defined in the application's desktop file.
@@ -3433,8 +3419,7 @@ GLFWAPI void glfwSetWindowTitle(GLFWwindow *window, const char *title);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwSetWindowIcon(GLFWwindow *window, int count,
-                               const GLFWimage *images);
+GLFWAPI void glfwSetWindowIcon(GLFWwindow* window, int count, const GLFWimage* images);
 
 /*! @brief Retrieves the position of the content area of the specified window.
  *
@@ -3466,7 +3451,7 @@ GLFWAPI void glfwSetWindowIcon(GLFWwindow *window, int count,
  *
  *  @ingroup window
  */
-GLFWAPI void glfwGetWindowPos(GLFWwindow *window, int *xpos, int *ypos);
+GLFWAPI void glfwGetWindowPos(GLFWwindow* window, int* xpos, int* ypos);
 
 /*! @brief Sets the position of the content area of the specified window.
  *
@@ -3481,10 +3466,8 @@ GLFWAPI void glfwGetWindowPos(GLFWwindow *window, int *xpos, int *ypos);
  *  cannot and should not override these limits.
  *
  *  @param[in] window The window to query.
- *  @param[in] xpos The x-coordinate of the upper-left corner of the content
- * area.
- *  @param[in] ypos The y-coordinate of the upper-left corner of the content
- * area.
+ *  @param[in] xpos The x-coordinate of the upper-left corner of the content area.
+ *  @param[in] ypos The y-coordinate of the upper-left corner of the content area.
  *
  *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
  *  GLFW_PLATFORM_ERROR and @ref GLFW_FEATURE_UNAVAILABLE (see remarks).
@@ -3503,7 +3486,7 @@ GLFWAPI void glfwGetWindowPos(GLFWwindow *window, int *xpos, int *ypos);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwSetWindowPos(GLFWwindow *window, int xpos, int ypos);
+GLFWAPI void glfwSetWindowPos(GLFWwindow* window, int xpos, int ypos);
 
 /*! @brief Retrieves the size of the content area of the specified window.
  *
@@ -3533,7 +3516,7 @@ GLFWAPI void glfwSetWindowPos(GLFWwindow *window, int xpos, int ypos);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwGetWindowSize(GLFWwindow *window, int *width, int *height);
+GLFWAPI void glfwGetWindowSize(GLFWwindow* window, int* width, int* height);
 
 /*! @brief Sets the size limits of the specified window.
  *
@@ -3576,9 +3559,7 @@ GLFWAPI void glfwGetWindowSize(GLFWwindow *window, int *width, int *height);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwSetWindowSizeLimits(GLFWwindow *window, int minwidth,
-                                     int minheight, int maxwidth,
-                                     int maxheight);
+GLFWAPI void glfwSetWindowSizeLimits(GLFWwindow* window, int minwidth, int minheight, int maxwidth, int maxheight);
 
 /*! @brief Sets the aspect ratio of the specified window.
  *
@@ -3609,8 +3590,8 @@ GLFWAPI void glfwSetWindowSizeLimits(GLFWwindow *window, int minwidth,
  *  @remark If you set size limits and an aspect ratio that conflict, the
  *  results are undefined.
  *
- *  @remark __Wayland:__ The aspect ratio will not be applied until the window
- * is actually resized, either by the user or by the compositor.
+ *  @remark __Wayland:__ The aspect ratio will not be applied until the window is
+ *  actually resized, either by the user or by the compositor.
  *
  *  @thread_safety This function must only be called from the main thread.
  *
@@ -3621,7 +3602,7 @@ GLFWAPI void glfwSetWindowSizeLimits(GLFWwindow *window, int minwidth,
  *
  *  @ingroup window
  */
-GLFWAPI void glfwSetWindowAspectRatio(GLFWwindow *window, int numer, int denom);
+GLFWAPI void glfwSetWindowAspectRatio(GLFWwindow* window, int numer, int denom);
 
 /*! @brief Sets the size of the content area of the specified window.
  *
@@ -3659,7 +3640,7 @@ GLFWAPI void glfwSetWindowAspectRatio(GLFWwindow *window, int numer, int denom);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwSetWindowSize(GLFWwindow *window, int width, int height);
+GLFWAPI void glfwSetWindowSize(GLFWwindow* window, int width, int height);
 
 /*! @brief Retrieves the size of the framebuffer of the specified window.
  *
@@ -3688,8 +3669,7 @@ GLFWAPI void glfwSetWindowSize(GLFWwindow *window, int width, int height);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwGetFramebufferSize(GLFWwindow *window, int *width,
-                                    int *height);
+GLFWAPI void glfwGetFramebufferSize(GLFWwindow* window, int* width, int* height);
 
 /*! @brief Retrieves the size of the frame of the window.
  *
@@ -3726,8 +3706,7 @@ GLFWAPI void glfwGetFramebufferSize(GLFWwindow *window, int *width,
  *
  *  @ingroup window
  */
-GLFWAPI void glfwGetWindowFrameSize(GLFWwindow *window, int *left, int *top,
-                                    int *right, int *bottom);
+GLFWAPI void glfwGetWindowFrameSize(GLFWwindow* window, int* left, int* top, int* right, int* bottom);
 
 /*! @brief Retrieves the content scale for the specified window.
  *
@@ -3760,8 +3739,7 @@ GLFWAPI void glfwGetWindowFrameSize(GLFWwindow *window, int *left, int *top,
  *
  *  @ingroup window
  */
-GLFWAPI void glfwGetWindowContentScale(GLFWwindow *window, float *xscale,
-                                       float *yscale);
+GLFWAPI void glfwGetWindowContentScale(GLFWwindow* window, float* xscale, float* yscale);
 
 /*! @brief Returns the opacity of the whole window.
  *
@@ -3769,8 +3747,7 @@ GLFWAPI void glfwGetWindowContentScale(GLFWwindow *window, float *xscale,
  *
  *  The opacity (or alpha) value is a positive finite number between zero and
  *  one, where zero is fully transparent and one is fully opaque.  If the system
- *  does not support whole window transparency, this function always returns
- * one.
+ *  does not support whole window transparency, this function always returns one.
  *
  *  The initial opacity value for newly created windows is one.
  *
@@ -3789,7 +3766,7 @@ GLFWAPI void glfwGetWindowContentScale(GLFWwindow *window, float *xscale,
  *
  *  @ingroup window
  */
-GLFWAPI float glfwGetWindowOpacity(GLFWwindow *window);
+GLFWAPI float glfwGetWindowOpacity(GLFWwindow* window);
 
 /*! @brief Sets the opacity of the whole window.
  *
@@ -3821,7 +3798,7 @@ GLFWAPI float glfwGetWindowOpacity(GLFWwindow *window);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwSetWindowOpacity(GLFWwindow *window, float opacity);
+GLFWAPI void glfwSetWindowOpacity(GLFWwindow* window, float opacity);
 
 /*! @brief Iconifies the specified window.
  *
@@ -3849,7 +3826,7 @@ GLFWAPI void glfwSetWindowOpacity(GLFWwindow *window, float opacity);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwIconifyWindow(GLFWwindow *window);
+GLFWAPI void glfwIconifyWindow(GLFWwindow* window);
 
 /*! @brief Restores the specified window.
  *
@@ -3880,7 +3857,7 @@ GLFWAPI void glfwIconifyWindow(GLFWwindow *window);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwRestoreWindow(GLFWwindow *window);
+GLFWAPI void glfwRestoreWindow(GLFWwindow* window);
 
 /*! @brief Maximizes the specified window.
  *
@@ -3905,7 +3882,7 @@ GLFWAPI void glfwRestoreWindow(GLFWwindow *window);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwMaximizeWindow(GLFWwindow *window);
+GLFWAPI void glfwMaximizeWindow(GLFWwindow* window);
 
 /*! @brief Makes the specified window visible.
  *
@@ -3937,7 +3914,7 @@ GLFWAPI void glfwMaximizeWindow(GLFWwindow *window);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwShowWindow(GLFWwindow *window);
+GLFWAPI void glfwShowWindow(GLFWwindow* window);
 
 /*! @brief Hides the specified window.
  *
@@ -3959,7 +3936,7 @@ GLFWAPI void glfwShowWindow(GLFWwindow *window);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwHideWindow(GLFWwindow *window);
+GLFWAPI void glfwHideWindow(GLFWwindow* window);
 
 /*! @brief Brings the specified window to front and sets input focus.
  *
@@ -3998,7 +3975,7 @@ GLFWAPI void glfwHideWindow(GLFWwindow *window);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwFocusWindow(GLFWwindow *window);
+GLFWAPI void glfwFocusWindow(GLFWwindow* window);
 
 /*! @brief Requests user attention to the specified window.
  *
@@ -4014,8 +3991,8 @@ GLFWAPI void glfwFocusWindow(GLFWwindow *window);
  *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
  *  GLFW_PLATFORM_ERROR.
  *
- *  @remark __macOS:__ Attention is requested to the application as a whole, not
- * the specific window.
+ *  @remark __macOS:__ Attention is requested to the application as a whole, not the
+ *  specific window.
  *
  *  @thread_safety This function must only be called from the main thread.
  *
@@ -4025,7 +4002,7 @@ GLFWAPI void glfwFocusWindow(GLFWwindow *window);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwRequestWindowAttention(GLFWwindow *window);
+GLFWAPI void glfwRequestWindowAttention(GLFWwindow* window);
 
 /*! @brief Returns the monitor that the window uses for full screen mode.
  *
@@ -4047,7 +4024,7 @@ GLFWAPI void glfwRequestWindowAttention(GLFWwindow *window);
  *
  *  @ingroup window
  */
-GLFWAPI GLFWmonitor *glfwGetWindowMonitor(GLFWwindow *window);
+GLFWAPI GLFWmonitor* glfwGetWindowMonitor(GLFWwindow* window);
 
 /*! @brief Sets the mode, monitor, video mode and placement of a window.
  *
@@ -4103,9 +4080,7 @@ GLFWAPI GLFWmonitor *glfwGetWindowMonitor(GLFWwindow *window);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwSetWindowMonitor(GLFWwindow *window, GLFWmonitor *monitor,
-                                  int xpos, int ypos, int width, int height,
-                                  int refreshRate);
+GLFWAPI void glfwSetWindowMonitor(GLFWwindow* window, GLFWmonitor* monitor, int xpos, int ypos, int width, int height, int refreshRate);
 
 /*! @brief Returns an attribute of the specified window.
  *
@@ -4143,7 +4118,7 @@ GLFWAPI void glfwSetWindowMonitor(GLFWwindow *window, GLFWmonitor *monitor,
  *
  *  @ingroup window
  */
-GLFWAPI int glfwGetWindowAttrib(GLFWwindow *window, int attrib);
+GLFWAPI int glfwGetWindowAttrib(GLFWwindow* window, int attrib);
 
 /*! @brief Sets an attribute of the specified window.
  *
@@ -4167,15 +4142,14 @@ GLFWAPI int glfwGetWindowAttrib(GLFWwindow *window, int attrib);
  *  @param[in] value `GLFW_TRUE` or `GLFW_FALSE`.
  *
  *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_INVALID_ENUM, @ref GLFW_INVALID_VALUE, @ref GLFW_PLATFORM_ERROR and
- * @ref GLFW_FEATURE_UNAVAILABLE (see remarks).
+ *  GLFW_INVALID_ENUM, @ref GLFW_INVALID_VALUE, @ref GLFW_PLATFORM_ERROR and @ref
+ *  GLFW_FEATURE_UNAVAILABLE (see remarks).
  *
  *  @remark Calling @ref glfwGetWindowAttrib will always return the latest
  *  value, even if that value is ignored by the current mode of the window.
  *
- *  @remark __Wayland:__ The [GLFW_FLOATING](@ref GLFW_FLOATING_attrib) window
- * attribute is not supported.  Setting this will emit @ref
- * GLFW_FEATURE_UNAVAILABLE.
+ *  @remark __Wayland:__ The [GLFW_FLOATING](@ref GLFW_FLOATING_attrib) window attribute is
+ *  not supported.  Setting this will emit @ref GLFW_FEATURE_UNAVAILABLE.
  *
  *  @thread_safety This function must only be called from the main thread.
  *
@@ -4186,7 +4160,7 @@ GLFWAPI int glfwGetWindowAttrib(GLFWwindow *window, int attrib);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwSetWindowAttrib(GLFWwindow *window, int attrib, int value);
+GLFWAPI void glfwSetWindowAttrib(GLFWwindow* window, int attrib, int value);
 
 /*! @brief Sets the user pointer of the specified window.
  *
@@ -4209,7 +4183,7 @@ GLFWAPI void glfwSetWindowAttrib(GLFWwindow *window, int attrib, int value);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwSetWindowUserPointer(GLFWwindow *window, void *pointer);
+GLFWAPI void glfwSetWindowUserPointer(GLFWwindow* window, void* pointer);
 
 /*! @brief Returns the user pointer of the specified window.
  *
@@ -4230,7 +4204,7 @@ GLFWAPI void glfwSetWindowUserPointer(GLFWwindow *window, void *pointer);
  *
  *  @ingroup window
  */
-GLFWAPI void *glfwGetWindowUserPointer(GLFWwindow *window);
+GLFWAPI void* glfwGetWindowUserPointer(GLFWwindow* window);
 
 /*! @brief Sets the position callback for the specified window.
  *
@@ -4265,8 +4239,7 @@ GLFWAPI void *glfwGetWindowUserPointer(GLFWwindow *window);
  *
  *  @ingroup window
  */
-GLFWAPI GLFWwindowposfun glfwSetWindowPosCallback(GLFWwindow *window,
-                                                  GLFWwindowposfun callback);
+GLFWAPI GLFWwindowposfun glfwSetWindowPosCallback(GLFWwindow* window, GLFWwindowposfun callback);
 
 /*! @brief Sets the size callback for the specified window.
  *
@@ -4298,8 +4271,7 @@ GLFWAPI GLFWwindowposfun glfwSetWindowPosCallback(GLFWwindow *window,
  *
  *  @ingroup window
  */
-GLFWAPI GLFWwindowsizefun glfwSetWindowSizeCallback(GLFWwindow *window,
-                                                    GLFWwindowsizefun callback);
+GLFWAPI GLFWwindowsizefun glfwSetWindowSizeCallback(GLFWwindow* window, GLFWwindowsizefun callback);
 
 /*! @brief Sets the close callback for the specified window.
  *
@@ -4339,8 +4311,7 @@ GLFWAPI GLFWwindowsizefun glfwSetWindowSizeCallback(GLFWwindow *window,
  *
  *  @ingroup window
  */
-GLFWAPI GLFWwindowclosefun
-glfwSetWindowCloseCallback(GLFWwindow *window, GLFWwindowclosefun callback);
+GLFWAPI GLFWwindowclosefun glfwSetWindowCloseCallback(GLFWwindow* window, GLFWwindowclosefun callback);
 
 /*! @brief Sets the refresh callback for the specified window.
  *
@@ -4376,8 +4347,7 @@ glfwSetWindowCloseCallback(GLFWwindow *window, GLFWwindowclosefun callback);
  *
  *  @ingroup window
  */
-GLFWAPI GLFWwindowrefreshfun
-glfwSetWindowRefreshCallback(GLFWwindow *window, GLFWwindowrefreshfun callback);
+GLFWAPI GLFWwindowrefreshfun glfwSetWindowRefreshCallback(GLFWwindow* window, GLFWwindowrefreshfun callback);
 
 /*! @brief Sets the focus callback for the specified window.
  *
@@ -4412,8 +4382,7 @@ glfwSetWindowRefreshCallback(GLFWwindow *window, GLFWwindowrefreshfun callback);
  *
  *  @ingroup window
  */
-GLFWAPI GLFWwindowfocusfun
-glfwSetWindowFocusCallback(GLFWwindow *window, GLFWwindowfocusfun callback);
+GLFWAPI GLFWwindowfocusfun glfwSetWindowFocusCallback(GLFWwindow* window, GLFWwindowfocusfun callback);
 
 /*! @brief Sets the iconify callback for the specified window.
  *
@@ -4447,8 +4416,7 @@ glfwSetWindowFocusCallback(GLFWwindow *window, GLFWwindowfocusfun callback);
  *
  *  @ingroup window
  */
-GLFWAPI GLFWwindowiconifyfun
-glfwSetWindowIconifyCallback(GLFWwindow *window, GLFWwindowiconifyfun callback);
+GLFWAPI GLFWwindowiconifyfun glfwSetWindowIconifyCallback(GLFWwindow* window, GLFWwindowiconifyfun callback);
 
 /*! @brief Sets the maximize callback for the specified window.
  *
@@ -4478,8 +4446,7 @@ glfwSetWindowIconifyCallback(GLFWwindow *window, GLFWwindowiconifyfun callback);
  *
  *  @ingroup window
  */
-GLFWAPI GLFWwindowmaximizefun glfwSetWindowMaximizeCallback(
-    GLFWwindow *window, GLFWwindowmaximizefun callback);
+GLFWAPI GLFWwindowmaximizefun glfwSetWindowMaximizeCallback(GLFWwindow* window, GLFWwindowmaximizefun callback);
 
 /*! @brief Sets the framebuffer resize callback for the specified window.
  *
@@ -4509,14 +4476,12 @@ GLFWAPI GLFWwindowmaximizefun glfwSetWindowMaximizeCallback(
  *
  *  @ingroup window
  */
-GLFWAPI GLFWframebuffersizefun glfwSetFramebufferSizeCallback(
-    GLFWwindow *window, GLFWframebuffersizefun callback);
+GLFWAPI GLFWframebuffersizefun glfwSetFramebufferSizeCallback(GLFWwindow* window, GLFWframebuffersizefun callback);
 
 /*! @brief Sets the window content scale callback for the specified window.
  *
- *  This function sets the window content scale callback of the specified
- * window, which is called when the content scale of the specified window
- * changes.
+ *  This function sets the window content scale callback of the specified window,
+ *  which is called when the content scale of the specified window changes.
  *
  *  @param[in] window The window whose callback to set.
  *  @param[in] callback The new callback, or `NULL` to remove the currently set
@@ -4542,8 +4507,7 @@ GLFWAPI GLFWframebuffersizefun glfwSetFramebufferSizeCallback(
  *
  *  @ingroup window
  */
-GLFWAPI GLFWwindowcontentscalefun glfwSetWindowContentScaleCallback(
-    GLFWwindow *window, GLFWwindowcontentscalefun callback);
+GLFWAPI GLFWwindowcontentscalefun glfwSetWindowContentScaleCallback(GLFWwindow* window, GLFWwindowcontentscalefun callback);
 
 /*! @brief Processes all pending events.
  *
@@ -4723,7 +4687,7 @@ GLFWAPI void glfwPostEmptyEvent(void);
  *
  *  @ingroup input
  */
-GLFWAPI int glfwGetInputMode(GLFWwindow *window, int mode);
+GLFWAPI int glfwGetInputMode(GLFWwindow* window, int mode);
 
 /*! @brief Sets an input option for the specified window.
  *
@@ -4793,7 +4757,7 @@ GLFWAPI int glfwGetInputMode(GLFWwindow *window, int mode);
  *
  *  @ingroup input
  */
-GLFWAPI void glfwSetInputMode(GLFWwindow *window, int mode, int value);
+GLFWAPI void glfwSetInputMode(GLFWwindow* window, int mode, int value);
 
 /*! @brief Returns whether raw mouse motion is supported.
  *
@@ -4890,7 +4854,7 @@ GLFWAPI int glfwRawMouseMotionSupported(void);
  *
  *  @ingroup input
  */
-GLFWAPI const char *glfwGetKeyName(int key, int scancode);
+GLFWAPI const char* glfwGetKeyName(int key, int scancode);
 
 /*! @brief Returns the platform-specific scancode of the specified key.
  *
@@ -4924,8 +4888,7 @@ GLFWAPI int glfwGetKeyScancode(int key);
  *
  *  This function returns the last state reported for the specified key to the
  *  specified window.  The returned state is one of `GLFW_PRESS` or
- *  `GLFW_RELEASE`.  The action `GLFW_REPEAT` is only reported to the key
- * callback.
+ *  `GLFW_RELEASE`.  The action `GLFW_REPEAT` is only reported to the key callback.
  *
  *  If the @ref GLFW_STICKY_KEYS input mode is enabled, this function returns
  *  `GLFW_PRESS` the first time you call it for a key that was pressed, even if
@@ -4957,7 +4920,7 @@ GLFWAPI int glfwGetKeyScancode(int key);
  *
  *  @ingroup input
  */
-GLFWAPI int glfwGetKey(GLFWwindow *window, int key);
+GLFWAPI int glfwGetKey(GLFWwindow* window, int key);
 
 /*! @brief Returns the last reported state of a mouse button for the specified
  *  window.
@@ -4989,7 +4952,7 @@ GLFWAPI int glfwGetKey(GLFWwindow *window, int key);
  *
  *  @ingroup input
  */
-GLFWAPI int glfwGetMouseButton(GLFWwindow *window, int button);
+GLFWAPI int glfwGetMouseButton(GLFWwindow* window, int button);
 
 /*! @brief Retrieves the position of the cursor relative to the content area of
  *  the window.
@@ -5027,7 +4990,7 @@ GLFWAPI int glfwGetMouseButton(GLFWwindow *window, int button);
  *
  *  @ingroup input
  */
-GLFWAPI void glfwGetCursorPos(GLFWwindow *window, double *xpos, double *ypos);
+GLFWAPI void glfwGetCursorPos(GLFWwindow* window, double* xpos, double* ypos);
 
 /*! @brief Sets the position of the cursor, relative to the content area of the
  *  window.
@@ -5056,8 +5019,7 @@ GLFWAPI void glfwGetCursorPos(GLFWwindow *window, double *xpos, double *ypos);
  *  GLFW_PLATFORM_ERROR and @ref GLFW_FEATURE_UNAVAILABLE (see remarks).
  *
  *  @remark __Wayland:__ This function will only work when the cursor mode is
- *  `GLFW_CURSOR_DISABLED`, otherwise it will emit @ref
- * GLFW_FEATURE_UNAVAILABLE.
+ *  `GLFW_CURSOR_DISABLED`, otherwise it will emit @ref GLFW_FEATURE_UNAVAILABLE.
  *
  *  @thread_safety This function must only be called from the main thread.
  *
@@ -5068,7 +5030,7 @@ GLFWAPI void glfwGetCursorPos(GLFWwindow *window, double *xpos, double *ypos);
  *
  *  @ingroup input
  */
-GLFWAPI void glfwSetCursorPos(GLFWwindow *window, double xpos, double ypos);
+GLFWAPI void glfwSetCursorPos(GLFWwindow* window, double xpos, double ypos);
 
 /*! @brief Creates a custom cursor.
  *
@@ -5106,8 +5068,7 @@ GLFWAPI void glfwSetCursorPos(GLFWwindow *window, double xpos, double ypos);
  *
  *  @ingroup input
  */
-GLFWAPI GLFWcursor *glfwCreateCursor(const GLFWimage *image, int xhot,
-                                     int yhot);
+GLFWAPI GLFWcursor* glfwCreateCursor(const GLFWimage* image, int xhot, int yhot);
 
 /*! @brief Creates a cursor with a standard shape.
  *
@@ -5126,13 +5087,10 @@ GLFWAPI GLFWcursor *glfwCreateCursor(const GLFWimage *image, int xhot,
  *  @ref GLFW_POINTING_HAND_CURSOR | Yes     | Yes   | Yes    | Yes
  *  @ref GLFW_RESIZE_EW_CURSOR     | Yes     | Yes   | Yes    | Yes
  *  @ref GLFW_RESIZE_NS_CURSOR     | Yes     | Yes   | Yes    | Yes
- *  @ref GLFW_RESIZE_NWSE_CURSOR   | Yes     | Yes<sup>1</sup> |
- * Maybe<sup>2</sup> | Maybe<sup>2</sup>
- *  @ref GLFW_RESIZE_NESW_CURSOR   | Yes     | Yes<sup>1</sup> |
- * Maybe<sup>2</sup> | Maybe<sup>2</sup>
+ *  @ref GLFW_RESIZE_NWSE_CURSOR   | Yes     | Yes<sup>1</sup> | Maybe<sup>2</sup> | Maybe<sup>2</sup>
+ *  @ref GLFW_RESIZE_NESW_CURSOR   | Yes     | Yes<sup>1</sup> | Maybe<sup>2</sup> | Maybe<sup>2</sup>
  *  @ref GLFW_RESIZE_ALL_CURSOR    | Yes     | Yes   | Yes    | Yes
- *  @ref GLFW_NOT_ALLOWED_CURSOR   | Yes     | Yes   | Maybe<sup>2</sup> |
- * Maybe<sup>2</sup>
+ *  @ref GLFW_NOT_ALLOWED_CURSOR   | Yes     | Yes   | Maybe<sup>2</sup> | Maybe<sup>2</sup>
  *
  *  1) This uses a private system API and may fail in the future.
  *
@@ -5158,7 +5116,7 @@ GLFWAPI GLFWcursor *glfwCreateCursor(const GLFWimage *image, int xhot,
  *
  *  @ingroup input
  */
-GLFWAPI GLFWcursor *glfwCreateStandardCursor(int shape);
+GLFWAPI GLFWcursor* glfwCreateStandardCursor(int shape);
 
 /*! @brief Destroys a cursor.
  *
@@ -5185,7 +5143,7 @@ GLFWAPI GLFWcursor *glfwCreateStandardCursor(int shape);
  *
  *  @ingroup input
  */
-GLFWAPI void glfwDestroyCursor(GLFWcursor *cursor);
+GLFWAPI void glfwDestroyCursor(GLFWcursor* cursor);
 
 /*! @brief Sets the cursor for the window.
  *
@@ -5212,7 +5170,7 @@ GLFWAPI void glfwDestroyCursor(GLFWcursor *cursor);
  *
  *  @ingroup input
  */
-GLFWAPI void glfwSetCursor(GLFWwindow *window, GLFWcursor *cursor);
+GLFWAPI void glfwSetCursor(GLFWwindow* window, GLFWcursor* cursor);
 
 /*! @brief Sets the key callback.
  *
@@ -5246,8 +5204,7 @@ GLFWAPI void glfwSetCursor(GLFWwindow *window, GLFWcursor *cursor);
  *
  *  @callback_signature
  *  @code
- *  void function_name(GLFWwindow* window, int key, int scancode, int action,
- * int mods)
+ *  void function_name(GLFWwindow* window, int key, int scancode, int action, int mods)
  *  @endcode
  *  For more information about the callback parameters, see the
  *  [function pointer type](@ref GLFWkeyfun).
@@ -5263,7 +5220,7 @@ GLFWAPI void glfwSetCursor(GLFWwindow *window, GLFWcursor *cursor);
  *
  *  @ingroup input
  */
-GLFWAPI GLFWkeyfun glfwSetKeyCallback(GLFWwindow *window, GLFWkeyfun callback);
+GLFWAPI GLFWkeyfun glfwSetKeyCallback(GLFWwindow* window, GLFWkeyfun callback);
 
 /*! @brief Sets the Unicode character callback.
  *
@@ -5279,8 +5236,8 @@ GLFWAPI GLFWkeyfun glfwSetKeyCallback(GLFWwindow *window, GLFWkeyfun callback);
  *
  *  The character callback behaves as system text input normally does and will
  *  not be called if modifier keys are held down that would prevent normal text
- *  input on that platform, for example a Super (Command) key on macOS or Alt
- * key on Windows.
+ *  input on that platform, for example a Super (Command) key on macOS or Alt key
+ *  on Windows.
  *
  *  @param[in] window The window whose callback to set.
  *  @param[in] callback The new callback, or `NULL` to remove the currently set
@@ -5306,8 +5263,7 @@ GLFWAPI GLFWkeyfun glfwSetKeyCallback(GLFWwindow *window, GLFWkeyfun callback);
  *
  *  @ingroup input
  */
-GLFWAPI GLFWcharfun glfwSetCharCallback(GLFWwindow *window,
-                                        GLFWcharfun callback);
+GLFWAPI GLFWcharfun glfwSetCharCallback(GLFWwindow* window, GLFWcharfun callback);
 
 /*! @brief Sets the Unicode character with modifiers callback.
  *
@@ -5349,8 +5305,7 @@ GLFWAPI GLFWcharfun glfwSetCharCallback(GLFWwindow *window,
  *
  *  @ingroup input
  */
-GLFWAPI GLFWcharmodsfun glfwSetCharModsCallback(GLFWwindow *window,
-                                                GLFWcharmodsfun callback);
+GLFWAPI GLFWcharmodsfun glfwSetCharModsCallback(GLFWwindow* window, GLFWcharmodsfun callback);
 
 /*! @brief Sets the mouse button callback.
  *
@@ -5392,8 +5347,7 @@ GLFWAPI GLFWcharmodsfun glfwSetCharModsCallback(GLFWwindow *window,
  *
  *  @ingroup input
  */
-GLFWAPI GLFWmousebuttonfun
-glfwSetMouseButtonCallback(GLFWwindow *window, GLFWmousebuttonfun callback);
+GLFWAPI GLFWmousebuttonfun glfwSetMouseButtonCallback(GLFWwindow* window, GLFWmousebuttonfun callback);
 
 /*! @brief Sets the cursor position callback.
  *
@@ -5425,8 +5379,7 @@ glfwSetMouseButtonCallback(GLFWwindow *window, GLFWmousebuttonfun callback);
  *
  *  @ingroup input
  */
-GLFWAPI GLFWcursorposfun glfwSetCursorPosCallback(GLFWwindow *window,
-                                                  GLFWcursorposfun callback);
+GLFWAPI GLFWcursorposfun glfwSetCursorPosCallback(GLFWwindow* window, GLFWcursorposfun callback);
 
 /*! @brief Sets the cursor enter/leave callback.
  *
@@ -5457,8 +5410,7 @@ GLFWAPI GLFWcursorposfun glfwSetCursorPosCallback(GLFWwindow *window,
  *
  *  @ingroup input
  */
-GLFWAPI GLFWcursorenterfun
-glfwSetCursorEnterCallback(GLFWwindow *window, GLFWcursorenterfun callback);
+GLFWAPI GLFWcursorenterfun glfwSetCursorEnterCallback(GLFWwindow* window, GLFWcursorenterfun callback);
 
 /*! @brief Sets the scroll callback.
  *
@@ -5492,8 +5444,7 @@ glfwSetCursorEnterCallback(GLFWwindow *window, GLFWcursorenterfun callback);
  *
  *  @ingroup input
  */
-GLFWAPI GLFWscrollfun glfwSetScrollCallback(GLFWwindow *window,
-                                            GLFWscrollfun callback);
+GLFWAPI GLFWscrollfun glfwSetScrollCallback(GLFWwindow* window, GLFWscrollfun callback);
 
 /*! @brief Sets the path drop callback.
  *
@@ -5528,8 +5479,7 @@ GLFWAPI GLFWscrollfun glfwSetScrollCallback(GLFWwindow *window,
  *
  *  @ingroup input
  */
-GLFWAPI GLFWdropfun glfwSetDropCallback(GLFWwindow *window,
-                                        GLFWdropfun callback);
+GLFWAPI GLFWdropfun glfwSetDropCallback(GLFWwindow* window, GLFWdropfun callback);
 
 /*! @brief Returns whether the specified joystick is present.
  *
@@ -5586,7 +5536,7 @@ GLFWAPI int glfwJoystickPresent(int jid);
  *
  *  @ingroup input
  */
-GLFWAPI const float *glfwGetJoystickAxes(int jid, int *count);
+GLFWAPI const float* glfwGetJoystickAxes(int jid, int* count);
 
 /*! @brief Returns the state of all buttons of the specified joystick.
  *
@@ -5627,7 +5577,7 @@ GLFWAPI const float *glfwGetJoystickAxes(int jid, int *count);
  *
  *  @ingroup input
  */
-GLFWAPI const unsigned char *glfwGetJoystickButtons(int jid, int *count);
+GLFWAPI const unsigned char* glfwGetJoystickButtons(int jid, int* count);
 
 /*! @brief Returns the state of all hats of the specified joystick.
  *
@@ -5684,7 +5634,7 @@ GLFWAPI const unsigned char *glfwGetJoystickButtons(int jid, int *count);
  *
  *  @ingroup input
  */
-GLFWAPI const unsigned char *glfwGetJoystickHats(int jid, int *count);
+GLFWAPI const unsigned char* glfwGetJoystickHats(int jid, int* count);
 
 /*! @brief Returns the name of the specified joystick.
  *
@@ -5715,7 +5665,7 @@ GLFWAPI const unsigned char *glfwGetJoystickHats(int jid, int *count);
  *
  *  @ingroup input
  */
-GLFWAPI const char *glfwGetJoystickName(int jid);
+GLFWAPI const char* glfwGetJoystickName(int jid);
 
 /*! @brief Returns the SDL compatible GUID of the specified joystick.
  *
@@ -5756,7 +5706,7 @@ GLFWAPI const char *glfwGetJoystickName(int jid);
  *
  *  @ingroup input
  */
-GLFWAPI const char *glfwGetJoystickGUID(int jid);
+GLFWAPI const char* glfwGetJoystickGUID(int jid);
 
 /*! @brief Sets the user pointer of the specified joystick.
  *
@@ -5782,7 +5732,7 @@ GLFWAPI const char *glfwGetJoystickGUID(int jid);
  *
  *  @ingroup input
  */
-GLFWAPI void glfwSetJoystickUserPointer(int jid, void *pointer);
+GLFWAPI void glfwSetJoystickUserPointer(int jid, void* pointer);
 
 /*! @brief Returns the user pointer of the specified joystick.
  *
@@ -5806,7 +5756,7 @@ GLFWAPI void glfwSetJoystickUserPointer(int jid, void *pointer);
  *
  *  @ingroup input
  */
-GLFWAPI void *glfwGetJoystickUserPointer(int jid);
+GLFWAPI void* glfwGetJoystickUserPointer(int jid);
 
 /*! @brief Returns whether the specified joystick has a gamepad mapping.
  *
@@ -5904,7 +5854,7 @@ GLFWAPI GLFWjoystickfun glfwSetJoystickCallback(GLFWjoystickfun callback);
  *
  *  @ingroup input
  */
-GLFWAPI int glfwUpdateGamepadMappings(const char *string);
+GLFWAPI int glfwUpdateGamepadMappings(const char* string);
 
 /*! @brief Returns the human-readable gamepad name for the specified joystick.
  *
@@ -5921,8 +5871,7 @@ GLFWAPI int glfwUpdateGamepadMappings(const char *string);
  *  joystick is not present, does not have a mapping or an
  *  [error](@ref error_handling) occurred.
  *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- * GLFW_INVALID_ENUM.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref GLFW_INVALID_ENUM.
  *
  *  @pointer_lifetime The returned string is allocated and freed by GLFW.  You
  *  should not free it yourself.  It is valid until the specified joystick is
@@ -5937,7 +5886,7 @@ GLFWAPI int glfwUpdateGamepadMappings(const char *string);
  *
  *  @ingroup input
  */
-GLFWAPI const char *glfwGetGamepadName(int jid);
+GLFWAPI const char* glfwGetGamepadName(int jid);
 
 /*! @brief Retrieves the state of the specified joystick remapped as a gamepad.
  *
@@ -5975,7 +5924,7 @@ GLFWAPI const char *glfwGetGamepadName(int jid);
  *
  *  @ingroup input
  */
-GLFWAPI int glfwGetGamepadState(int jid, GLFWgamepadstate *state);
+GLFWAPI int glfwGetGamepadState(int jid, GLFWgamepadstate* state);
 
 /*! @brief Sets the clipboard to the specified string.
  *
@@ -5988,10 +5937,10 @@ GLFWAPI int glfwGetGamepadState(int jid, GLFWgamepadstate *state);
  *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
  *  GLFW_PLATFORM_ERROR.
  *
- *  @remark __Win32:__ The clipboard on Windows has a single global lock for
- * reading and writing.  GLFW tries to acquire it a few times, which is almost
- * always enough.  If it cannot acquire the lock then this function emits @ref
- * GLFW_PLATFORM_ERROR and returns. It is safe to try this multiple times.
+ *  @remark __Win32:__ The clipboard on Windows has a single global lock for reading and
+ *  writing.  GLFW tries to acquire it a few times, which is almost always enough.  If it
+ *  cannot acquire the lock then this function emits @ref GLFW_PLATFORM_ERROR and returns.
+ *  It is safe to try this multiple times.
  *
  *  @pointer_lifetime The specified string is copied before this function
  *  returns.
@@ -6005,7 +5954,7 @@ GLFWAPI int glfwGetGamepadState(int jid, GLFWgamepadstate *state);
  *
  *  @ingroup input
  */
-GLFWAPI void glfwSetClipboardString(GLFWwindow *window, const char *string);
+GLFWAPI void glfwSetClipboardString(GLFWwindow* window, const char* string);
 
 /*! @brief Returns the contents of the clipboard as a string.
  *
@@ -6021,10 +5970,10 @@ GLFWAPI void glfwSetClipboardString(GLFWwindow *window, const char *string);
  *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
  *  GLFW_FORMAT_UNAVAILABLE and @ref GLFW_PLATFORM_ERROR.
  *
- *  @remark __Win32:__ The clipboard on Windows has a single global lock for
- * reading and writing.  GLFW tries to acquire it a few times, which is almost
- * always enough.  If it cannot acquire the lock then this function emits @ref
- * GLFW_PLATFORM_ERROR and returns. It is safe to try this multiple times.
+ *  @remark __Win32:__ The clipboard on Windows has a single global lock for reading and
+ *  writing.  GLFW tries to acquire it a few times, which is almost always enough.  If it
+ *  cannot acquire the lock then this function emits @ref GLFW_PLATFORM_ERROR and returns.
+ *  It is safe to try this multiple times.
  *
  *  @pointer_lifetime The returned string is allocated and freed by GLFW.  You
  *  should not free it yourself.  It is valid until the next call to @ref
@@ -6040,7 +5989,7 @@ GLFWAPI void glfwSetClipboardString(GLFWwindow *window, const char *string);
  *
  *  @ingroup input
  */
-GLFWAPI const char *glfwGetClipboardString(GLFWwindow *window);
+GLFWAPI const char* glfwGetClipboardString(GLFWwindow* window);
 
 /*! @brief Returns the GLFW time.
  *
@@ -6187,7 +6136,7 @@ GLFWAPI uint64_t glfwGetTimerFrequency(void);
  *
  *  @ingroup context
  */
-GLFWAPI void glfwMakeContextCurrent(GLFWwindow *window);
+GLFWAPI void glfwMakeContextCurrent(GLFWwindow* window);
 
 /*! @brief Returns the window whose context is current on the calling thread.
  *
@@ -6208,7 +6157,7 @@ GLFWAPI void glfwMakeContextCurrent(GLFWwindow *window);
  *
  *  @ingroup context
  */
-GLFWAPI GLFWwindow *glfwGetCurrentContext(void);
+GLFWAPI GLFWwindow* glfwGetCurrentContext(void);
 
 /*! @brief Swaps the front and back buffers of the specified window.
  *
@@ -6246,7 +6195,7 @@ GLFWAPI GLFWwindow *glfwGetCurrentContext(void);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwSwapBuffers(GLFWwindow *window);
+GLFWAPI void glfwSwapBuffers(GLFWwindow* window);
 
 /*! @brief Sets the swap interval for the current context.
  *
@@ -6330,7 +6279,7 @@ GLFWAPI void glfwSwapInterval(int interval);
  *
  *  @ingroup context
  */
-GLFWAPI int glfwExtensionSupported(const char *extension);
+GLFWAPI int glfwExtensionSupported(const char* extension);
 
 /*! @brief Returns the address of the specified function for the current
  *  context.
@@ -6372,19 +6321,18 @@ GLFWAPI int glfwExtensionSupported(const char *extension);
  *
  *  @ingroup context
  */
-GLFWAPI GLFWglproc glfwGetProcAddress(const char *procname);
+GLFWAPI GLFWglproc glfwGetProcAddress(const char* procname);
 
 /*! @brief Returns whether the Vulkan loader and an ICD have been found.
  *
  *  This function returns whether the Vulkan loader and any minimally functional
  *  ICD have been found.
  *
- *  The availability of a Vulkan loader and even an ICD does not by itself
- * guarantee that surface creation or even instance creation is possible.  Call
- * @ref glfwGetRequiredInstanceExtensions to check whether the extensions
- * necessary for Vulkan surface creation are available and @ref
- * glfwGetPhysicalDevicePresentationSupport to check whether a queue family of a
- * physical device supports image presentation.
+ *  The availability of a Vulkan loader and even an ICD does not by itself guarantee that
+ *  surface creation or even instance creation is possible.  Call @ref
+ *  glfwGetRequiredInstanceExtensions to check whether the extensions necessary for Vulkan
+ *  surface creation are available and @ref glfwGetPhysicalDevicePresentationSupport to
+ *  check whether a queue family of a physical device supports image presentation.
  *
  *  @return `GLFW_TRUE` if Vulkan is minimally available, or `GLFW_FALSE`
  *  otherwise.
@@ -6403,10 +6351,10 @@ GLFWAPI int glfwVulkanSupported(void);
 
 /*! @brief Returns the Vulkan instance extensions required by GLFW.
  *
- *  This function returns an array of names of Vulkan instance extensions
- * required by GLFW for creating Vulkan surfaces for GLFW windows.  If
- * successful, the list will always contain `VK_KHR_surface`, so if you don't
- * require any additional extensions you can pass this list directly to the
+ *  This function returns an array of names of Vulkan instance extensions required
+ *  by GLFW for creating Vulkan surfaces for GLFW windows.  If successful, the
+ *  list will always contain `VK_KHR_surface`, so if you don't require any
+ *  additional extensions you can pass this list directly to the
  *  `VkInstanceCreateInfo` struct.
  *
  *  If Vulkan is not available on the machine, this function returns `NULL` and
@@ -6443,7 +6391,7 @@ GLFWAPI int glfwVulkanSupported(void);
  *
  *  @ingroup vulkan
  */
-GLFWAPI const char **glfwGetRequiredInstanceExtensions(uint32_t *count);
+GLFWAPI const char** glfwGetRequiredInstanceExtensions(uint32_t* count);
 
 #if defined(VK_VERSION_1_0)
 
@@ -6486,8 +6434,7 @@ GLFWAPI const char **glfwGetRequiredInstanceExtensions(uint32_t *count);
  *
  *  @ingroup vulkan
  */
-GLFWAPI GLFWvkproc glfwGetInstanceProcAddress(VkInstance instance,
-                                              const char *procname);
+GLFWAPI GLFWvkproc glfwGetInstanceProcAddress(VkInstance instance, const char* procname);
 
 /*! @brief Returns whether the specified queue family can present images.
  *
@@ -6511,9 +6458,9 @@ GLFWAPI GLFWvkproc glfwGetInstanceProcAddress(VkInstance instance,
  *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
  *  GLFW_API_UNAVAILABLE and @ref GLFW_PLATFORM_ERROR.
  *
- *  @remark __macOS:__ This function currently always returns `GLFW_TRUE`, as
- * the `VK_MVK_macos_surface` and `VK_EXT_metal_surface` extensions do not
- * provide a `vkGetPhysicalDevice*PresentationSupport` type function.
+ *  @remark __macOS:__ This function currently always returns `GLFW_TRUE`, as the
+ *  `VK_MVK_macos_surface` and `VK_EXT_metal_surface` extensions do not provide
+ *  a `vkGetPhysicalDevice*PresentationSupport` type function.
  *
  *  @thread_safety This function may be called from any thread.  For
  *  synchronization details of Vulkan objects, see the Vulkan specification.
@@ -6524,18 +6471,16 @@ GLFWAPI GLFWvkproc glfwGetInstanceProcAddress(VkInstance instance,
  *
  *  @ingroup vulkan
  */
-GLFWAPI int glfwGetPhysicalDevicePresentationSupport(VkInstance instance,
-                                                     VkPhysicalDevice device,
-                                                     uint32_t queuefamily);
+GLFWAPI int glfwGetPhysicalDevicePresentationSupport(VkInstance instance, VkPhysicalDevice device, uint32_t queuefamily);
 
 /*! @brief Creates a Vulkan surface for the specified window.
  *
  *  This function creates a Vulkan surface for the specified window.
  *
- *  If the Vulkan loader or at least one minimally functional ICD were not
- * found, this function returns `VK_ERROR_INITIALIZATION_FAILED` and generates a
- * @ref GLFW_API_UNAVAILABLE error.  Call @ref glfwVulkanSupported to check
- * whether Vulkan is at least minimally available.
+ *  If the Vulkan loader or at least one minimally functional ICD were not found,
+ *  this function returns `VK_ERROR_INITIALIZATION_FAILED` and generates a @ref
+ *  GLFW_API_UNAVAILABLE error.  Call @ref glfwVulkanSupported to check whether
+ *  Vulkan is at least minimally available.
  *
  *  If the required window surface creation instance extensions are not
  *  available or if the specified instance was not created with these extensions
@@ -6571,13 +6516,13 @@ GLFWAPI int glfwGetPhysicalDevicePresentationSupport(VkInstance instance,
  *  @ref glfwVulkanSupported and @ref glfwGetRequiredInstanceExtensions should
  *  eliminate almost all occurrences of these errors.
  *
- *  @remark __macOS:__ GLFW prefers the `VK_EXT_metal_surface` extension, with
- * the `VK_MVK_macos_surface` extension as a fallback.  The name of the selected
+ *  @remark __macOS:__ GLFW prefers the `VK_EXT_metal_surface` extension, with the
+ *  `VK_MVK_macos_surface` extension as a fallback.  The name of the selected
  *  extension, if any, is included in the array returned by @ref
  *  glfwGetRequiredInstanceExtensions.
  *
- *  @remark __macOS:__ This function creates and sets a `CAMetalLayer` instance
- * for the window content view, which is required for MoltenVK to function.
+ *  @remark __macOS:__ This function creates and sets a `CAMetalLayer` instance for
+ *  the window content view, which is required for MoltenVK to function.
  *
  *  @remark __X11:__ By default GLFW prefers the `VK_KHR_xcb_surface` extension,
  *  with the `VK_KHR_xlib_surface` extension as a fallback.  You can make
@@ -6596,12 +6541,10 @@ GLFWAPI int glfwGetPhysicalDevicePresentationSupport(VkInstance instance,
  *
  *  @ingroup vulkan
  */
-GLFWAPI VkResult glfwCreateWindowSurface(VkInstance instance,
-                                         GLFWwindow *window,
-                                         const VkAllocationCallbacks *allocator,
-                                         VkSurfaceKHR *surface);
+GLFWAPI VkResult glfwCreateWindowSurface(VkInstance instance, GLFWwindow* window, const VkAllocationCallbacks* allocator, VkSurfaceKHR* surface);
 
 #endif /*VK_VERSION_1_0*/
+
 
 /*************************************************************************
  * Global definition cleanup
@@ -6610,24 +6553,25 @@ GLFWAPI VkResult glfwCreateWindowSurface(VkInstance instance,
 /* ------------------- BEGIN SYSTEM/COMPILER SPECIFIC -------------------- */
 
 #ifdef GLFW_WINGDIAPI_DEFINED
-#undef WINGDIAPI
-#undef GLFW_WINGDIAPI_DEFINED
+ #undef WINGDIAPI
+ #undef GLFW_WINGDIAPI_DEFINED
 #endif
 
 #ifdef GLFW_CALLBACK_DEFINED
-#undef CALLBACK
-#undef GLFW_CALLBACK_DEFINED
+ #undef CALLBACK
+ #undef GLFW_CALLBACK_DEFINED
 #endif
 
 /* Some OpenGL related headers need GLAPIENTRY, but it is unconditionally
  * defined by some gl.h variants (OpenBSD) so define it after if needed.
  */
 #ifndef GLAPIENTRY
-#define GLAPIENTRY APIENTRY
-#define GLFW_GLAPIENTRY_DEFINED
+ #define GLAPIENTRY APIENTRY
+ #define GLFW_GLAPIENTRY_DEFINED
 #endif
 
 /* -------------------- END SYSTEM/COMPILER SPECIFIC --------------------- */
+
 
 #ifdef __cplusplus
 }

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -33,7 +33,6 @@
 extern "C" {
 #endif
 
-
 /*************************************************************************
  * Doxygen documentation
  *************************************************************************/
@@ -85,15 +84,15 @@ extern "C" {
  *  information, see the @ref window_guide.
  */
 
-
 /*************************************************************************
  * Compiler- and platform-specific preprocessor work
  *************************************************************************/
 
 /* If we are we on Windows, we want a single define for it.
  */
-#if !defined(_WIN32) && (defined(__WIN32__) || defined(WIN32) || defined(__MINGW32__))
- #define _WIN32
+#if !defined(_WIN32) &&                                                        \
+    (defined(__WIN32__) || defined(WIN32) || defined(__MINGW32__))
+#define _WIN32
 #endif /* _WIN32 */
 
 /* Include because most Windows GLU headers need wchar_t and
@@ -108,7 +107,7 @@ extern "C" {
 #include <stdint.h>
 
 #if defined(GLFW_INCLUDE_VULKAN)
-  #include <vulkan/vulkan.h>
+#include <vulkan/vulkan.h>
 #endif /* Vulkan header */
 
 /* The Vulkan header may have indirectly included windows.h (because of
@@ -119,158 +118,151 @@ extern "C" {
  * all platforms.  Additionally, the Windows OpenGL header needs APIENTRY.
  */
 #if !defined(APIENTRY)
- #if defined(_WIN32)
-  #define APIENTRY __stdcall
- #else
-  #define APIENTRY
- #endif
- #define GLFW_APIENTRY_DEFINED
+#if defined(_WIN32)
+#define APIENTRY __stdcall
+#else
+#define APIENTRY
+#endif
+#define GLFW_APIENTRY_DEFINED
 #endif /* APIENTRY */
 
 /* Some Windows OpenGL headers need this.
  */
 #if !defined(WINGDIAPI) && defined(_WIN32)
- #define WINGDIAPI __declspec(dllimport)
- #define GLFW_WINGDIAPI_DEFINED
+#define WINGDIAPI __declspec(dllimport)
+#define GLFW_WINGDIAPI_DEFINED
 #endif /* WINGDIAPI */
 
 /* Some Windows GLU headers need this.
  */
 #if !defined(CALLBACK) && defined(_WIN32)
- #define CALLBACK __stdcall
- #define GLFW_CALLBACK_DEFINED
+#define CALLBACK __stdcall
+#define GLFW_CALLBACK_DEFINED
 #endif /* CALLBACK */
 
 /* Include the chosen OpenGL or OpenGL ES headers.
  */
 #if defined(GLFW_INCLUDE_ES1)
 
- #include <GLES/gl.h>
- #if defined(GLFW_INCLUDE_GLEXT)
-  #include <GLES/glext.h>
- #endif
+#include <GLES/gl.h>
+#if defined(GLFW_INCLUDE_GLEXT)
+#include <GLES/glext.h>
+#endif
 
 #elif defined(GLFW_INCLUDE_ES2)
 
- #include <GLES2/gl2.h>
- #if defined(GLFW_INCLUDE_GLEXT)
-  #include <GLES2/gl2ext.h>
- #endif
+#include <GLES2/gl2.h>
+#if defined(GLFW_INCLUDE_GLEXT)
+#include <GLES2/gl2ext.h>
+#endif
 
 #elif defined(GLFW_INCLUDE_ES3)
 
- #include <GLES3/gl3.h>
- #if defined(GLFW_INCLUDE_GLEXT)
-  #include <GLES2/gl2ext.h>
- #endif
+#include <GLES3/gl3.h>
+#if defined(GLFW_INCLUDE_GLEXT)
+#include <GLES2/gl2ext.h>
+#endif
 
 #elif defined(GLFW_INCLUDE_ES31)
 
- #include <GLES3/gl31.h>
- #if defined(GLFW_INCLUDE_GLEXT)
-  #include <GLES2/gl2ext.h>
- #endif
+#include <GLES3/gl31.h>
+#if defined(GLFW_INCLUDE_GLEXT)
+#include <GLES2/gl2ext.h>
+#endif
 
 #elif defined(GLFW_INCLUDE_ES32)
 
- #include <GLES3/gl32.h>
- #if defined(GLFW_INCLUDE_GLEXT)
-  #include <GLES2/gl2ext.h>
- #endif
+#include <GLES3/gl32.h>
+#if defined(GLFW_INCLUDE_GLEXT)
+#include <GLES2/gl2ext.h>
+#endif
 
 #elif defined(GLFW_INCLUDE_GLCOREARB)
 
- #if defined(__APPLE__)
+#if defined(__APPLE__)
 
-  #include <OpenGL/gl3.h>
-  #if defined(GLFW_INCLUDE_GLEXT)
-   #include <OpenGL/gl3ext.h>
-  #endif /*GLFW_INCLUDE_GLEXT*/
+#include <OpenGL/gl3.h>
+#if defined(GLFW_INCLUDE_GLEXT)
+#include <OpenGL/gl3ext.h>
+#endif /*GLFW_INCLUDE_GLEXT*/
 
- #else /*__APPLE__*/
+#else /*__APPLE__*/
 
-  #include <GL/glcorearb.h>
-  #if defined(GLFW_INCLUDE_GLEXT)
-   #include <GL/glext.h>
-  #endif
+#include <GL/glcorearb.h>
+#if defined(GLFW_INCLUDE_GLEXT)
+#include <GL/glext.h>
+#endif
 
- #endif /*__APPLE__*/
+#endif /*__APPLE__*/
 
 #elif defined(GLFW_INCLUDE_GLU)
 
- #if defined(__APPLE__)
+#if defined(__APPLE__)
 
-  #if defined(GLFW_INCLUDE_GLU)
-   #include <OpenGL/glu.h>
-  #endif
+#if defined(GLFW_INCLUDE_GLU)
+#include <OpenGL/glu.h>
+#endif
 
- #else /*__APPLE__*/
+#else /*__APPLE__*/
 
-  #if defined(GLFW_INCLUDE_GLU)
-   #include <GL/glu.h>
-  #endif
+#if defined(GLFW_INCLUDE_GLU)
+#include <GL/glu.h>
+#endif
 
- #endif /*__APPLE__*/
+#endif /*__APPLE__*/
 
-#elif !defined(GLFW_INCLUDE_NONE) && \
-      !defined(__gl_h_) && \
-      !defined(__gles1_gl_h_) && \
-      !defined(__gles2_gl2_h_) && \
-      !defined(__gles2_gl3_h_) && \
-      !defined(__gles2_gl31_h_) && \
-      !defined(__gles2_gl32_h_) && \
-      !defined(__gl_glcorearb_h_) && \
-      !defined(__gl2_h_) /*legacy*/ && \
-      !defined(__gl3_h_) /*legacy*/ && \
-      !defined(__gl31_h_) /*legacy*/ && \
-      !defined(__gl32_h_) /*legacy*/ && \
-      !defined(__glcorearb_h_) /*legacy*/ && \
-      !defined(__GL_H__) /*non-standard*/ && \
-      !defined(__gltypes_h_) /*non-standard*/ && \
-      !defined(__glee_h_) /*non-standard*/
+#elif !defined(GLFW_INCLUDE_NONE) && !defined(__gl_h_) &&                      \
+    !defined(__gles1_gl_h_) && !defined(__gles2_gl2_h_) &&                     \
+    !defined(__gles2_gl3_h_) && !defined(__gles2_gl31_h_) &&                   \
+    !defined(__gles2_gl32_h_) && !defined(__gl_glcorearb_h_) &&                \
+    !defined(__gl2_h_) /*legacy*/ && !defined(__gl3_h_) /*legacy*/ &&          \
+    !defined(__gl31_h_) /*legacy*/ && !defined(__gl32_h_) /*legacy*/ &&        \
+    !defined(__glcorearb_h_) /*legacy*/ &&                                     \
+    !defined(__GL_H__) /*non-standard*/ &&                                     \
+    !defined(__gltypes_h_) /*non-standard*/ &&                                 \
+    !defined(__glee_h_) /*non-standard*/
 
- #if defined(__APPLE__)
+#if defined(__APPLE__)
 
-  #if !defined(GLFW_INCLUDE_GLEXT)
-   #define GL_GLEXT_LEGACY
-  #endif
-  #include <OpenGL/gl.h>
+#if !defined(GLFW_INCLUDE_GLEXT)
+#define GL_GLEXT_LEGACY
+#endif
+#include <OpenGL/gl.h>
 
- #else /*__APPLE__*/
+#else /*__APPLE__*/
 
-  #include <GL/gl.h>
-  #if defined(GLFW_INCLUDE_GLEXT)
-   #include <GL/glext.h>
-  #endif
+#include <GL/gl.h>
+#if defined(GLFW_INCLUDE_GLEXT)
+#include <GL/glext.h>
+#endif
 
- #endif /*__APPLE__*/
+#endif /*__APPLE__*/
 
 #endif /* OpenGL and OpenGL ES headers */
 
 #if defined(GLFW_DLL) && defined(_GLFW_BUILD_DLL)
- /* GLFW_DLL must be defined by applications that are linking against the DLL
-  * version of the GLFW library.  _GLFW_BUILD_DLL is defined by the GLFW
-  * configuration header when compiling the DLL version of the library.
-  */
- #error "You must not have both GLFW_DLL and _GLFW_BUILD_DLL defined"
+/* GLFW_DLL must be defined by applications that are linking against the DLL
+ * version of the GLFW library.  _GLFW_BUILD_DLL is defined by the GLFW
+ * configuration header when compiling the DLL version of the library.
+ */
+#error "You must not have both GLFW_DLL and _GLFW_BUILD_DLL defined"
 #endif
 
 /* GLFWAPI is used to declare public API functions for export
  * from the DLL / shared library / dynamic library.
  */
 #if defined(_WIN32) && defined(_GLFW_BUILD_DLL)
- /* We are building GLFW as a Win32 DLL */
- #define GLFWAPI __declspec(dllexport)
+/* We are building GLFW as a Win32 DLL */
+#define GLFWAPI __declspec(dllexport)
 #elif defined(_WIN32) && defined(GLFW_DLL)
- /* We are calling a GLFW Win32 DLL */
- #define GLFWAPI __declspec(dllimport)
+/* We are calling a GLFW Win32 DLL */
+#define GLFWAPI __declspec(dllimport)
 #elif defined(__GNUC__) && defined(_GLFW_BUILD_DLL)
- /* We are building GLFW as a Unix shared library */
- #define GLFWAPI __attribute__((visibility("default")))
+/* We are building GLFW as a Unix shared library */
+#define GLFWAPI __attribute__((visibility("default")))
 #else
- #define GLFWAPI
+#define GLFWAPI
 #endif
-
 
 /*************************************************************************
  * GLFW API tokens
@@ -284,21 +276,21 @@ extern "C" {
  *  API is changed in non-compatible ways.
  *  @ingroup init
  */
-#define GLFW_VERSION_MAJOR          3
+#define GLFW_VERSION_MAJOR 3
 /*! @brief The minor version number of the GLFW header.
  *
  *  The minor version number of the GLFW header.  This is incremented when
  *  features are added to the API but it remains backward-compatible.
  *  @ingroup init
  */
-#define GLFW_VERSION_MINOR          6
+#define GLFW_VERSION_MINOR 6
 /*! @brief The revision number of the GLFW header.
  *
  *  The revision number of the GLFW header.  This is incremented when a bug fix
  *  release is made that does not contain any API changes.
  *  @ingroup init
  */
-#define GLFW_VERSION_REVISION       0
+#define GLFW_VERSION_REVISION 0
 /*! @} */
 
 /*! @brief One.
@@ -309,7 +301,7 @@ extern "C" {
  *
  *  @ingroup init
  */
-#define GLFW_TRUE                   1
+#define GLFW_TRUE 1
 /*! @brief Zero.
  *
  *  This is only semantic sugar for the number 0.  You can instead use `0` or
@@ -318,7 +310,7 @@ extern "C" {
  *
  *  @ingroup init
  */
-#define GLFW_FALSE                  0
+#define GLFW_FALSE 0
 
 /*! @name Key and button actions
  *  @{ */
@@ -328,21 +320,21 @@ extern "C" {
  *
  *  @ingroup input
  */
-#define GLFW_RELEASE                0
+#define GLFW_RELEASE 0
 /*! @brief The key or mouse button was pressed.
  *
  *  The key or mouse button was pressed.
  *
  *  @ingroup input
  */
-#define GLFW_PRESS                  1
+#define GLFW_PRESS 1
 /*! @brief The key was held down until it repeated.
  *
  *  The key was held down until it repeated.
  *
  *  @ingroup input
  */
-#define GLFW_REPEAT                 2
+#define GLFW_REPEAT 2
 /*! @} */
 
 /*! @defgroup hat_state Joystick hat states
@@ -352,19 +344,19 @@ extern "C" {
  *
  *  @ingroup input
  *  @{ */
-#define GLFW_HAT_CENTERED           0
-#define GLFW_HAT_UP                 1
-#define GLFW_HAT_RIGHT              2
-#define GLFW_HAT_DOWN               4
-#define GLFW_HAT_LEFT               8
-#define GLFW_HAT_RIGHT_UP           (GLFW_HAT_RIGHT | GLFW_HAT_UP)
-#define GLFW_HAT_RIGHT_DOWN         (GLFW_HAT_RIGHT | GLFW_HAT_DOWN)
-#define GLFW_HAT_LEFT_UP            (GLFW_HAT_LEFT  | GLFW_HAT_UP)
-#define GLFW_HAT_LEFT_DOWN          (GLFW_HAT_LEFT  | GLFW_HAT_DOWN)
+#define GLFW_HAT_CENTERED 0
+#define GLFW_HAT_UP 1
+#define GLFW_HAT_RIGHT 2
+#define GLFW_HAT_DOWN 4
+#define GLFW_HAT_LEFT 8
+#define GLFW_HAT_RIGHT_UP (GLFW_HAT_RIGHT | GLFW_HAT_UP)
+#define GLFW_HAT_RIGHT_DOWN (GLFW_HAT_RIGHT | GLFW_HAT_DOWN)
+#define GLFW_HAT_LEFT_UP (GLFW_HAT_LEFT | GLFW_HAT_UP)
+#define GLFW_HAT_LEFT_DOWN (GLFW_HAT_LEFT | GLFW_HAT_DOWN)
 
 /*! @ingroup input
  */
-#define GLFW_KEY_UNKNOWN            -1
+#define GLFW_KEY_UNKNOWN -1
 
 /*! @} */
 
@@ -393,130 +385,130 @@ extern "C" {
  */
 
 /* Printable keys */
-#define GLFW_KEY_SPACE              32
-#define GLFW_KEY_APOSTROPHE         39  /* ' */
-#define GLFW_KEY_COMMA              44  /* , */
-#define GLFW_KEY_MINUS              45  /* - */
-#define GLFW_KEY_PERIOD             46  /* . */
-#define GLFW_KEY_SLASH              47  /* / */
-#define GLFW_KEY_0                  48
-#define GLFW_KEY_1                  49
-#define GLFW_KEY_2                  50
-#define GLFW_KEY_3                  51
-#define GLFW_KEY_4                  52
-#define GLFW_KEY_5                  53
-#define GLFW_KEY_6                  54
-#define GLFW_KEY_7                  55
-#define GLFW_KEY_8                  56
-#define GLFW_KEY_9                  57
-#define GLFW_KEY_SEMICOLON          59  /* ; */
-#define GLFW_KEY_EQUAL              61  /* = */
-#define GLFW_KEY_A                  65
-#define GLFW_KEY_B                  66
-#define GLFW_KEY_C                  67
-#define GLFW_KEY_D                  68
-#define GLFW_KEY_E                  69
-#define GLFW_KEY_F                  70
-#define GLFW_KEY_G                  71
-#define GLFW_KEY_H                  72
-#define GLFW_KEY_I                  73
-#define GLFW_KEY_J                  74
-#define GLFW_KEY_K                  75
-#define GLFW_KEY_L                  76
-#define GLFW_KEY_M                  77
-#define GLFW_KEY_N                  78
-#define GLFW_KEY_O                  79
-#define GLFW_KEY_P                  80
-#define GLFW_KEY_Q                  81
-#define GLFW_KEY_R                  82
-#define GLFW_KEY_S                  83
-#define GLFW_KEY_T                  84
-#define GLFW_KEY_U                  85
-#define GLFW_KEY_V                  86
-#define GLFW_KEY_W                  87
-#define GLFW_KEY_X                  88
-#define GLFW_KEY_Y                  89
-#define GLFW_KEY_Z                  90
-#define GLFW_KEY_LEFT_BRACKET       91  /* [ */
-#define GLFW_KEY_BACKSLASH          92  /* \ */
-#define GLFW_KEY_RIGHT_BRACKET      93  /* ] */
-#define GLFW_KEY_GRAVE_ACCENT       96  /* ` */
-#define GLFW_KEY_WORLD_1            161 /* non-US #1 */
-#define GLFW_KEY_WORLD_2            162 /* non-US #2 */
+#define GLFW_KEY_SPACE 32
+#define GLFW_KEY_APOSTROPHE 39 /* ' */
+#define GLFW_KEY_COMMA 44      /* , */
+#define GLFW_KEY_MINUS 45      /* - */
+#define GLFW_KEY_PERIOD 46     /* . */
+#define GLFW_KEY_SLASH 47      /* / */
+#define GLFW_KEY_0 48
+#define GLFW_KEY_1 49
+#define GLFW_KEY_2 50
+#define GLFW_KEY_3 51
+#define GLFW_KEY_4 52
+#define GLFW_KEY_5 53
+#define GLFW_KEY_6 54
+#define GLFW_KEY_7 55
+#define GLFW_KEY_8 56
+#define GLFW_KEY_9 57
+#define GLFW_KEY_SEMICOLON 59 /* ; */
+#define GLFW_KEY_EQUAL 61     /* = */
+#define GLFW_KEY_A 65
+#define GLFW_KEY_B 66
+#define GLFW_KEY_C 67
+#define GLFW_KEY_D 68
+#define GLFW_KEY_E 69
+#define GLFW_KEY_F 70
+#define GLFW_KEY_G 71
+#define GLFW_KEY_H 72
+#define GLFW_KEY_I 73
+#define GLFW_KEY_J 74
+#define GLFW_KEY_K 75
+#define GLFW_KEY_L 76
+#define GLFW_KEY_M 77
+#define GLFW_KEY_N 78
+#define GLFW_KEY_O 79
+#define GLFW_KEY_P 80
+#define GLFW_KEY_Q 81
+#define GLFW_KEY_R 82
+#define GLFW_KEY_S 83
+#define GLFW_KEY_T 84
+#define GLFW_KEY_U 85
+#define GLFW_KEY_V 86
+#define GLFW_KEY_W 87
+#define GLFW_KEY_X 88
+#define GLFW_KEY_Y 89
+#define GLFW_KEY_Z 90
+#define GLFW_KEY_LEFT_BRACKET 91  /* [ */
+#define GLFW_KEY_BACKSLASH 92     /* \ */
+#define GLFW_KEY_RIGHT_BRACKET 93 /* ] */
+#define GLFW_KEY_GRAVE_ACCENT 96  /* ` */
+#define GLFW_KEY_WORLD_1 161      /* non-US #1 */
+#define GLFW_KEY_WORLD_2 162      /* non-US #2 */
 
 /* Function keys */
-#define GLFW_KEY_ESCAPE             256
-#define GLFW_KEY_ENTER              257
-#define GLFW_KEY_TAB                258
-#define GLFW_KEY_BACKSPACE          259
-#define GLFW_KEY_INSERT             260
-#define GLFW_KEY_DELETE             261
-#define GLFW_KEY_RIGHT              262
-#define GLFW_KEY_LEFT               263
-#define GLFW_KEY_DOWN               264
-#define GLFW_KEY_UP                 265
-#define GLFW_KEY_PAGE_UP            266
-#define GLFW_KEY_PAGE_DOWN          267
-#define GLFW_KEY_HOME               268
-#define GLFW_KEY_END                269
-#define GLFW_KEY_CAPS_LOCK          280
-#define GLFW_KEY_SCROLL_LOCK        281
-#define GLFW_KEY_NUM_LOCK           282
-#define GLFW_KEY_PRINT_SCREEN       283
-#define GLFW_KEY_PAUSE              284
-#define GLFW_KEY_F1                 290
-#define GLFW_KEY_F2                 291
-#define GLFW_KEY_F3                 292
-#define GLFW_KEY_F4                 293
-#define GLFW_KEY_F5                 294
-#define GLFW_KEY_F6                 295
-#define GLFW_KEY_F7                 296
-#define GLFW_KEY_F8                 297
-#define GLFW_KEY_F9                 298
-#define GLFW_KEY_F10                299
-#define GLFW_KEY_F11                300
-#define GLFW_KEY_F12                301
-#define GLFW_KEY_F13                302
-#define GLFW_KEY_F14                303
-#define GLFW_KEY_F15                304
-#define GLFW_KEY_F16                305
-#define GLFW_KEY_F17                306
-#define GLFW_KEY_F18                307
-#define GLFW_KEY_F19                308
-#define GLFW_KEY_F20                309
-#define GLFW_KEY_F21                310
-#define GLFW_KEY_F22                311
-#define GLFW_KEY_F23                312
-#define GLFW_KEY_F24                313
-#define GLFW_KEY_F25                314
-#define GLFW_KEY_KP_0               320
-#define GLFW_KEY_KP_1               321
-#define GLFW_KEY_KP_2               322
-#define GLFW_KEY_KP_3               323
-#define GLFW_KEY_KP_4               324
-#define GLFW_KEY_KP_5               325
-#define GLFW_KEY_KP_6               326
-#define GLFW_KEY_KP_7               327
-#define GLFW_KEY_KP_8               328
-#define GLFW_KEY_KP_9               329
-#define GLFW_KEY_KP_DECIMAL         330
-#define GLFW_KEY_KP_DIVIDE          331
-#define GLFW_KEY_KP_MULTIPLY        332
-#define GLFW_KEY_KP_SUBTRACT        333
-#define GLFW_KEY_KP_ADD             334
-#define GLFW_KEY_KP_ENTER           335
-#define GLFW_KEY_KP_EQUAL           336
-#define GLFW_KEY_LEFT_SHIFT         340
-#define GLFW_KEY_LEFT_CONTROL       341
-#define GLFW_KEY_LEFT_ALT           342
-#define GLFW_KEY_LEFT_SUPER         343
-#define GLFW_KEY_RIGHT_SHIFT        344
-#define GLFW_KEY_RIGHT_CONTROL      345
-#define GLFW_KEY_RIGHT_ALT          346
-#define GLFW_KEY_RIGHT_SUPER        347
-#define GLFW_KEY_MENU               348
+#define GLFW_KEY_ESCAPE 256
+#define GLFW_KEY_ENTER 257
+#define GLFW_KEY_TAB 258
+#define GLFW_KEY_BACKSPACE 259
+#define GLFW_KEY_INSERT 260
+#define GLFW_KEY_DELETE 261
+#define GLFW_KEY_RIGHT 262
+#define GLFW_KEY_LEFT 263
+#define GLFW_KEY_DOWN 264
+#define GLFW_KEY_UP 265
+#define GLFW_KEY_PAGE_UP 266
+#define GLFW_KEY_PAGE_DOWN 267
+#define GLFW_KEY_HOME 268
+#define GLFW_KEY_END 269
+#define GLFW_KEY_CAPS_LOCK 280
+#define GLFW_KEY_SCROLL_LOCK 281
+#define GLFW_KEY_NUM_LOCK 282
+#define GLFW_KEY_PRINT_SCREEN 283
+#define GLFW_KEY_PAUSE 284
+#define GLFW_KEY_F1 290
+#define GLFW_KEY_F2 291
+#define GLFW_KEY_F3 292
+#define GLFW_KEY_F4 293
+#define GLFW_KEY_F5 294
+#define GLFW_KEY_F6 295
+#define GLFW_KEY_F7 296
+#define GLFW_KEY_F8 297
+#define GLFW_KEY_F9 298
+#define GLFW_KEY_F10 299
+#define GLFW_KEY_F11 300
+#define GLFW_KEY_F12 301
+#define GLFW_KEY_F13 302
+#define GLFW_KEY_F14 303
+#define GLFW_KEY_F15 304
+#define GLFW_KEY_F16 305
+#define GLFW_KEY_F17 306
+#define GLFW_KEY_F18 307
+#define GLFW_KEY_F19 308
+#define GLFW_KEY_F20 309
+#define GLFW_KEY_F21 310
+#define GLFW_KEY_F22 311
+#define GLFW_KEY_F23 312
+#define GLFW_KEY_F24 313
+#define GLFW_KEY_F25 314
+#define GLFW_KEY_KP_0 320
+#define GLFW_KEY_KP_1 321
+#define GLFW_KEY_KP_2 322
+#define GLFW_KEY_KP_3 323
+#define GLFW_KEY_KP_4 324
+#define GLFW_KEY_KP_5 325
+#define GLFW_KEY_KP_6 326
+#define GLFW_KEY_KP_7 327
+#define GLFW_KEY_KP_8 328
+#define GLFW_KEY_KP_9 329
+#define GLFW_KEY_KP_DECIMAL 330
+#define GLFW_KEY_KP_DIVIDE 331
+#define GLFW_KEY_KP_MULTIPLY 332
+#define GLFW_KEY_KP_SUBTRACT 333
+#define GLFW_KEY_KP_ADD 334
+#define GLFW_KEY_KP_ENTER 335
+#define GLFW_KEY_KP_EQUAL 336
+#define GLFW_KEY_LEFT_SHIFT 340
+#define GLFW_KEY_LEFT_CONTROL 341
+#define GLFW_KEY_LEFT_ALT 342
+#define GLFW_KEY_LEFT_SUPER 343
+#define GLFW_KEY_RIGHT_SHIFT 344
+#define GLFW_KEY_RIGHT_CONTROL 345
+#define GLFW_KEY_RIGHT_ALT 346
+#define GLFW_KEY_RIGHT_SUPER 347
+#define GLFW_KEY_MENU 348
 
-#define GLFW_KEY_LAST               GLFW_KEY_MENU
+#define GLFW_KEY_LAST GLFW_KEY_MENU
 
 /*! @} */
 
@@ -532,34 +524,34 @@ extern "C" {
  *
  *  If this bit is set one or more Shift keys were held down.
  */
-#define GLFW_MOD_SHIFT           0x0001
+#define GLFW_MOD_SHIFT 0x0001
 /*! @brief If this bit is set one or more Control keys were held down.
  *
  *  If this bit is set one or more Control keys were held down.
  */
-#define GLFW_MOD_CONTROL         0x0002
+#define GLFW_MOD_CONTROL 0x0002
 /*! @brief If this bit is set one or more Alt keys were held down.
  *
  *  If this bit is set one or more Alt keys were held down.
  */
-#define GLFW_MOD_ALT             0x0004
+#define GLFW_MOD_ALT 0x0004
 /*! @brief If this bit is set one or more Super keys were held down.
  *
  *  If this bit is set one or more Super keys were held down.
  */
-#define GLFW_MOD_SUPER           0x0008
+#define GLFW_MOD_SUPER 0x0008
 /*! @brief If this bit is set the Caps Lock key is enabled.
  *
  *  If this bit is set the Caps Lock key is enabled and the @ref
  *  GLFW_LOCK_KEY_MODS input mode is set.
  */
-#define GLFW_MOD_CAPS_LOCK       0x0010
+#define GLFW_MOD_CAPS_LOCK 0x0010
 /*! @brief If this bit is set the Num Lock key is enabled.
  *
  *  If this bit is set the Num Lock key is enabled and the @ref
  *  GLFW_LOCK_KEY_MODS input mode is set.
  */
-#define GLFW_MOD_NUM_LOCK        0x0020
+#define GLFW_MOD_NUM_LOCK 0x0020
 
 /*! @} */
 
@@ -570,18 +562,18 @@ extern "C" {
  *
  *  @ingroup input
  *  @{ */
-#define GLFW_MOUSE_BUTTON_1         0
-#define GLFW_MOUSE_BUTTON_2         1
-#define GLFW_MOUSE_BUTTON_3         2
-#define GLFW_MOUSE_BUTTON_4         3
-#define GLFW_MOUSE_BUTTON_5         4
-#define GLFW_MOUSE_BUTTON_6         5
-#define GLFW_MOUSE_BUTTON_7         6
-#define GLFW_MOUSE_BUTTON_8         7
-#define GLFW_MOUSE_BUTTON_LAST      GLFW_MOUSE_BUTTON_8
-#define GLFW_MOUSE_BUTTON_LEFT      GLFW_MOUSE_BUTTON_1
-#define GLFW_MOUSE_BUTTON_RIGHT     GLFW_MOUSE_BUTTON_2
-#define GLFW_MOUSE_BUTTON_MIDDLE    GLFW_MOUSE_BUTTON_3
+#define GLFW_MOUSE_BUTTON_1 0
+#define GLFW_MOUSE_BUTTON_2 1
+#define GLFW_MOUSE_BUTTON_3 2
+#define GLFW_MOUSE_BUTTON_4 3
+#define GLFW_MOUSE_BUTTON_5 4
+#define GLFW_MOUSE_BUTTON_6 5
+#define GLFW_MOUSE_BUTTON_7 6
+#define GLFW_MOUSE_BUTTON_8 7
+#define GLFW_MOUSE_BUTTON_LAST GLFW_MOUSE_BUTTON_8
+#define GLFW_MOUSE_BUTTON_LEFT GLFW_MOUSE_BUTTON_1
+#define GLFW_MOUSE_BUTTON_RIGHT GLFW_MOUSE_BUTTON_2
+#define GLFW_MOUSE_BUTTON_MIDDLE GLFW_MOUSE_BUTTON_3
 /*! @} */
 
 /*! @defgroup joysticks Joysticks
@@ -591,23 +583,23 @@ extern "C" {
  *
  *  @ingroup input
  *  @{ */
-#define GLFW_JOYSTICK_1             0
-#define GLFW_JOYSTICK_2             1
-#define GLFW_JOYSTICK_3             2
-#define GLFW_JOYSTICK_4             3
-#define GLFW_JOYSTICK_5             4
-#define GLFW_JOYSTICK_6             5
-#define GLFW_JOYSTICK_7             6
-#define GLFW_JOYSTICK_8             7
-#define GLFW_JOYSTICK_9             8
-#define GLFW_JOYSTICK_10            9
-#define GLFW_JOYSTICK_11            10
-#define GLFW_JOYSTICK_12            11
-#define GLFW_JOYSTICK_13            12
-#define GLFW_JOYSTICK_14            13
-#define GLFW_JOYSTICK_15            14
-#define GLFW_JOYSTICK_16            15
-#define GLFW_JOYSTICK_LAST          GLFW_JOYSTICK_16
+#define GLFW_JOYSTICK_1 0
+#define GLFW_JOYSTICK_2 1
+#define GLFW_JOYSTICK_3 2
+#define GLFW_JOYSTICK_4 3
+#define GLFW_JOYSTICK_5 4
+#define GLFW_JOYSTICK_6 5
+#define GLFW_JOYSTICK_7 6
+#define GLFW_JOYSTICK_8 7
+#define GLFW_JOYSTICK_9 8
+#define GLFW_JOYSTICK_10 9
+#define GLFW_JOYSTICK_11 10
+#define GLFW_JOYSTICK_12 11
+#define GLFW_JOYSTICK_13 12
+#define GLFW_JOYSTICK_14 13
+#define GLFW_JOYSTICK_15 14
+#define GLFW_JOYSTICK_16 15
+#define GLFW_JOYSTICK_LAST GLFW_JOYSTICK_16
 /*! @} */
 
 /*! @defgroup gamepad_buttons Gamepad buttons
@@ -617,27 +609,27 @@ extern "C" {
  *
  *  @ingroup input
  *  @{ */
-#define GLFW_GAMEPAD_BUTTON_A               0
-#define GLFW_GAMEPAD_BUTTON_B               1
-#define GLFW_GAMEPAD_BUTTON_X               2
-#define GLFW_GAMEPAD_BUTTON_Y               3
-#define GLFW_GAMEPAD_BUTTON_LEFT_BUMPER     4
-#define GLFW_GAMEPAD_BUTTON_RIGHT_BUMPER    5
-#define GLFW_GAMEPAD_BUTTON_BACK            6
-#define GLFW_GAMEPAD_BUTTON_START           7
-#define GLFW_GAMEPAD_BUTTON_GUIDE           8
-#define GLFW_GAMEPAD_BUTTON_LEFT_THUMB      9
-#define GLFW_GAMEPAD_BUTTON_RIGHT_THUMB     10
-#define GLFW_GAMEPAD_BUTTON_DPAD_UP         11
-#define GLFW_GAMEPAD_BUTTON_DPAD_RIGHT      12
-#define GLFW_GAMEPAD_BUTTON_DPAD_DOWN       13
-#define GLFW_GAMEPAD_BUTTON_DPAD_LEFT       14
-#define GLFW_GAMEPAD_BUTTON_LAST            GLFW_GAMEPAD_BUTTON_DPAD_LEFT
+#define GLFW_GAMEPAD_BUTTON_A 0
+#define GLFW_GAMEPAD_BUTTON_B 1
+#define GLFW_GAMEPAD_BUTTON_X 2
+#define GLFW_GAMEPAD_BUTTON_Y 3
+#define GLFW_GAMEPAD_BUTTON_LEFT_BUMPER 4
+#define GLFW_GAMEPAD_BUTTON_RIGHT_BUMPER 5
+#define GLFW_GAMEPAD_BUTTON_BACK 6
+#define GLFW_GAMEPAD_BUTTON_START 7
+#define GLFW_GAMEPAD_BUTTON_GUIDE 8
+#define GLFW_GAMEPAD_BUTTON_LEFT_THUMB 9
+#define GLFW_GAMEPAD_BUTTON_RIGHT_THUMB 10
+#define GLFW_GAMEPAD_BUTTON_DPAD_UP 11
+#define GLFW_GAMEPAD_BUTTON_DPAD_RIGHT 12
+#define GLFW_GAMEPAD_BUTTON_DPAD_DOWN 13
+#define GLFW_GAMEPAD_BUTTON_DPAD_LEFT 14
+#define GLFW_GAMEPAD_BUTTON_LAST GLFW_GAMEPAD_BUTTON_DPAD_LEFT
 
-#define GLFW_GAMEPAD_BUTTON_CROSS       GLFW_GAMEPAD_BUTTON_A
-#define GLFW_GAMEPAD_BUTTON_CIRCLE      GLFW_GAMEPAD_BUTTON_B
-#define GLFW_GAMEPAD_BUTTON_SQUARE      GLFW_GAMEPAD_BUTTON_X
-#define GLFW_GAMEPAD_BUTTON_TRIANGLE    GLFW_GAMEPAD_BUTTON_Y
+#define GLFW_GAMEPAD_BUTTON_CROSS GLFW_GAMEPAD_BUTTON_A
+#define GLFW_GAMEPAD_BUTTON_CIRCLE GLFW_GAMEPAD_BUTTON_B
+#define GLFW_GAMEPAD_BUTTON_SQUARE GLFW_GAMEPAD_BUTTON_X
+#define GLFW_GAMEPAD_BUTTON_TRIANGLE GLFW_GAMEPAD_BUTTON_Y
 /*! @} */
 
 /*! @defgroup gamepad_axes Gamepad axes
@@ -647,13 +639,13 @@ extern "C" {
  *
  *  @ingroup input
  *  @{ */
-#define GLFW_GAMEPAD_AXIS_LEFT_X        0
-#define GLFW_GAMEPAD_AXIS_LEFT_Y        1
-#define GLFW_GAMEPAD_AXIS_RIGHT_X       2
-#define GLFW_GAMEPAD_AXIS_RIGHT_Y       3
-#define GLFW_GAMEPAD_AXIS_LEFT_TRIGGER  4
+#define GLFW_GAMEPAD_AXIS_LEFT_X 0
+#define GLFW_GAMEPAD_AXIS_LEFT_Y 1
+#define GLFW_GAMEPAD_AXIS_RIGHT_X 2
+#define GLFW_GAMEPAD_AXIS_RIGHT_Y 3
+#define GLFW_GAMEPAD_AXIS_LEFT_TRIGGER 4
 #define GLFW_GAMEPAD_AXIS_RIGHT_TRIGGER 5
-#define GLFW_GAMEPAD_AXIS_LAST          GLFW_GAMEPAD_AXIS_RIGHT_TRIGGER
+#define GLFW_GAMEPAD_AXIS_LAST GLFW_GAMEPAD_AXIS_RIGHT_TRIGGER
 /*! @} */
 
 /*! @defgroup errors Error codes
@@ -669,7 +661,7 @@ extern "C" {
  *
  *  @analysis Yay.
  */
-#define GLFW_NO_ERROR               0
+#define GLFW_NO_ERROR 0
 /*! @brief GLFW has not been initialized.
  *
  *  This occurs if a GLFW function was called that must not be called unless the
@@ -678,7 +670,7 @@ extern "C" {
  *  @analysis Application programmer error.  Initialize GLFW before calling any
  *  function that requires initialization.
  */
-#define GLFW_NOT_INITIALIZED        0x00010001
+#define GLFW_NOT_INITIALIZED 0x00010001
 /*! @brief No context is current for this thread.
  *
  *  This occurs if a GLFW function was called that needs and operates on the
@@ -688,7 +680,7 @@ extern "C" {
  *  @analysis Application programmer error.  Ensure a context is current before
  *  calling functions that require a current context.
  */
-#define GLFW_NO_CURRENT_CONTEXT     0x00010002
+#define GLFW_NO_CURRENT_CONTEXT 0x00010002
 /*! @brief One of the arguments to the function was an invalid enum value.
  *
  *  One of the arguments to the function was an invalid enum value, for example
@@ -696,7 +688,7 @@ extern "C" {
  *
  *  @analysis Application programmer error.  Fix the offending call.
  */
-#define GLFW_INVALID_ENUM           0x00010003
+#define GLFW_INVALID_ENUM 0x00010003
 /*! @brief One of the arguments to the function was an invalid value.
  *
  *  One of the arguments to the function was an invalid value, for example
@@ -707,7 +699,7 @@ extern "C" {
  *
  *  @analysis Application programmer error.  Fix the offending call.
  */
-#define GLFW_INVALID_VALUE          0x00010004
+#define GLFW_INVALID_VALUE 0x00010004
 /*! @brief A memory allocation failed.
  *
  *  A memory allocation failed.
@@ -715,7 +707,7 @@ extern "C" {
  *  @analysis A bug in GLFW or the underlying operating system.  Report the bug
  *  to our [issue tracker](https://github.com/glfw/glfw/issues).
  */
-#define GLFW_OUT_OF_MEMORY          0x00010005
+#define GLFW_OUT_OF_MEMORY 0x00010005
 /*! @brief GLFW could not find support for the requested API on the system.
  *
  *  GLFW could not find support for the requested API on the system.
@@ -731,7 +723,7 @@ extern "C" {
  *  EGL, OpenGL and OpenGL ES libraries do not interface with the Nvidia binary
  *  driver.  Older graphics drivers do not support Vulkan.
  */
-#define GLFW_API_UNAVAILABLE        0x00010006
+#define GLFW_API_UNAVAILABLE 0x00010006
 /*! @brief The requested OpenGL or OpenGL ES version is not available.
  *
  *  The requested OpenGL or OpenGL ES version (including any requested context
@@ -748,7 +740,7 @@ extern "C" {
  *  not @ref GLFW_INVALID_VALUE, because GLFW cannot know what future versions
  *  will exist.
  */
-#define GLFW_VERSION_UNAVAILABLE    0x00010007
+#define GLFW_VERSION_UNAVAILABLE 0x00010007
 /*! @brief A platform-specific error occurred that does not match any of the
  *  more specific categories.
  *
@@ -759,7 +751,7 @@ extern "C" {
  *  system or its drivers, or a lack of required resources.  Report the issue to
  *  our [issue tracker](https://github.com/glfw/glfw/issues).
  */
-#define GLFW_PLATFORM_ERROR         0x00010008
+#define GLFW_PLATFORM_ERROR 0x00010008
 /*! @brief The requested format is not supported or available.
  *
  *  If emitted during window creation, the requested pixel format is not
@@ -778,7 +770,7 @@ extern "C" {
  *  If emitted when querying the clipboard, ignore the error or report it to
  *  the user, as appropriate.
  */
-#define GLFW_FORMAT_UNAVAILABLE     0x00010009
+#define GLFW_FORMAT_UNAVAILABLE 0x00010009
 /*! @brief The specified window does not have an OpenGL or OpenGL ES context.
  *
  *  A window that does not have an OpenGL or OpenGL ES context was passed to
@@ -786,7 +778,7 @@ extern "C" {
  *
  *  @analysis Application programmer error.  Fix the offending call.
  */
-#define GLFW_NO_WINDOW_CONTEXT      0x0001000A
+#define GLFW_NO_WINDOW_CONTEXT 0x0001000A
 /*! @brief The specified cursor shape is not available.
  *
  *  The specified standard cursor shape is not available, either because the
@@ -797,7 +789,7 @@ extern "C" {
  *  [standard cursor shape](@ref shapes) or create a
  *  [custom cursor](@ref cursor_custom).
  */
-#define GLFW_CURSOR_UNAVAILABLE     0x0001000B
+#define GLFW_CURSOR_UNAVAILABLE 0x0001000B
 /*! @brief The requested feature is not provided by the platform.
  *
  *  The requested feature is not provided by the platform, so GLFW is unable to
@@ -811,10 +803,11 @@ extern "C" {
  *  A function call that emits this error has no effect other than the error and
  *  updating any existing out parameters.
  */
-#define GLFW_FEATURE_UNAVAILABLE    0x0001000C
+#define GLFW_FEATURE_UNAVAILABLE 0x0001000C
 /*! @brief The requested feature is not implemented for the platform.
  *
- *  The requested feature has not yet been implemented in GLFW for this platform.
+ *  The requested feature has not yet been implemented in GLFW for this
+ * platform.
  *
  *  @analysis An incomplete implementation of GLFW for this platform, hopefully
  *  fixed in a future release.  The error can be ignored unless the feature is
@@ -824,29 +817,30 @@ extern "C" {
  *  A function call that emits this error has no effect other than the error and
  *  updating any existing out parameters.
  */
-#define GLFW_FEATURE_UNIMPLEMENTED  0x0001000D
+#define GLFW_FEATURE_UNIMPLEMENTED 0x0001000D
 /*! @brief Platform unavailable or no matching platform was found.
  *
- *  If emitted during initialization, no matching platform was found.  If the @ref
- *  GLFW_PLATFORM init hint was set to `GLFW_ANY_PLATFORM`, GLFW could not detect any of
- *  the platforms supported by this library binary, except for the Null platform.  If the
- *  init hint was set to a specific platform, it is either not supported by this library
- *  binary or GLFW was not able to detect it.
+ *  If emitted during initialization, no matching platform was found.  If the
+ * @ref GLFW_PLATFORM init hint was set to `GLFW_ANY_PLATFORM`, GLFW could not
+ * detect any of the platforms supported by this library binary, except for the
+ * Null platform.  If the init hint was set to a specific platform, it is either
+ * not supported by this library binary or GLFW was not able to detect it.
  *
- *  If emitted by a native access function, GLFW was initialized for a different platform
- *  than the function is for.
+ *  If emitted by a native access function, GLFW was initialized for a different
+ * platform than the function is for.
  *
- *  @analysis Failure to detect any platform usually only happens on non-macOS Unix
- *  systems, either when no window system is running or the program was run from
- *  a terminal that does not have the necessary environment variables.  Fall back to
- *  a different platform if possible or notify the user that no usable platform was
- *  detected.
+ *  @analysis Failure to detect any platform usually only happens on non-macOS
+ * Unix systems, either when no window system is running or the program was run
+ * from a terminal that does not have the necessary environment variables.  Fall
+ * back to a different platform if possible or notify the user that no usable
+ * platform was detected.
  *
- *  Failure to detect a specific platform may have the same cause as above or be because
- *  support for that platform was not compiled in.  Call @ref glfwPlatformSupported to
- *  check whether a specific platform is supported by a library binary.
+ *  Failure to detect a specific platform may have the same cause as above or be
+ * because support for that platform was not compiled in.  Call @ref
+ * glfwPlatformSupported to check whether a specific platform is supported by a
+ * library binary.
  */
-#define GLFW_PLATFORM_UNAVAILABLE   0x0001000E
+#define GLFW_PLATFORM_UNAVAILABLE 0x0001000E
 /*! @} */
 
 /*! @addtogroup window
@@ -856,53 +850,53 @@ extern "C" {
  *  Input focus [window hint](@ref GLFW_FOCUSED_hint) or
  *  [window attribute](@ref GLFW_FOCUSED_attrib).
  */
-#define GLFW_FOCUSED                0x00020001
+#define GLFW_FOCUSED 0x00020001
 /*! @brief Window iconification window attribute
  *
  *  Window iconification [window attribute](@ref GLFW_ICONIFIED_attrib).
  */
-#define GLFW_ICONIFIED              0x00020002
+#define GLFW_ICONIFIED 0x00020002
 /*! @brief Window resize-ability window hint and attribute
  *
  *  Window resize-ability [window hint](@ref GLFW_RESIZABLE_hint) and
  *  [window attribute](@ref GLFW_RESIZABLE_attrib).
  */
-#define GLFW_RESIZABLE              0x00020003
+#define GLFW_RESIZABLE 0x00020003
 /*! @brief Window visibility window hint and attribute
  *
  *  Window visibility [window hint](@ref GLFW_VISIBLE_hint) and
  *  [window attribute](@ref GLFW_VISIBLE_attrib).
  */
-#define GLFW_VISIBLE                0x00020004
+#define GLFW_VISIBLE 0x00020004
 /*! @brief Window decoration window hint and attribute
  *
  *  Window decoration [window hint](@ref GLFW_DECORATED_hint) and
  *  [window attribute](@ref GLFW_DECORATED_attrib).
  */
-#define GLFW_DECORATED              0x00020005
+#define GLFW_DECORATED 0x00020005
 /*! @brief Window auto-iconification window hint and attribute
  *
  *  Window auto-iconification [window hint](@ref GLFW_AUTO_ICONIFY_hint) and
  *  [window attribute](@ref GLFW_AUTO_ICONIFY_attrib).
  */
-#define GLFW_AUTO_ICONIFY           0x00020006
+#define GLFW_AUTO_ICONIFY 0x00020006
 /*! @brief Window decoration window hint and attribute
  *
  *  Window decoration [window hint](@ref GLFW_FLOATING_hint) and
  *  [window attribute](@ref GLFW_FLOATING_attrib).
  */
-#define GLFW_FLOATING               0x00020007
+#define GLFW_FLOATING 0x00020007
 /*! @brief Window maximization window hint and attribute
  *
  *  Window maximization [window hint](@ref GLFW_MAXIMIZED_hint) and
  *  [window attribute](@ref GLFW_MAXIMIZED_attrib).
  */
-#define GLFW_MAXIMIZED              0x00020008
+#define GLFW_MAXIMIZED 0x00020008
 /*! @brief Cursor centering window hint
  *
  *  Cursor centering [window hint](@ref GLFW_CENTER_CURSOR_hint).
  */
-#define GLFW_CENTER_CURSOR          0x00020009
+#define GLFW_CENTER_CURSOR 0x00020009
 /*! @brief Window framebuffer transparency hint and attribute
  *
  *  Window framebuffer transparency
@@ -914,168 +908,170 @@ extern "C" {
  *
  *  Mouse cursor hover [window attribute](@ref GLFW_HOVERED_attrib).
  */
-#define GLFW_HOVERED                0x0002000B
+#define GLFW_HOVERED 0x0002000B
 /*! @brief Input focus on calling show window hint and attribute
  *
  *  Input focus [window hint](@ref GLFW_FOCUS_ON_SHOW_hint) or
  *  [window attribute](@ref GLFW_FOCUS_ON_SHOW_attrib).
  */
-#define GLFW_FOCUS_ON_SHOW          0x0002000C
+#define GLFW_FOCUS_ON_SHOW 0x0002000C
 
 /*! @brief Mouse input transparency window hint and attribute
  *
  *  Mouse input transparency [window hint](@ref GLFW_MOUSE_PASSTHROUGH_hint) or
  *  [window attribute](@ref GLFW_MOUSE_PASSTHROUGH_attrib).
  */
-#define GLFW_MOUSE_PASSTHROUGH      0x0002000D
+#define GLFW_MOUSE_PASSTHROUGH 0x0002000D
 
 /*! @brief Initial position x-coordinate window hint.
  *
  *  Initial position x-coordinate [window hint](@ref GLFW_POSITION_X).
  */
-#define GLFW_POSITION_X             0x0002000E
+#define GLFW_POSITION_X 0x0002000E
 
 /*! @brief Initial position y-coordinate window hint.
  *
  *  Initial position y-coordinate [window hint](@ref GLFW_POSITION_Y).
  */
-#define GLFW_POSITION_Y             0x0002000F
+#define GLFW_POSITION_Y 0x0002000F
 
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_RED_BITS).
  */
-#define GLFW_RED_BITS               0x00021001
+#define GLFW_RED_BITS 0x00021001
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_GREEN_BITS).
  */
-#define GLFW_GREEN_BITS             0x00021002
+#define GLFW_GREEN_BITS 0x00021002
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_BLUE_BITS).
  */
-#define GLFW_BLUE_BITS              0x00021003
+#define GLFW_BLUE_BITS 0x00021003
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_ALPHA_BITS).
  */
-#define GLFW_ALPHA_BITS             0x00021004
+#define GLFW_ALPHA_BITS 0x00021004
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_DEPTH_BITS).
  */
-#define GLFW_DEPTH_BITS             0x00021005
+#define GLFW_DEPTH_BITS 0x00021005
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_STENCIL_BITS).
  */
-#define GLFW_STENCIL_BITS           0x00021006
+#define GLFW_STENCIL_BITS 0x00021006
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_ACCUM_RED_BITS).
  */
-#define GLFW_ACCUM_RED_BITS         0x00021007
+#define GLFW_ACCUM_RED_BITS 0x00021007
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_ACCUM_GREEN_BITS).
  */
-#define GLFW_ACCUM_GREEN_BITS       0x00021008
+#define GLFW_ACCUM_GREEN_BITS 0x00021008
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_ACCUM_BLUE_BITS).
  */
-#define GLFW_ACCUM_BLUE_BITS        0x00021009
+#define GLFW_ACCUM_BLUE_BITS 0x00021009
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_ACCUM_ALPHA_BITS).
  */
-#define GLFW_ACCUM_ALPHA_BITS       0x0002100A
+#define GLFW_ACCUM_ALPHA_BITS 0x0002100A
 /*! @brief Framebuffer auxiliary buffer hint.
  *
  *  Framebuffer auxiliary buffer [hint](@ref GLFW_AUX_BUFFERS).
  */
-#define GLFW_AUX_BUFFERS            0x0002100B
+#define GLFW_AUX_BUFFERS 0x0002100B
 /*! @brief OpenGL stereoscopic rendering hint.
  *
  *  OpenGL stereoscopic rendering [hint](@ref GLFW_STEREO).
  */
-#define GLFW_STEREO                 0x0002100C
+#define GLFW_STEREO 0x0002100C
 /*! @brief Framebuffer MSAA samples hint.
  *
  *  Framebuffer MSAA samples [hint](@ref GLFW_SAMPLES).
  */
-#define GLFW_SAMPLES                0x0002100D
+#define GLFW_SAMPLES 0x0002100D
 /*! @brief Framebuffer sRGB hint.
  *
  *  Framebuffer sRGB [hint](@ref GLFW_SRGB_CAPABLE).
  */
-#define GLFW_SRGB_CAPABLE           0x0002100E
+#define GLFW_SRGB_CAPABLE 0x0002100E
 /*! @brief Monitor refresh rate hint.
  *
  *  Monitor refresh rate [hint](@ref GLFW_REFRESH_RATE).
  */
-#define GLFW_REFRESH_RATE           0x0002100F
+#define GLFW_REFRESH_RATE 0x0002100F
 /*! @brief Framebuffer double buffering hint and attribute.
  *
  *  Framebuffer double buffering [hint](@ref GLFW_DOUBLEBUFFER_hint) and
  *  [attribute](@ref GLFW_DOUBLEBUFFER_attrib).
  */
-#define GLFW_DOUBLEBUFFER           0x00021010
+#define GLFW_DOUBLEBUFFER 0x00021010
 
 /*! @brief Context client API hint and attribute.
  *
  *  Context client API [hint](@ref GLFW_CLIENT_API_hint) and
  *  [attribute](@ref GLFW_CLIENT_API_attrib).
  */
-#define GLFW_CLIENT_API             0x00022001
+#define GLFW_CLIENT_API 0x00022001
 /*! @brief Context client API major version hint and attribute.
  *
- *  Context client API major version [hint](@ref GLFW_CONTEXT_VERSION_MAJOR_hint)
- *  and [attribute](@ref GLFW_CONTEXT_VERSION_MAJOR_attrib).
+ *  Context client API major version [hint](@ref
+ * GLFW_CONTEXT_VERSION_MAJOR_hint) and [attribute](@ref
+ * GLFW_CONTEXT_VERSION_MAJOR_attrib).
  */
-#define GLFW_CONTEXT_VERSION_MAJOR  0x00022002
+#define GLFW_CONTEXT_VERSION_MAJOR 0x00022002
 /*! @brief Context client API minor version hint and attribute.
  *
- *  Context client API minor version [hint](@ref GLFW_CONTEXT_VERSION_MINOR_hint)
- *  and [attribute](@ref GLFW_CONTEXT_VERSION_MINOR_attrib).
+ *  Context client API minor version [hint](@ref
+ * GLFW_CONTEXT_VERSION_MINOR_hint) and [attribute](@ref
+ * GLFW_CONTEXT_VERSION_MINOR_attrib).
  */
-#define GLFW_CONTEXT_VERSION_MINOR  0x00022003
+#define GLFW_CONTEXT_VERSION_MINOR 0x00022003
 /*! @brief Context client API revision number attribute.
  *
  *  Context client API revision number
  *  [attribute](@ref GLFW_CONTEXT_REVISION_attrib).
  */
-#define GLFW_CONTEXT_REVISION       0x00022004
+#define GLFW_CONTEXT_REVISION 0x00022004
 /*! @brief Context robustness hint and attribute.
  *
  *  Context client API revision number [hint](@ref GLFW_CONTEXT_ROBUSTNESS_hint)
  *  and [attribute](@ref GLFW_CONTEXT_ROBUSTNESS_attrib).
  */
-#define GLFW_CONTEXT_ROBUSTNESS     0x00022005
+#define GLFW_CONTEXT_ROBUSTNESS 0x00022005
 /*! @brief OpenGL forward-compatibility hint and attribute.
  *
  *  OpenGL forward-compatibility [hint](@ref GLFW_OPENGL_FORWARD_COMPAT_hint)
  *  and [attribute](@ref GLFW_OPENGL_FORWARD_COMPAT_attrib).
  */
-#define GLFW_OPENGL_FORWARD_COMPAT  0x00022006
+#define GLFW_OPENGL_FORWARD_COMPAT 0x00022006
 /*! @brief Debug mode context hint and attribute.
  *
  *  Debug mode context [hint](@ref GLFW_CONTEXT_DEBUG_hint) and
  *  [attribute](@ref GLFW_CONTEXT_DEBUG_attrib).
  */
-#define GLFW_CONTEXT_DEBUG          0x00022007
+#define GLFW_CONTEXT_DEBUG 0x00022007
 /*! @brief Legacy name for compatibility.
  *
  *  This is an alias for compatibility with earlier versions.
  */
-#define GLFW_OPENGL_DEBUG_CONTEXT   GLFW_CONTEXT_DEBUG
+#define GLFW_OPENGL_DEBUG_CONTEXT GLFW_CONTEXT_DEBUG
 /*! @brief OpenGL profile hint and attribute.
  *
  *  OpenGL profile [hint](@ref GLFW_OPENGL_PROFILE_hint) and
  *  [attribute](@ref GLFW_OPENGL_PROFILE_attrib).
  */
-#define GLFW_OPENGL_PROFILE         0x00022008
+#define GLFW_OPENGL_PROFILE 0x00022008
 /*! @brief Context flush-on-release hint and attribute.
  *
  *  Context flush-on-release [hint](@ref GLFW_CONTEXT_RELEASE_BEHAVIOR_hint) and
@@ -1087,21 +1083,21 @@ extern "C" {
  *  Context error suppression [hint](@ref GLFW_CONTEXT_NO_ERROR_hint) and
  *  [attribute](@ref GLFW_CONTEXT_NO_ERROR_attrib).
  */
-#define GLFW_CONTEXT_NO_ERROR       0x0002200A
+#define GLFW_CONTEXT_NO_ERROR 0x0002200A
 /*! @brief Context creation API hint and attribute.
  *
  *  Context creation API [hint](@ref GLFW_CONTEXT_CREATION_API_hint) and
  *  [attribute](@ref GLFW_CONTEXT_CREATION_API_attrib).
  */
-#define GLFW_CONTEXT_CREATION_API   0x0002200B
+#define GLFW_CONTEXT_CREATION_API 0x0002200B
 /*! @brief Window content area scaling window
  *  [window hint](@ref GLFW_SCALE_TO_MONITOR).
  */
-#define GLFW_SCALE_TO_MONITOR       0x0002200C
+#define GLFW_SCALE_TO_MONITOR 0x0002200C
 /*! @brief Window framebuffer scaling
  *  [window hint](@ref GLFW_SCALE_FRAMEBUFFER_hint).
  */
-#define GLFW_SCALE_FRAMEBUFFER      0x0002200D
+#define GLFW_SCALE_FRAMEBUFFER 0x0002200D
 /*! @brief Legacy name for compatibility.
  *
  *  This is an alias for the
@@ -1112,7 +1108,7 @@ extern "C" {
 /*! @brief macOS specific
  *  [window hint](@ref GLFW_COCOA_FRAME_NAME_hint).
  */
-#define GLFW_COCOA_FRAME_NAME         0x00023002
+#define GLFW_COCOA_FRAME_NAME 0x00023002
 /*! @brief macOS specific
  *  [window hint](@ref GLFW_COCOA_GRAPHICS_SWITCHING_hint).
  */
@@ -1120,67 +1116,71 @@ extern "C" {
 /*! @brief X11 specific
  *  [window hint](@ref GLFW_X11_CLASS_NAME_hint).
  */
-#define GLFW_X11_CLASS_NAME         0x00024001
+#define GLFW_X11_CLASS_NAME 0x00024001
 /*! @brief X11 specific
  *  [window hint](@ref GLFW_X11_CLASS_NAME_hint).
  */
-#define GLFW_X11_INSTANCE_NAME      0x00024002
-#define GLFW_WIN32_KEYBOARD_MENU    0x00025001
+#define GLFW_X11_INSTANCE_NAME 0x00024002
+#define GLFW_WIN32_KEYBOARD_MENU 0x00025001
 /*! @brief Win32 specific [window hint](@ref GLFW_WIN32_SHOWDEFAULT_hint).
  */
-#define GLFW_WIN32_SHOWDEFAULT      0x00025002
+#define GLFW_WIN32_SHOWDEFAULT 0x00025002
 /*! @brief Wayland specific
  *  [window hint](@ref GLFW_WAYLAND_APP_ID_hint).
- *  
+ *
  *  Allows specification of the Wayland app_id.
  */
-#define GLFW_WAYLAND_APP_ID         0x00026001
+#define GLFW_WAYLAND_APP_ID 0x00026001
+/*! @brief X11 specific
+ *  [window hint](@ref GLFW_X11_OVERRIDE_REDIRECT_hint).
+ */
+#define GLFW_X11_OVERRIDE_REDIRECT 0x00026002
 /*! @} */
 
-#define GLFW_NO_API                          0
-#define GLFW_OPENGL_API             0x00030001
-#define GLFW_OPENGL_ES_API          0x00030002
+#define GLFW_NO_API 0
+#define GLFW_OPENGL_API 0x00030001
+#define GLFW_OPENGL_ES_API 0x00030002
 
-#define GLFW_NO_ROBUSTNESS                   0
-#define GLFW_NO_RESET_NOTIFICATION  0x00031001
-#define GLFW_LOSE_CONTEXT_ON_RESET  0x00031002
+#define GLFW_NO_ROBUSTNESS 0
+#define GLFW_NO_RESET_NOTIFICATION 0x00031001
+#define GLFW_LOSE_CONTEXT_ON_RESET 0x00031002
 
-#define GLFW_OPENGL_ANY_PROFILE              0
-#define GLFW_OPENGL_CORE_PROFILE    0x00032001
-#define GLFW_OPENGL_COMPAT_PROFILE  0x00032002
+#define GLFW_OPENGL_ANY_PROFILE 0
+#define GLFW_OPENGL_CORE_PROFILE 0x00032001
+#define GLFW_OPENGL_COMPAT_PROFILE 0x00032002
 
-#define GLFW_CURSOR                  0x00033001
-#define GLFW_STICKY_KEYS             0x00033002
-#define GLFW_STICKY_MOUSE_BUTTONS    0x00033003
-#define GLFW_LOCK_KEY_MODS           0x00033004
-#define GLFW_RAW_MOUSE_MOTION        0x00033005
+#define GLFW_CURSOR 0x00033001
+#define GLFW_STICKY_KEYS 0x00033002
+#define GLFW_STICKY_MOUSE_BUTTONS 0x00033003
+#define GLFW_LOCK_KEY_MODS 0x00033004
+#define GLFW_RAW_MOUSE_MOTION 0x00033005
 #define GLFW_UNLIMITED_MOUSE_BUTTONS 0x00033006
 
-#define GLFW_CURSOR_NORMAL          0x00034001
-#define GLFW_CURSOR_HIDDEN          0x00034002
-#define GLFW_CURSOR_DISABLED        0x00034003
-#define GLFW_CURSOR_CAPTURED        0x00034004
+#define GLFW_CURSOR_NORMAL 0x00034001
+#define GLFW_CURSOR_HIDDEN 0x00034002
+#define GLFW_CURSOR_DISABLED 0x00034003
+#define GLFW_CURSOR_CAPTURED 0x00034004
 
-#define GLFW_ANY_RELEASE_BEHAVIOR            0
+#define GLFW_ANY_RELEASE_BEHAVIOR 0
 #define GLFW_RELEASE_BEHAVIOR_FLUSH 0x00035001
-#define GLFW_RELEASE_BEHAVIOR_NONE  0x00035002
+#define GLFW_RELEASE_BEHAVIOR_NONE 0x00035002
 
-#define GLFW_NATIVE_CONTEXT_API     0x00036001
-#define GLFW_EGL_CONTEXT_API        0x00036002
-#define GLFW_OSMESA_CONTEXT_API     0x00036003
+#define GLFW_NATIVE_CONTEXT_API 0x00036001
+#define GLFW_EGL_CONTEXT_API 0x00036002
+#define GLFW_OSMESA_CONTEXT_API 0x00036003
 
-#define GLFW_ANGLE_PLATFORM_TYPE_NONE    0x00037001
-#define GLFW_ANGLE_PLATFORM_TYPE_OPENGL  0x00037002
+#define GLFW_ANGLE_PLATFORM_TYPE_NONE 0x00037001
+#define GLFW_ANGLE_PLATFORM_TYPE_OPENGL 0x00037002
 #define GLFW_ANGLE_PLATFORM_TYPE_OPENGLES 0x00037003
-#define GLFW_ANGLE_PLATFORM_TYPE_D3D9    0x00037004
-#define GLFW_ANGLE_PLATFORM_TYPE_D3D11   0x00037005
-#define GLFW_ANGLE_PLATFORM_TYPE_VULKAN  0x00037007
-#define GLFW_ANGLE_PLATFORM_TYPE_METAL   0x00037008
+#define GLFW_ANGLE_PLATFORM_TYPE_D3D9 0x00037004
+#define GLFW_ANGLE_PLATFORM_TYPE_D3D11 0x00037005
+#define GLFW_ANGLE_PLATFORM_TYPE_VULKAN 0x00037007
+#define GLFW_ANGLE_PLATFORM_TYPE_METAL 0x00037008
 
-#define GLFW_WAYLAND_PREFER_LIBDECOR    0x00038001
-#define GLFW_WAYLAND_DISABLE_LIBDECOR   0x00038002
+#define GLFW_WAYLAND_PREFER_LIBDECOR 0x00038001
+#define GLFW_WAYLAND_DISABLE_LIBDECOR 0x00038002
 
-#define GLFW_ANY_POSITION           0x80000000
+#define GLFW_ANY_POSITION 0x80000000
 
 /*! @defgroup shapes Standard cursor shapes
  *  @brief Standard system cursor shapes.
@@ -1195,34 +1195,34 @@ extern "C" {
  *
  *  The regular arrow cursor shape.
  */
-#define GLFW_ARROW_CURSOR           0x00036001
+#define GLFW_ARROW_CURSOR 0x00036001
 /*! @brief The text input I-beam cursor shape.
  *
  *  The text input I-beam cursor shape.
  */
-#define GLFW_IBEAM_CURSOR           0x00036002
+#define GLFW_IBEAM_CURSOR 0x00036002
 /*! @brief The crosshair cursor shape.
  *
  *  The crosshair cursor shape.
  */
-#define GLFW_CROSSHAIR_CURSOR       0x00036003
+#define GLFW_CROSSHAIR_CURSOR 0x00036003
 /*! @brief The pointing hand cursor shape.
  *
  *  The pointing hand cursor shape.
  */
-#define GLFW_POINTING_HAND_CURSOR   0x00036004
+#define GLFW_POINTING_HAND_CURSOR 0x00036004
 /*! @brief The horizontal resize/move arrow shape.
  *
  *  The horizontal resize/move arrow shape.  This is usually a horizontal
  *  double-headed arrow.
  */
-#define GLFW_RESIZE_EW_CURSOR       0x00036005
+#define GLFW_RESIZE_EW_CURSOR 0x00036005
 /*! @brief The vertical resize/move arrow shape.
  *
  *  The vertical resize/move shape.  This is usually a vertical double-headed
  *  arrow.
  */
-#define GLFW_RESIZE_NS_CURSOR       0x00036006
+#define GLFW_RESIZE_NS_CURSOR 0x00036006
 /*! @brief The top-left to bottom-right diagonal resize/move arrow shape.
  *
  *  The top-left to bottom-right diagonal resize/move shape.  This is usually
@@ -1231,13 +1231,13 @@ extern "C" {
  *  @note __macOS:__ This shape is provided by a private system API and may fail
  *  with @ref GLFW_CURSOR_UNAVAILABLE in the future.
  *
- *  @note __Wayland:__ This shape is provided by a newer standard not supported by
- *  all cursor themes.
+ *  @note __Wayland:__ This shape is provided by a newer standard not supported
+ * by all cursor themes.
  *
- *  @note __X11:__ This shape is provided by a newer standard not supported by all
- *  cursor themes.
+ *  @note __X11:__ This shape is provided by a newer standard not supported by
+ * all cursor themes.
  */
-#define GLFW_RESIZE_NWSE_CURSOR     0x00036007
+#define GLFW_RESIZE_NWSE_CURSOR 0x00036007
 /*! @brief The top-right to bottom-left diagonal resize/move arrow shape.
  *
  *  The top-right to bottom-left diagonal resize/move shape.  This is usually
@@ -1246,50 +1246,50 @@ extern "C" {
  *  @note __macOS:__ This shape is provided by a private system API and may fail
  *  with @ref GLFW_CURSOR_UNAVAILABLE in the future.
  *
- *  @note __Wayland:__ This shape is provided by a newer standard not supported by
- *  all cursor themes.
+ *  @note __Wayland:__ This shape is provided by a newer standard not supported
+ * by all cursor themes.
  *
- *  @note __X11:__ This shape is provided by a newer standard not supported by all
- *  cursor themes.
+ *  @note __X11:__ This shape is provided by a newer standard not supported by
+ * all cursor themes.
  */
-#define GLFW_RESIZE_NESW_CURSOR     0x00036008
+#define GLFW_RESIZE_NESW_CURSOR 0x00036008
 /*! @brief The omni-directional resize/move cursor shape.
  *
  *  The omni-directional resize cursor/move shape.  This is usually either
  *  a combined horizontal and vertical double-headed arrow or a grabbing hand.
  */
-#define GLFW_RESIZE_ALL_CURSOR      0x00036009
+#define GLFW_RESIZE_ALL_CURSOR 0x00036009
 /*! @brief The operation-not-allowed shape.
  *
  *  The operation-not-allowed shape.  This is usually a circle with a diagonal
  *  line through it.
  *
- *  @note __Wayland:__ This shape is provided by a newer standard not supported by
- *  all cursor themes.
+ *  @note __Wayland:__ This shape is provided by a newer standard not supported
+ * by all cursor themes.
  *
- *  @note __X11:__ This shape is provided by a newer standard not supported by all
- *  cursor themes.
+ *  @note __X11:__ This shape is provided by a newer standard not supported by
+ * all cursor themes.
  */
-#define GLFW_NOT_ALLOWED_CURSOR     0x0003600A
+#define GLFW_NOT_ALLOWED_CURSOR 0x0003600A
 /*! @brief Legacy name for compatibility.
  *
  *  This is an alias for compatibility with earlier versions.
  */
-#define GLFW_HRESIZE_CURSOR         GLFW_RESIZE_EW_CURSOR
+#define GLFW_HRESIZE_CURSOR GLFW_RESIZE_EW_CURSOR
 /*! @brief Legacy name for compatibility.
  *
  *  This is an alias for compatibility with earlier versions.
  */
-#define GLFW_VRESIZE_CURSOR         GLFW_RESIZE_NS_CURSOR
+#define GLFW_VRESIZE_CURSOR GLFW_RESIZE_NS_CURSOR
 /*! @brief Legacy name for compatibility.
  *
  *  This is an alias for compatibility with earlier versions.
  */
-#define GLFW_HAND_CURSOR            GLFW_POINTING_HAND_CURSOR
+#define GLFW_HAND_CURSOR GLFW_POINTING_HAND_CURSOR
 /*! @} */
 
-#define GLFW_CONNECTED              0x00040001
-#define GLFW_DISCONNECTED           0x00040002
+#define GLFW_CONNECTED 0x00040001
+#define GLFW_DISCONNECTED 0x00040002
 
 /*! @addtogroup init
  *  @{ */
@@ -1297,27 +1297,27 @@ extern "C" {
  *
  *  Joystick hat buttons [init hint](@ref GLFW_JOYSTICK_HAT_BUTTONS).
  */
-#define GLFW_JOYSTICK_HAT_BUTTONS   0x00050001
+#define GLFW_JOYSTICK_HAT_BUTTONS 0x00050001
 /*! @brief ANGLE rendering backend init hint.
  *
  *  ANGLE rendering backend [init hint](@ref GLFW_ANGLE_PLATFORM_TYPE_hint).
  */
-#define GLFW_ANGLE_PLATFORM_TYPE    0x00050002
+#define GLFW_ANGLE_PLATFORM_TYPE 0x00050002
 /*! @brief Platform selection init hint.
  *
  *  Platform selection [init hint](@ref GLFW_PLATFORM).
  */
-#define GLFW_PLATFORM               0x00050003
+#define GLFW_PLATFORM 0x00050003
 /*! @brief macOS specific init hint.
  *
  *  macOS specific [init hint](@ref GLFW_COCOA_CHDIR_RESOURCES_hint).
  */
-#define GLFW_COCOA_CHDIR_RESOURCES  0x00051001
+#define GLFW_COCOA_CHDIR_RESOURCES 0x00051001
 /*! @brief macOS specific init hint.
  *
  *  macOS specific [init hint](@ref GLFW_COCOA_MENUBAR_hint).
  */
-#define GLFW_COCOA_MENUBAR          0x00051002
+#define GLFW_COCOA_MENUBAR 0x00051002
 /*! @brief X11 specific init hint.
  *
  *  X11 specific [init hint](@ref GLFW_X11_XCB_VULKAN_SURFACE_hint).
@@ -1327,7 +1327,7 @@ extern "C" {
  *
  *  Wayland specific [init hint](@ref GLFW_WAYLAND_LIBDECOR_hint).
  */
-#define GLFW_WAYLAND_LIBDECOR       0x00053001
+#define GLFW_WAYLAND_LIBDECOR 0x00053001
 /*! @} */
 
 /*! @addtogroup init
@@ -1336,20 +1336,19 @@ extern "C" {
  *
  *  Hint value for @ref GLFW_PLATFORM that enables automatic platform selection.
  */
-#define GLFW_ANY_PLATFORM           0x00060000
-#define GLFW_PLATFORM_WIN32         0x00060001
-#define GLFW_PLATFORM_COCOA         0x00060002
-#define GLFW_PLATFORM_WAYLAND       0x00060003
-#define GLFW_PLATFORM_X11           0x00060004
-#define GLFW_PLATFORM_NULL          0x00060005
+#define GLFW_ANY_PLATFORM 0x00060000
+#define GLFW_PLATFORM_WIN32 0x00060001
+#define GLFW_PLATFORM_COCOA 0x00060002
+#define GLFW_PLATFORM_WAYLAND 0x00060003
+#define GLFW_PLATFORM_X11 0x00060004
+#define GLFW_PLATFORM_NULL 0x00060005
 /*! @} */
 
 /* Reserved platform define for external Emscripten ports: 0x00060006
  * See https://github.com/pongasoft/emscripten-glfw
  */
 
-#define GLFW_DONT_CARE              -1
-
+#define GLFW_DONT_CARE -1
 
 /*************************************************************************
  * GLFW API types
@@ -1428,23 +1427,23 @@ typedef struct GLFWcursor GLFWcursor;
  *  @endcode
  *
  *  This function must return either a memory block at least `size` bytes long,
- *  or `NULL` if allocation failed.  Note that not all parts of GLFW handle allocation
- *  failures gracefully yet.
+ *  or `NULL` if allocation failed.  Note that not all parts of GLFW handle
+ * allocation failures gracefully yet.
  *
- *  This function must support being called during @ref glfwInit but before the library is
- *  flagged as initialized, as well as during @ref glfwTerminate after the library is no
- *  longer flagged as initialized.
+ *  This function must support being called during @ref glfwInit but before the
+ * library is flagged as initialized, as well as during @ref glfwTerminate after
+ * the library is no longer flagged as initialized.
  *
- *  Any memory allocated via this function will be deallocated via the same allocator
- *  during library termination or earlier.
+ *  Any memory allocated via this function will be deallocated via the same
+ * allocator during library termination or earlier.
  *
- *  Any memory allocated via this function must be suitably aligned for any object type.
- *  If you are using C99 or earlier, this alignment is platform-dependent but will be the
- *  same as what `malloc` provides.  If you are using C11 or later, this is the value of
- *  `alignof(max_align_t)`.
+ *  Any memory allocated via this function must be suitably aligned for any
+ * object type. If you are using C99 or earlier, this alignment is
+ * platform-dependent but will be the same as what `malloc` provides.  If you
+ * are using C11 or later, this is the value of `alignof(max_align_t)`.
  *
- *  The size will always be greater than zero.  Allocations of size zero are filtered out
- *  before reaching the custom allocator.
+ *  The size will always be greater than zero.  Allocations of size zero are
+ * filtered out before reaching the custom allocator.
  *
  *  If this function returns `NULL`, GLFW will emit @ref GLFW_OUT_OF_MEMORY.
  *
@@ -1460,8 +1459,8 @@ typedef struct GLFWcursor GLFWcursor;
  *
  *  @reentrancy This function should not call any GLFW function.
  *
- *  @thread_safety This function must support being called from any thread that calls GLFW
- *  functions.
+ *  @thread_safety This function must support being called from any thread that
+ * calls GLFW functions.
  *
  *  @sa @ref init_allocator
  *  @sa @ref GLFWallocator
@@ -1470,7 +1469,7 @@ typedef struct GLFWcursor GLFWcursor;
  *
  *  @ingroup init
  */
-typedef void* (* GLFWallocatefun)(size_t size, void* user);
+typedef void *(*GLFWallocatefun)(size_t size, void *user);
 
 /*! @brief The function pointer type for memory reallocation callbacks.
  *
@@ -1481,25 +1480,26 @@ typedef void* (* GLFWallocatefun)(size_t size, void* user);
  *  @endcode
  *
  *  This function must return a memory block at least `size` bytes long, or
- *  `NULL` if allocation failed.  Note that not all parts of GLFW handle allocation
- *  failures gracefully yet.
+ *  `NULL` if allocation failed.  Note that not all parts of GLFW handle
+ * allocation failures gracefully yet.
  *
- *  This function must support being called during @ref glfwInit but before the library is
- *  flagged as initialized, as well as during @ref glfwTerminate after the library is no
- *  longer flagged as initialized.
+ *  This function must support being called during @ref glfwInit but before the
+ * library is flagged as initialized, as well as during @ref glfwTerminate after
+ * the library is no longer flagged as initialized.
  *
- *  Any memory allocated via this function will be deallocated via the same allocator
- *  during library termination or earlier.
+ *  Any memory allocated via this function will be deallocated via the same
+ * allocator during library termination or earlier.
  *
- *  Any memory allocated via this function must be suitably aligned for any object type.
- *  If you are using C99 or earlier, this alignment is platform-dependent but will be the
- *  same as what `realloc` provides.  If you are using C11 or later, this is the value of
- *  `alignof(max_align_t)`.
+ *  Any memory allocated via this function must be suitably aligned for any
+ * object type. If you are using C99 or earlier, this alignment is
+ * platform-dependent but will be the same as what `realloc` provides.  If you
+ * are using C11 or later, this is the value of `alignof(max_align_t)`.
  *
- *  The block address will never be `NULL` and the size will always be greater than zero.
- *  Reallocations of a block to size zero are converted into deallocations before reaching
- *  the custom allocator.  Reallocations of `NULL` to a non-zero size are converted into
- *  regular allocations before reaching the custom allocator.
+ *  The block address will never be `NULL` and the size will always be greater
+ * than zero. Reallocations of a block to size zero are converted into
+ * deallocations before reaching the custom allocator.  Reallocations of `NULL`
+ * to a non-zero size are converted into regular allocations before reaching the
+ * custom allocator.
  *
  *  If this function returns `NULL`, GLFW will emit @ref GLFW_OUT_OF_MEMORY.
  *
@@ -1516,8 +1516,8 @@ typedef void* (* GLFWallocatefun)(size_t size, void* user);
  *
  *  @reentrancy This function should not call any GLFW function.
  *
- *  @thread_safety This function must support being called from any thread that calls GLFW
- *  functions.
+ *  @thread_safety This function must support being called from any thread that
+ * calls GLFW functions.
  *
  *  @sa @ref init_allocator
  *  @sa @ref GLFWallocator
@@ -1526,7 +1526,7 @@ typedef void* (* GLFWallocatefun)(size_t size, void* user);
  *
  *  @ingroup init
  */
-typedef void* (* GLFWreallocatefun)(void* block, size_t size, void* user);
+typedef void *(*GLFWreallocatefun)(void *block, size_t size, void *user);
 
 /*! @brief The function pointer type for memory deallocation callbacks.
  *
@@ -1539,12 +1539,12 @@ typedef void* (* GLFWreallocatefun)(void* block, size_t size, void* user);
  *  This function may deallocate the specified memory block.  This memory block
  *  will have been allocated with the same allocator.
  *
- *  This function must support being called during @ref glfwInit but before the library is
- *  flagged as initialized, as well as during @ref glfwTerminate after the library is no
- *  longer flagged as initialized.
+ *  This function must support being called during @ref glfwInit but before the
+ * library is flagged as initialized, as well as during @ref glfwTerminate after
+ * the library is no longer flagged as initialized.
  *
- *  The block address will never be `NULL`.  Deallocations of `NULL` are filtered out
- *  before reaching the custom allocator.
+ *  The block address will never be `NULL`.  Deallocations of `NULL` are
+ * filtered out before reaching the custom allocator.
  *
  *  If this function returns `NULL`, GLFW will emit @ref GLFW_OUT_OF_MEMORY.
  *
@@ -1558,8 +1558,8 @@ typedef void* (* GLFWreallocatefun)(void* block, size_t size, void* user);
  *
  *  @reentrancy This function should not call any GLFW function.
  *
- *  @thread_safety This function must support being called from any thread that calls GLFW
- *  functions.
+ *  @thread_safety This function must support being called from any thread that
+ * calls GLFW functions.
  *
  *  @sa @ref init_allocator
  *  @sa @ref GLFWallocator
@@ -1568,7 +1568,7 @@ typedef void* (* GLFWreallocatefun)(void* block, size_t size, void* user);
  *
  *  @ingroup init
  */
-typedef void (* GLFWdeallocatefun)(void* block, void* user);
+typedef void (*GLFWdeallocatefun)(void *block, void *user);
 
 /*! @brief The function pointer type for error callbacks.
  *
@@ -1592,7 +1592,7 @@ typedef void (* GLFWdeallocatefun)(void* block, void* user);
  *
  *  @ingroup init
  */
-typedef void (* GLFWerrorfun)(int error_code, const char* description);
+typedef void (*GLFWerrorfun)(int error_code, const char *description);
 
 /*! @brief The function pointer type for window position callbacks.
  *
@@ -1615,7 +1615,7 @@ typedef void (* GLFWerrorfun)(int error_code, const char* description);
  *
  *  @ingroup window
  */
-typedef void (* GLFWwindowposfun)(GLFWwindow* window, int xpos, int ypos);
+typedef void (*GLFWwindowposfun)(GLFWwindow *window, int xpos, int ypos);
 
 /*! @brief The function pointer type for window size callbacks.
  *
@@ -1637,7 +1637,7 @@ typedef void (* GLFWwindowposfun)(GLFWwindow* window, int xpos, int ypos);
  *
  *  @ingroup window
  */
-typedef void (* GLFWwindowsizefun)(GLFWwindow* window, int width, int height);
+typedef void (*GLFWwindowsizefun)(GLFWwindow *window, int width, int height);
 
 /*! @brief The function pointer type for window close callbacks.
  *
@@ -1657,7 +1657,7 @@ typedef void (* GLFWwindowsizefun)(GLFWwindow* window, int width, int height);
  *
  *  @ingroup window
  */
-typedef void (* GLFWwindowclosefun)(GLFWwindow* window);
+typedef void (*GLFWwindowclosefun)(GLFWwindow *window);
 
 /*! @brief The function pointer type for window content refresh callbacks.
  *
@@ -1677,7 +1677,7 @@ typedef void (* GLFWwindowclosefun)(GLFWwindow* window);
  *
  *  @ingroup window
  */
-typedef void (* GLFWwindowrefreshfun)(GLFWwindow* window);
+typedef void (*GLFWwindowrefreshfun)(GLFWwindow *window);
 
 /*! @brief The function pointer type for window focus callbacks.
  *
@@ -1698,7 +1698,7 @@ typedef void (* GLFWwindowrefreshfun)(GLFWwindow* window);
  *
  *  @ingroup window
  */
-typedef void (* GLFWwindowfocusfun)(GLFWwindow* window, int focused);
+typedef void (*GLFWwindowfocusfun)(GLFWwindow *window, int focused);
 
 /*! @brief The function pointer type for window iconify callbacks.
  *
@@ -1719,7 +1719,7 @@ typedef void (* GLFWwindowfocusfun)(GLFWwindow* window, int focused);
  *
  *  @ingroup window
  */
-typedef void (* GLFWwindowiconifyfun)(GLFWwindow* window, int iconified);
+typedef void (*GLFWwindowiconifyfun)(GLFWwindow *window, int iconified);
 
 /*! @brief The function pointer type for window maximize callbacks.
  *
@@ -1740,7 +1740,7 @@ typedef void (* GLFWwindowiconifyfun)(GLFWwindow* window, int iconified);
  *
  *  @ingroup window
  */
-typedef void (* GLFWwindowmaximizefun)(GLFWwindow* window, int maximized);
+typedef void (*GLFWwindowmaximizefun)(GLFWwindow *window, int maximized);
 
 /*! @brief The function pointer type for framebuffer size callbacks.
  *
@@ -1761,7 +1761,8 @@ typedef void (* GLFWwindowmaximizefun)(GLFWwindow* window, int maximized);
  *
  *  @ingroup window
  */
-typedef void (* GLFWframebuffersizefun)(GLFWwindow* window, int width, int height);
+typedef void (*GLFWframebuffersizefun)(GLFWwindow *window, int width,
+                                       int height);
 
 /*! @brief The function pointer type for window content scale callbacks.
  *
@@ -1782,7 +1783,8 @@ typedef void (* GLFWframebuffersizefun)(GLFWwindow* window, int width, int heigh
  *
  *  @ingroup window
  */
-typedef void (* GLFWwindowcontentscalefun)(GLFWwindow* window, float xscale, float yscale);
+typedef void (*GLFWwindowcontentscalefun)(GLFWwindow *window, float xscale,
+                                          float yscale);
 
 /*! @brief The function pointer type for mouse button callbacks.
  *
@@ -1808,7 +1810,8 @@ typedef void (* GLFWwindowcontentscalefun)(GLFWwindow* window, float xscale, flo
  *
  *  @ingroup input
  */
-typedef void (* GLFWmousebuttonfun)(GLFWwindow* window, int button, int action, int mods);
+typedef void (*GLFWmousebuttonfun)(GLFWwindow *window, int button, int action,
+                                   int mods);
 
 /*! @brief The function pointer type for cursor position callbacks.
  *
@@ -1831,7 +1834,7 @@ typedef void (* GLFWmousebuttonfun)(GLFWwindow* window, int button, int action, 
  *
  *  @ingroup input
  */
-typedef void (* GLFWcursorposfun)(GLFWwindow* window, double xpos, double ypos);
+typedef void (*GLFWcursorposfun)(GLFWwindow *window, double xpos, double ypos);
 
 /*! @brief The function pointer type for cursor enter/leave callbacks.
  *
@@ -1852,7 +1855,7 @@ typedef void (* GLFWcursorposfun)(GLFWwindow* window, double xpos, double ypos);
  *
  *  @ingroup input
  */
-typedef void (* GLFWcursorenterfun)(GLFWwindow* window, int entered);
+typedef void (*GLFWcursorenterfun)(GLFWwindow *window, int entered);
 
 /*! @brief The function pointer type for scroll callbacks.
  *
@@ -1873,14 +1876,16 @@ typedef void (* GLFWcursorenterfun)(GLFWwindow* window, int entered);
  *
  *  @ingroup input
  */
-typedef void (* GLFWscrollfun)(GLFWwindow* window, double xoffset, double yoffset);
+typedef void (*GLFWscrollfun)(GLFWwindow *window, double xoffset,
+                              double yoffset);
 
 /*! @brief The function pointer type for keyboard key callbacks.
  *
  *  This is the function pointer type for keyboard key callbacks.  A keyboard
  *  key callback function has the following signature:
  *  @code
- *  void function_name(GLFWwindow* window, int key, int scancode, int action, int mods)
+ *  void function_name(GLFWwindow* window, int key, int scancode, int action,
+ * int mods)
  *  @endcode
  *
  *  @param[in] window The window that received the event.
@@ -1899,7 +1904,8 @@ typedef void (* GLFWscrollfun)(GLFWwindow* window, double xoffset, double yoffse
  *
  *  @ingroup input
  */
-typedef void (* GLFWkeyfun)(GLFWwindow* window, int key, int scancode, int action, int mods);
+typedef void (*GLFWkeyfun)(GLFWwindow *window, int key, int scancode,
+                           int action, int mods);
 
 /*! @brief The function pointer type for Unicode character callbacks.
  *
@@ -1920,7 +1926,7 @@ typedef void (* GLFWkeyfun)(GLFWwindow* window, int key, int scancode, int actio
  *
  *  @ingroup input
  */
-typedef void (* GLFWcharfun)(GLFWwindow* window, unsigned int codepoint);
+typedef void (*GLFWcharfun)(GLFWwindow *window, unsigned int codepoint);
 
 /*! @brief The function pointer type for Unicode character with modifiers
  *  callbacks.
@@ -1947,7 +1953,8 @@ typedef void (* GLFWcharfun)(GLFWwindow* window, unsigned int codepoint);
  *
  *  @ingroup input
  */
-typedef void (* GLFWcharmodsfun)(GLFWwindow* window, unsigned int codepoint, int mods);
+typedef void (*GLFWcharmodsfun)(GLFWwindow *window, unsigned int codepoint,
+                                int mods);
 
 /*! @brief The function pointer type for path drop callbacks.
  *
@@ -1971,7 +1978,8 @@ typedef void (* GLFWcharmodsfun)(GLFWwindow* window, unsigned int codepoint, int
  *
  *  @ingroup input
  */
-typedef void (* GLFWdropfun)(GLFWwindow* window, int path_count, const char* paths[]);
+typedef void (*GLFWdropfun)(GLFWwindow *window, int path_count,
+                            const char *paths[]);
 
 /*! @brief The function pointer type for monitor configuration callbacks.
  *
@@ -1992,7 +2000,7 @@ typedef void (* GLFWdropfun)(GLFWwindow* window, int path_count, const char* pat
  *
  *  @ingroup monitor
  */
-typedef void (* GLFWmonitorfun)(GLFWmonitor* monitor, int event);
+typedef void (*GLFWmonitorfun)(GLFWmonitor *monitor, int event);
 
 /*! @brief The function pointer type for joystick configuration callbacks.
  *
@@ -2013,7 +2021,7 @@ typedef void (* GLFWmonitorfun)(GLFWmonitor* monitor, int event);
  *
  *  @ingroup input
  */
-typedef void (* GLFWjoystickfun)(int jid, int event);
+typedef void (*GLFWjoystickfun)(int jid, int event);
 
 /*! @brief Video mode type.
  *
@@ -2028,26 +2036,25 @@ typedef void (* GLFWjoystickfun)(int jid, int event);
  *
  *  @ingroup monitor
  */
-typedef struct GLFWvidmode
-{
-    /*! The width, in screen coordinates, of the video mode.
-     */
-    int width;
-    /*! The height, in screen coordinates, of the video mode.
-     */
-    int height;
-    /*! The bit depth of the red channel of the video mode.
-     */
-    int redBits;
-    /*! The bit depth of the green channel of the video mode.
-     */
-    int greenBits;
-    /*! The bit depth of the blue channel of the video mode.
-     */
-    int blueBits;
-    /*! The refresh rate, in Hz, of the video mode.
-     */
-    int refreshRate;
+typedef struct GLFWvidmode {
+  /*! The width, in screen coordinates, of the video mode.
+   */
+  int width;
+  /*! The height, in screen coordinates, of the video mode.
+   */
+  int height;
+  /*! The bit depth of the red channel of the video mode.
+   */
+  int redBits;
+  /*! The bit depth of the green channel of the video mode.
+   */
+  int greenBits;
+  /*! The bit depth of the blue channel of the video mode.
+   */
+  int blueBits;
+  /*! The refresh rate, in Hz, of the video mode.
+   */
+  int refreshRate;
 } GLFWvidmode;
 
 /*! @brief Gamma ramp.
@@ -2062,20 +2069,19 @@ typedef struct GLFWvidmode
  *
  *  @ingroup monitor
  */
-typedef struct GLFWgammaramp
-{
-    /*! An array of value describing the response of the red channel.
-     */
-    unsigned short* red;
-    /*! An array of value describing the response of the green channel.
-     */
-    unsigned short* green;
-    /*! An array of value describing the response of the blue channel.
-     */
-    unsigned short* blue;
-    /*! The number of elements in each array.
-     */
-    unsigned int size;
+typedef struct GLFWgammaramp {
+  /*! An array of value describing the response of the red channel.
+   */
+  unsigned short *red;
+  /*! An array of value describing the response of the green channel.
+   */
+  unsigned short *green;
+  /*! An array of value describing the response of the blue channel.
+   */
+  unsigned short *blue;
+  /*! The number of elements in each array.
+   */
+  unsigned int size;
 } GLFWgammaramp;
 
 /*! @brief Image data.
@@ -2091,17 +2097,16 @@ typedef struct GLFWgammaramp
  *
  *  @ingroup window
  */
-typedef struct GLFWimage
-{
-    /*! The width, in pixels, of this image.
-     */
-    int width;
-    /*! The height, in pixels, of this image.
-     */
-    int height;
-    /*! The pixel data of this image, arranged left-to-right, top-to-bottom.
-     */
-    unsigned char* pixels;
+typedef struct GLFWimage {
+  /*! The width, in pixels, of this image.
+   */
+  int width;
+  /*! The height, in pixels, of this image.
+   */
+  int height;
+  /*! The pixel data of this image, arranged left-to-right, top-to-bottom.
+   */
+  unsigned char *pixels;
 } GLFWimage;
 
 /*! @brief Gamepad input state
@@ -2115,22 +2120,21 @@ typedef struct GLFWimage
  *
  *  @ingroup input
  */
-typedef struct GLFWgamepadstate
-{
-    /*! The states of each [gamepad button](@ref gamepad_buttons), `GLFW_PRESS`
-     *  or `GLFW_RELEASE`.
-     */
-    unsigned char buttons[15];
-    /*! The states of each [gamepad axis](@ref gamepad_axes), in the range -1.0
-     *  to 1.0 inclusive.
-     */
-    float axes[6];
+typedef struct GLFWgamepadstate {
+  /*! The states of each [gamepad button](@ref gamepad_buttons), `GLFW_PRESS`
+   *  or `GLFW_RELEASE`.
+   */
+  unsigned char buttons[15];
+  /*! The states of each [gamepad axis](@ref gamepad_axes), in the range -1.0
+   *  to 1.0 inclusive.
+   */
+  float axes[6];
 } GLFWgamepadstate;
 
 /*! @brief Custom heap memory allocator.
  *
- *  This describes a custom heap memory allocator for GLFW.  To set an allocator, pass it
- *  to @ref glfwInitAllocator before initializing the library.
+ *  This describes a custom heap memory allocator for GLFW.  To set an
+ * allocator, pass it to @ref glfwInitAllocator before initializing the library.
  *
  *  @sa @ref init_allocator
  *  @sa @ref glfwInitAllocator
@@ -2139,26 +2143,24 @@ typedef struct GLFWgamepadstate
  *
  *  @ingroup init
  */
-typedef struct GLFWallocator
-{
-    /*! The memory allocation function.  See @ref GLFWallocatefun for details about
-     *  allocation function.
-     */
-    GLFWallocatefun allocate;
-    /*! The memory reallocation function.  See @ref GLFWreallocatefun for details about
-     *  reallocation function.
-     */
-    GLFWreallocatefun reallocate;
-    /*! The memory deallocation function.  See @ref GLFWdeallocatefun for details about
-     *  deallocation function.
-     */
-    GLFWdeallocatefun deallocate;
-    /*! The user pointer for this custom allocator.  This value will be passed to the
-     *  allocator functions.
-     */
-    void* user;
+typedef struct GLFWallocator {
+  /*! The memory allocation function.  See @ref GLFWallocatefun for details
+   * about allocation function.
+   */
+  GLFWallocatefun allocate;
+  /*! The memory reallocation function.  See @ref GLFWreallocatefun for details
+   * about reallocation function.
+   */
+  GLFWreallocatefun reallocate;
+  /*! The memory deallocation function.  See @ref GLFWdeallocatefun for details
+   * about deallocation function.
+   */
+  GLFWdeallocatefun deallocate;
+  /*! The user pointer for this custom allocator.  This value will be passed to
+   * the allocator functions.
+   */
+  void *user;
 } GLFWallocator;
-
 
 /*************************************************************************
  * GLFW API functions
@@ -2177,9 +2179,9 @@ typedef struct GLFWallocator
  *  Additional calls to this function after successful initialization but before
  *  termination will return `GLFW_TRUE` immediately.
  *
- *  The @ref GLFW_PLATFORM init hint controls which platforms are considered during
- *  initialization.  This also depends on which platforms the library was compiled to
- *  support.
+ *  The @ref GLFW_PLATFORM init hint controls which platforms are considered
+ * during initialization.  This also depends on which platforms the library was
+ * compiled to support.
  *
  *  @return `GLFW_TRUE` if successful, or `GLFW_FALSE` if an
  *  [error](@ref error_handling) occurred.
@@ -2192,8 +2194,8 @@ typedef struct GLFWallocator
  *  bundle, if present.  This can be disabled with the @ref
  *  GLFW_COCOA_CHDIR_RESOURCES init hint.
  *
- *  @remark __macOS:__ This function will create the main menu and dock icon for the
- *  application.  If GLFW finds a `MainMenu.nib` it is loaded and assumed to
+ *  @remark __macOS:__ This function will create the main menu and dock icon for
+ * the application.  If GLFW finds a `MainMenu.nib` it is loaded and assumed to
  *  contain a menu bar.  Otherwise a minimal menu bar is created manually with
  *  common commands like Hide, Quit and About.  The About entry opens a minimal
  *  about dialog with information from the application's bundle.  The menu bar
@@ -2298,8 +2300,8 @@ GLFWAPI void glfwInitHint(int hint, int value);
  *  pointer.  If any member is `NULL`, this function will emit @ref
  *  GLFW_INVALID_VALUE and the init allocator will be unchanged.
  *
- *  The functions in the allocator must fulfil a number of requirements.  See the
- *  documentation for @ref GLFWallocatefun, @ref GLFWreallocatefun and @ref
+ *  The functions in the allocator must fulfil a number of requirements.  See
+ * the documentation for @ref GLFWallocatefun, @ref GLFWreallocatefun and @ref
  *  GLFWdeallocatefun for details.
  *
  *  @param[in] allocator The allocator to use at the next initialization, or
@@ -2319,35 +2321,38 @@ GLFWAPI void glfwInitHint(int hint, int value);
  *
  *  @ingroup init
  */
-GLFWAPI void glfwInitAllocator(const GLFWallocator* allocator);
+GLFWAPI void glfwInitAllocator(const GLFWallocator *allocator);
 
 #if defined(VK_VERSION_1_0)
 
 /*! @brief Sets the desired Vulkan `vkGetInstanceProcAddr` function.
  *
- *  This function sets the `vkGetInstanceProcAddr` function that GLFW will use for all
- *  Vulkan related entry point queries.
+ *  This function sets the `vkGetInstanceProcAddr` function that GLFW will use
+ * for all Vulkan related entry point queries.
  *
- *  This feature is mostly useful on macOS, if your copy of the Vulkan loader is in
- *  a location where GLFW cannot find it through dynamic loading, or if you are still
- *  using the static library version of the loader.
+ *  This feature is mostly useful on macOS, if your copy of the Vulkan loader is
+ * in a location where GLFW cannot find it through dynamic loading, or if you
+ * are still using the static library version of the loader.
  *
- *  If set to `NULL`, GLFW will try to load the Vulkan loader dynamically by its standard
- *  name and get this function from there.  This is the default behavior.
+ *  If set to `NULL`, GLFW will try to load the Vulkan loader dynamically by its
+ * standard name and get this function from there.  This is the default
+ * behavior.
  *
- *  The standard name of the loader is `vulkan-1.dll` on Windows, `libvulkan.so.1` on
- *  Linux and other Unix-like systems and `libvulkan.1.dylib` on macOS.  If your code is
- *  also loading it via these names then you probably don't need to use this function.
+ *  The standard name of the loader is `vulkan-1.dll` on Windows,
+ * `libvulkan.so.1` on Linux and other Unix-like systems and `libvulkan.1.dylib`
+ * on macOS.  If your code is also loading it via these names then you probably
+ * don't need to use this function.
  *
- *  The function address you set is never reset by GLFW, but it only takes effect during
- *  initialization.  Once GLFW has been initialized, any updates will be ignored until the
- *  library is terminated and initialized again.
+ *  The function address you set is never reset by GLFW, but it only takes
+ * effect during initialization.  Once GLFW has been initialized, any updates
+ * will be ignored until the library is terminated and initialized again.
  *
  *  @param[in] loader The address of the function to use, or `NULL`.
  *
  *  @par Loader function signature
  *  @code
- *  PFN_vkVoidFunction vkGetInstanceProcAddr(VkInstance instance, const char* name)
+ *  PFN_vkVoidFunction vkGetInstanceProcAddr(VkInstance instance, const char*
+ * name)
  *  @endcode
  *  For more information about this function, see the
  *  [Vulkan Registry](https://www.khronos.org/registry/vulkan/).
@@ -2394,22 +2399,22 @@ GLFWAPI void glfwInitVulkanLoader(PFN_vkGetInstanceProcAddr loader);
  *
  *  @ingroup init
  */
-GLFWAPI void glfwGetVersion(int* major, int* minor, int* rev);
+GLFWAPI void glfwGetVersion(int *major, int *minor, int *rev);
 
 /*! @brief Returns a string describing the compile-time configuration.
  *
  *  This function returns the compile-time generated
- *  [version string](@ref intro_version_string) of the GLFW library binary.  It describes
- *  the version, platforms, compiler and any platform or operating system specific
- *  compile-time options.  It should not be confused with the OpenGL or OpenGL ES version
- *  string, queried with `glGetString`.
+ *  [version string](@ref intro_version_string) of the GLFW library binary.  It
+ * describes the version, platforms, compiler and any platform or operating
+ * system specific compile-time options.  It should not be confused with the
+ * OpenGL or OpenGL ES version string, queried with `glGetString`.
  *
  *  __Do not use the version string__ to parse the GLFW library version.  The
  *  @ref glfwGetVersion function provides the version of the running library
  *  binary in numerical format.
  *
- *  __Do not use the version string__ to parse what platforms are supported.  The @ref
- *  glfwPlatformSupported function lets you query platform support.
+ *  __Do not use the version string__ to parse what platforms are supported. The
+ * @ref glfwPlatformSupported function lets you query platform support.
  *
  *  @return The ASCII encoded GLFW version string.
  *
@@ -2428,7 +2433,7 @@ GLFWAPI void glfwGetVersion(int* major, int* minor, int* rev);
  *
  *  @ingroup init
  */
-GLFWAPI const char* glfwGetVersionString(void);
+GLFWAPI const char *glfwGetVersionString(void);
 
 /*! @brief Returns and clears the last error for the calling thread.
  *
@@ -2438,7 +2443,8 @@ GLFWAPI const char* glfwGetVersionString(void);
  *  call, it returns @ref GLFW_NO_ERROR (zero) and the description pointer is
  *  set to `NULL`.
  *
- *  @param[in] description Where to store the error description pointer, or `NULL`.
+ *  @param[in] description Where to store the error description pointer, or
+ * `NULL`.
  *  @return The last error code for the calling thread, or @ref GLFW_NO_ERROR
  *  (zero).
  *
@@ -2459,7 +2465,7 @@ GLFWAPI const char* glfwGetVersionString(void);
  *
  *  @ingroup init
  */
-GLFWAPI int glfwGetError(const char** description);
+GLFWAPI int glfwGetError(const char **description);
 
 /*! @brief Sets the error callback.
  *
@@ -2509,9 +2515,10 @@ GLFWAPI GLFWerrorfun glfwSetErrorCallback(GLFWerrorfun callback);
 
 /*! @brief Returns the currently selected platform.
  *
- *  This function returns the platform that was selected during initialization.  The
- *  returned value will be one of `GLFW_PLATFORM_WIN32`, `GLFW_PLATFORM_COCOA`,
- *  `GLFW_PLATFORM_WAYLAND`, `GLFW_PLATFORM_X11` or `GLFW_PLATFORM_NULL`.
+ *  This function returns the platform that was selected during initialization.
+ * The returned value will be one of `GLFW_PLATFORM_WIN32`,
+ * `GLFW_PLATFORM_COCOA`, `GLFW_PLATFORM_WAYLAND`, `GLFW_PLATFORM_X11` or
+ * `GLFW_PLATFORM_NULL`.
  *
  *  @return The currently selected platform, or zero if an error occurred.
  *
@@ -2528,11 +2535,13 @@ GLFWAPI GLFWerrorfun glfwSetErrorCallback(GLFWerrorfun callback);
  */
 GLFWAPI int glfwGetPlatform(void);
 
-/*! @brief Returns whether the library includes support for the specified platform.
+/*! @brief Returns whether the library includes support for the specified
+ * platform.
  *
- *  This function returns whether the library was compiled with support for the specified
- *  platform.  The platform must be one of `GLFW_PLATFORM_WIN32`, `GLFW_PLATFORM_COCOA`,
- *  `GLFW_PLATFORM_WAYLAND`, `GLFW_PLATFORM_X11` or `GLFW_PLATFORM_NULL`.
+ *  This function returns whether the library was compiled with support for the
+ * specified platform.  The platform must be one of `GLFW_PLATFORM_WIN32`,
+ * `GLFW_PLATFORM_COCOA`, `GLFW_PLATFORM_WAYLAND`, `GLFW_PLATFORM_X11` or
+ * `GLFW_PLATFORM_NULL`.
  *
  *  @param[in] platform The platform to query.
  *  @return `GLFW_TRUE` if the platform is supported, or `GLFW_FALSE` otherwise.
@@ -2579,7 +2588,7 @@ GLFWAPI int glfwPlatformSupported(int platform);
  *
  *  @ingroup monitor
  */
-GLFWAPI GLFWmonitor** glfwGetMonitors(int* count);
+GLFWAPI GLFWmonitor **glfwGetMonitors(int *count);
 
 /*! @brief Returns the primary monitor.
  *
@@ -2603,7 +2612,7 @@ GLFWAPI GLFWmonitor** glfwGetMonitors(int* count);
  *
  *  @ingroup monitor
  */
-GLFWAPI GLFWmonitor* glfwGetPrimaryMonitor(void);
+GLFWAPI GLFWmonitor *glfwGetPrimaryMonitor(void);
 
 /*! @brief Returns the position of the monitor's viewport on the virtual screen.
  *
@@ -2628,7 +2637,7 @@ GLFWAPI GLFWmonitor* glfwGetPrimaryMonitor(void);
  *
  *  @ingroup monitor
  */
-GLFWAPI void glfwGetMonitorPos(GLFWmonitor* monitor, int* xpos, int* ypos);
+GLFWAPI void glfwGetMonitorPos(GLFWmonitor *monitor, int *xpos, int *ypos);
 
 /*! @brief Retrieves the work area of the monitor.
  *
@@ -2659,7 +2668,8 @@ GLFWAPI void glfwGetMonitorPos(GLFWmonitor* monitor, int* xpos, int* ypos);
  *
  *  @ingroup monitor
  */
-GLFWAPI void glfwGetMonitorWorkarea(GLFWmonitor* monitor, int* xpos, int* ypos, int* width, int* height);
+GLFWAPI void glfwGetMonitorWorkarea(GLFWmonitor *monitor, int *xpos, int *ypos,
+                                    int *width, int *height);
 
 /*! @brief Returns the physical size of the monitor.
  *
@@ -2683,8 +2693,9 @@ GLFWAPI void glfwGetMonitorWorkarea(GLFWmonitor* monitor, int* xpos, int* ypos, 
  *
  *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
  *
- *  @remark __Win32:__ On Windows 8 and earlier the physical size is calculated from
- *  the current resolution and system DPI instead of querying the monitor EDID data.
+ *  @remark __Win32:__ On Windows 8 and earlier the physical size is calculated
+ * from the current resolution and system DPI instead of querying the monitor
+ * EDID data.
  *
  *  @thread_safety This function must only be called from the main thread.
  *
@@ -2694,7 +2705,8 @@ GLFWAPI void glfwGetMonitorWorkarea(GLFWmonitor* monitor, int* xpos, int* ypos, 
  *
  *  @ingroup monitor
  */
-GLFWAPI void glfwGetMonitorPhysicalSize(GLFWmonitor* monitor, int* widthMM, int* heightMM);
+GLFWAPI void glfwGetMonitorPhysicalSize(GLFWmonitor *monitor, int *widthMM,
+                                        int *heightMM);
 
 /*! @brief Retrieves the content scale for the specified monitor.
  *
@@ -2729,7 +2741,8 @@ GLFWAPI void glfwGetMonitorPhysicalSize(GLFWmonitor* monitor, int* widthMM, int*
  *
  *  @ingroup monitor
  */
-GLFWAPI void glfwGetMonitorContentScale(GLFWmonitor* monitor, float* xscale, float* yscale);
+GLFWAPI void glfwGetMonitorContentScale(GLFWmonitor *monitor, float *xscale,
+                                        float *yscale);
 
 /*! @brief Returns the name of the specified monitor.
  *
@@ -2755,7 +2768,7 @@ GLFWAPI void glfwGetMonitorContentScale(GLFWmonitor* monitor, float* xscale, flo
  *
  *  @ingroup monitor
  */
-GLFWAPI const char* glfwGetMonitorName(GLFWmonitor* monitor);
+GLFWAPI const char *glfwGetMonitorName(GLFWmonitor *monitor);
 
 /*! @brief Sets the user pointer of the specified monitor.
  *
@@ -2781,7 +2794,7 @@ GLFWAPI const char* glfwGetMonitorName(GLFWmonitor* monitor);
  *
  *  @ingroup monitor
  */
-GLFWAPI void glfwSetMonitorUserPointer(GLFWmonitor* monitor, void* pointer);
+GLFWAPI void glfwSetMonitorUserPointer(GLFWmonitor *monitor, void *pointer);
 
 /*! @brief Returns the user pointer of the specified monitor.
  *
@@ -2805,7 +2818,7 @@ GLFWAPI void glfwSetMonitorUserPointer(GLFWmonitor* monitor, void* pointer);
  *
  *  @ingroup monitor
  */
-GLFWAPI void* glfwGetMonitorUserPointer(GLFWmonitor* monitor);
+GLFWAPI void *glfwGetMonitorUserPointer(GLFWmonitor *monitor);
 
 /*! @brief Sets the monitor configuration callback.
  *
@@ -2869,7 +2882,7 @@ GLFWAPI GLFWmonitorfun glfwSetMonitorCallback(GLFWmonitorfun callback);
  *
  *  @ingroup monitor
  */
-GLFWAPI const GLFWvidmode* glfwGetVideoModes(GLFWmonitor* monitor, int* count);
+GLFWAPI const GLFWvidmode *glfwGetVideoModes(GLFWmonitor *monitor, int *count);
 
 /*! @brief Returns the current mode of the specified monitor.
  *
@@ -2897,7 +2910,7 @@ GLFWAPI const GLFWvidmode* glfwGetVideoModes(GLFWmonitor* monitor, int* count);
  *
  *  @ingroup monitor
  */
-GLFWAPI const GLFWvidmode* glfwGetVideoMode(GLFWmonitor* monitor);
+GLFWAPI const GLFWvidmode *glfwGetVideoMode(GLFWmonitor *monitor);
 
 /*! @brief Generates a gamma ramp and sets it for the specified monitor.
  *
@@ -2916,11 +2929,12 @@ GLFWAPI const GLFWvidmode* glfwGetVideoMode(GLFWmonitor* monitor);
  *  @param[in] monitor The monitor whose gamma ramp to set.
  *  @param[in] gamma The desired exponent.
  *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref GLFW_INVALID_VALUE,
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+ * GLFW_INVALID_VALUE,
  *  @ref GLFW_PLATFORM_ERROR and @ref GLFW_FEATURE_UNAVAILABLE (see remarks).
  *
- *  @remark __Wayland:__ Monitor gamma is a privileged protocol, so this function
- *  cannot be implemented and emits @ref GLFW_FEATURE_UNAVAILABLE.
+ *  @remark __Wayland:__ Monitor gamma is a privileged protocol, so this
+ * function cannot be implemented and emits @ref GLFW_FEATURE_UNAVAILABLE.
  *
  *  @thread_safety This function must only be called from the main thread.
  *
@@ -2930,7 +2944,7 @@ GLFWAPI const GLFWvidmode* glfwGetVideoMode(GLFWmonitor* monitor);
  *
  *  @ingroup monitor
  */
-GLFWAPI void glfwSetGamma(GLFWmonitor* monitor, float gamma);
+GLFWAPI void glfwSetGamma(GLFWmonitor *monitor, float gamma);
 
 /*! @brief Returns the current gamma ramp for the specified monitor.
  *
@@ -2940,11 +2954,11 @@ GLFWAPI void glfwSetGamma(GLFWmonitor* monitor, float gamma);
  *  @return The current gamma ramp, or `NULL` if an
  *  [error](@ref error_handling) occurred.
  *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref GLFW_PLATFORM_ERROR
- *  and @ref GLFW_FEATURE_UNAVAILABLE (see remarks).
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+ * GLFW_PLATFORM_ERROR and @ref GLFW_FEATURE_UNAVAILABLE (see remarks).
  *
- *  @remark __Wayland:__ Monitor gamma is a privileged protocol, so this function
- *  cannot be implemented and emits @ref GLFW_FEATURE_UNAVAILABLE while
+ *  @remark __Wayland:__ Monitor gamma is a privileged protocol, so this
+ * function cannot be implemented and emits @ref GLFW_FEATURE_UNAVAILABLE while
  *  returning `NULL`.
  *
  *  @pointer_lifetime The returned structure and its arrays are allocated and
@@ -2960,7 +2974,7 @@ GLFWAPI void glfwSetGamma(GLFWmonitor* monitor, float gamma);
  *
  *  @ingroup monitor
  */
-GLFWAPI const GLFWgammaramp* glfwGetGammaRamp(GLFWmonitor* monitor);
+GLFWAPI const GLFWgammaramp *glfwGetGammaRamp(GLFWmonitor *monitor);
 
 /*! @brief Sets the current gamma ramp for the specified monitor.
  *
@@ -2979,16 +2993,16 @@ GLFWAPI const GLFWgammaramp* glfwGetGammaRamp(GLFWmonitor* monitor);
  *  @param[in] monitor The monitor whose gamma ramp to set.
  *  @param[in] ramp The gamma ramp to use.
  *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref GLFW_PLATFORM_ERROR
- *  and @ref GLFW_FEATURE_UNAVAILABLE (see remarks).
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+ * GLFW_PLATFORM_ERROR and @ref GLFW_FEATURE_UNAVAILABLE (see remarks).
  *
  *  @remark The size of the specified gamma ramp should match the size of the
  *  current ramp for that monitor.
  *
  *  @remark __Win32:__ The gamma ramp size must be 256.
  *
- *  @remark __Wayland:__ Monitor gamma is a privileged protocol, so this function
- *  cannot be implemented and emits @ref GLFW_FEATURE_UNAVAILABLE.
+ *  @remark __Wayland:__ Monitor gamma is a privileged protocol, so this
+ * function cannot be implemented and emits @ref GLFW_FEATURE_UNAVAILABLE.
  *
  *  @pointer_lifetime The specified gamma ramp is copied before this function
  *  returns.
@@ -3001,7 +3015,7 @@ GLFWAPI const GLFWgammaramp* glfwGetGammaRamp(GLFWmonitor* monitor);
  *
  *  @ingroup monitor
  */
-GLFWAPI void glfwSetGammaRamp(GLFWmonitor* monitor, const GLFWgammaramp* ramp);
+GLFWAPI void glfwSetGammaRamp(GLFWmonitor *monitor, const GLFWgammaramp *ramp);
 
 /*! @brief Resets all window hints to their default values.
  *
@@ -3093,7 +3107,7 @@ GLFWAPI void glfwWindowHint(int hint, int value);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwWindowHintString(int hint, const char* value);
+GLFWAPI void glfwWindowHintString(int hint, const char *value);
 
 /*! @brief Creates a window and its associated context.
  *
@@ -3166,13 +3180,13 @@ GLFWAPI void glfwWindowHintString(int hint, const char* value);
  *  @remark __Win32:__ Window creation will fail if the Microsoft GDI software
  *  OpenGL implementation is the only one available.
  *
- *  @remark __Win32:__ If the executable has an icon resource named `GLFW_ICON,` it
- *  will be set as the initial icon for the window.  If no such icon is present,
- *  the `IDI_APPLICATION` icon will be used instead.  To set a different icon,
- *  see @ref glfwSetWindowIcon.
+ *  @remark __Win32:__ If the executable has an icon resource named `GLFW_ICON,`
+ * it will be set as the initial icon for the window.  If no such icon is
+ * present, the `IDI_APPLICATION` icon will be used instead.  To set a different
+ * icon, see @ref glfwSetWindowIcon.
  *
- *  @remark __Win32:__ The context to share resources with must not be current on
- *  any other thread.
+ *  @remark __Win32:__ The context to share resources with must not be current
+ * on any other thread.
  *
  *  @remark __macOS:__ The OS only supports core profile contexts for OpenGL
  *  versions 3.2 and later.  Before creating an OpenGL context of version 3.2 or
@@ -3185,7 +3199,8 @@ GLFWAPI void glfwWindowHintString(int hint, const char* value);
  *  For more information on bundles, see the
  *  [Bundle Programming Guide][bundle-guide] in the Mac Developer Library.
  *
- *  [bundle-guide]: https://developer.apple.com/library/mac/documentation/CoreFoundation/Conceptual/CFBundles/
+ *  [bundle-guide]:
+ * https://developer.apple.com/library/mac/documentation/CoreFoundation/Conceptual/CFBundles/
  *
  *  @remark __macOS:__  The window frame will not be rendered at full resolution
  *  on Retina displays unless the
@@ -3197,26 +3212,27 @@ GLFWAPI void glfwWindowHintString(int hint, const char* value);
  *  template for this, which can be found as `CMake/Info.plist.in` in the source
  *  tree.
  *
- *  [hidpi-guide]: https://developer.apple.com/library/mac/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Explained/Explained.html
+ *  [hidpi-guide]:
+ * https://developer.apple.com/library/mac/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Explained/Explained.html
  *
  *  @remark __macOS:__ When activating frame autosaving with
  *  [GLFW_COCOA_FRAME_NAME](@ref GLFW_COCOA_FRAME_NAME_hint), the specified
  *  window size and position may be overridden by previously saved values.
  *
- *  @remark __Wayland:__ GLFW uses [libdecor][] where available to create its window
- *  decorations.  This in turn uses server-side XDG decorations where available
- *  and provides high quality client-side decorations on compositors like GNOME.
- *  If both XDG decorations and libdecor are unavailable, GLFW falls back to
- *  a very simple set of window decorations that only support moving, resizing
- *  and the window manager's right-click menu.
+ *  @remark __Wayland:__ GLFW uses [libdecor][] where available to create its
+ * window decorations.  This in turn uses server-side XDG decorations where
+ * available and provides high quality client-side decorations on compositors
+ * like GNOME. If both XDG decorations and libdecor are unavailable, GLFW falls
+ * back to a very simple set of window decorations that only support moving,
+ * resizing and the window manager's right-click menu.
  *
  *  [libdecor]: https://gitlab.freedesktop.org/libdecor/libdecor
  *
  *  @remark __X11:__ Some window managers will not respect the placement of
  *  initially hidden windows.
  *
- *  @remark __X11:__ Due to the asynchronous nature of X11, it may take a moment for
- *  a window to reach its requested state.  This means you may not be able to
+ *  @remark __X11:__ Due to the asynchronous nature of X11, it may take a moment
+ * for a window to reach its requested state.  This means you may not be able to
  *  query the final size, position or other attributes directly after window
  *  creation.
  *
@@ -3237,7 +3253,8 @@ GLFWAPI void glfwWindowHintString(int hint, const char* value);
  *
  *  @ingroup window
  */
-GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height, const char* title, GLFWmonitor* monitor, GLFWwindow* share);
+GLFWAPI GLFWwindow *glfwCreateWindow(int width, int height, const char *title,
+                                     GLFWmonitor *monitor, GLFWwindow *share);
 
 /*! @brief Destroys the specified window and its context.
  *
@@ -3266,7 +3283,7 @@ GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height, const char* title, G
  *
  *  @ingroup window
  */
-GLFWAPI void glfwDestroyWindow(GLFWwindow* window);
+GLFWAPI void glfwDestroyWindow(GLFWwindow *window);
 
 /*! @brief Checks the close flag of the specified window.
  *
@@ -3286,7 +3303,7 @@ GLFWAPI void glfwDestroyWindow(GLFWwindow* window);
  *
  *  @ingroup window
  */
-GLFWAPI int glfwWindowShouldClose(GLFWwindow* window);
+GLFWAPI int glfwWindowShouldClose(GLFWwindow *window);
 
 /*! @brief Sets the close flag of the specified window.
  *
@@ -3308,7 +3325,7 @@ GLFWAPI int glfwWindowShouldClose(GLFWwindow* window);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwSetWindowShouldClose(GLFWwindow* window, int value);
+GLFWAPI void glfwSetWindowShouldClose(GLFWwindow *window, int value);
 
 /*! @brief Returns the title of the specified window.
  *
@@ -3340,7 +3357,7 @@ GLFWAPI void glfwSetWindowShouldClose(GLFWwindow* window, int value);
  *
  *  @ingroup window
  */
-GLFWAPI const char* glfwGetWindowTitle(GLFWwindow* window);
+GLFWAPI const char *glfwGetWindowTitle(GLFWwindow *window);
 
 /*! @brief Sets the title of the specified window.
  *
@@ -3353,8 +3370,8 @@ GLFWAPI const char* glfwGetWindowTitle(GLFWwindow* window);
  *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
  *  GLFW_PLATFORM_ERROR.
  *
- *  @remark __macOS:__ The window title will not be updated until the next time you
- *  process events.
+ *  @remark __macOS:__ The window title will not be updated until the next time
+ * you process events.
  *
  *  @thread_safety This function must only be called from the main thread.
  *
@@ -3366,7 +3383,7 @@ GLFWAPI const char* glfwGetWindowTitle(GLFWwindow* window);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwSetWindowTitle(GLFWwindow* window, const char* title);
+GLFWAPI void glfwSetWindowTitle(GLFWwindow *window, const char *title);
 
 /*! @brief Sets the icon for the specified window.
  *
@@ -3396,12 +3413,13 @@ GLFWAPI void glfwSetWindowTitle(GLFWwindow* window, const char* title);
  *  @pointer_lifetime The specified image data is copied before this function
  *  returns.
  *
- *  @remark __macOS:__ Regular windows do not have icons on macOS.  This function
- *  will emit @ref GLFW_FEATURE_UNAVAILABLE.  The dock icon will be the same as
- *  the application bundle's icon.  For more information on bundles, see the
- *  [Bundle Programming Guide][bundle-guide] in the Mac Developer Library.
+ *  @remark __macOS:__ Regular windows do not have icons on macOS.  This
+ * function will emit @ref GLFW_FEATURE_UNAVAILABLE.  The dock icon will be the
+ * same as the application bundle's icon.  For more information on bundles, see
+ * the [Bundle Programming Guide][bundle-guide] in the Mac Developer Library.
  *
- *  [bundle-guide]: https://developer.apple.com/library/mac/documentation/CoreFoundation/Conceptual/CFBundles/
+ *  [bundle-guide]:
+ * https://developer.apple.com/library/mac/documentation/CoreFoundation/Conceptual/CFBundles/
  *
  *  @remark __Wayland:__ There is no existing protocol to change an icon, the
  *  window will thus inherit the one defined in the application's desktop file.
@@ -3415,7 +3433,8 @@ GLFWAPI void glfwSetWindowTitle(GLFWwindow* window, const char* title);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwSetWindowIcon(GLFWwindow* window, int count, const GLFWimage* images);
+GLFWAPI void glfwSetWindowIcon(GLFWwindow *window, int count,
+                               const GLFWimage *images);
 
 /*! @brief Retrieves the position of the content area of the specified window.
  *
@@ -3447,7 +3466,7 @@ GLFWAPI void glfwSetWindowIcon(GLFWwindow* window, int count, const GLFWimage* i
  *
  *  @ingroup window
  */
-GLFWAPI void glfwGetWindowPos(GLFWwindow* window, int* xpos, int* ypos);
+GLFWAPI void glfwGetWindowPos(GLFWwindow *window, int *xpos, int *ypos);
 
 /*! @brief Sets the position of the content area of the specified window.
  *
@@ -3462,8 +3481,10 @@ GLFWAPI void glfwGetWindowPos(GLFWwindow* window, int* xpos, int* ypos);
  *  cannot and should not override these limits.
  *
  *  @param[in] window The window to query.
- *  @param[in] xpos The x-coordinate of the upper-left corner of the content area.
- *  @param[in] ypos The y-coordinate of the upper-left corner of the content area.
+ *  @param[in] xpos The x-coordinate of the upper-left corner of the content
+ * area.
+ *  @param[in] ypos The y-coordinate of the upper-left corner of the content
+ * area.
  *
  *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
  *  GLFW_PLATFORM_ERROR and @ref GLFW_FEATURE_UNAVAILABLE (see remarks).
@@ -3482,7 +3503,7 @@ GLFWAPI void glfwGetWindowPos(GLFWwindow* window, int* xpos, int* ypos);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwSetWindowPos(GLFWwindow* window, int xpos, int ypos);
+GLFWAPI void glfwSetWindowPos(GLFWwindow *window, int xpos, int ypos);
 
 /*! @brief Retrieves the size of the content area of the specified window.
  *
@@ -3512,7 +3533,7 @@ GLFWAPI void glfwSetWindowPos(GLFWwindow* window, int xpos, int ypos);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwGetWindowSize(GLFWwindow* window, int* width, int* height);
+GLFWAPI void glfwGetWindowSize(GLFWwindow *window, int *width, int *height);
 
 /*! @brief Sets the size limits of the specified window.
  *
@@ -3555,7 +3576,9 @@ GLFWAPI void glfwGetWindowSize(GLFWwindow* window, int* width, int* height);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwSetWindowSizeLimits(GLFWwindow* window, int minwidth, int minheight, int maxwidth, int maxheight);
+GLFWAPI void glfwSetWindowSizeLimits(GLFWwindow *window, int minwidth,
+                                     int minheight, int maxwidth,
+                                     int maxheight);
 
 /*! @brief Sets the aspect ratio of the specified window.
  *
@@ -3586,8 +3609,8 @@ GLFWAPI void glfwSetWindowSizeLimits(GLFWwindow* window, int minwidth, int minhe
  *  @remark If you set size limits and an aspect ratio that conflict, the
  *  results are undefined.
  *
- *  @remark __Wayland:__ The aspect ratio will not be applied until the window is
- *  actually resized, either by the user or by the compositor.
+ *  @remark __Wayland:__ The aspect ratio will not be applied until the window
+ * is actually resized, either by the user or by the compositor.
  *
  *  @thread_safety This function must only be called from the main thread.
  *
@@ -3598,7 +3621,7 @@ GLFWAPI void glfwSetWindowSizeLimits(GLFWwindow* window, int minwidth, int minhe
  *
  *  @ingroup window
  */
-GLFWAPI void glfwSetWindowAspectRatio(GLFWwindow* window, int numer, int denom);
+GLFWAPI void glfwSetWindowAspectRatio(GLFWwindow *window, int numer, int denom);
 
 /*! @brief Sets the size of the content area of the specified window.
  *
@@ -3636,7 +3659,7 @@ GLFWAPI void glfwSetWindowAspectRatio(GLFWwindow* window, int numer, int denom);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwSetWindowSize(GLFWwindow* window, int width, int height);
+GLFWAPI void glfwSetWindowSize(GLFWwindow *window, int width, int height);
 
 /*! @brief Retrieves the size of the framebuffer of the specified window.
  *
@@ -3665,7 +3688,8 @@ GLFWAPI void glfwSetWindowSize(GLFWwindow* window, int width, int height);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwGetFramebufferSize(GLFWwindow* window, int* width, int* height);
+GLFWAPI void glfwGetFramebufferSize(GLFWwindow *window, int *width,
+                                    int *height);
 
 /*! @brief Retrieves the size of the frame of the window.
  *
@@ -3702,7 +3726,8 @@ GLFWAPI void glfwGetFramebufferSize(GLFWwindow* window, int* width, int* height)
  *
  *  @ingroup window
  */
-GLFWAPI void glfwGetWindowFrameSize(GLFWwindow* window, int* left, int* top, int* right, int* bottom);
+GLFWAPI void glfwGetWindowFrameSize(GLFWwindow *window, int *left, int *top,
+                                    int *right, int *bottom);
 
 /*! @brief Retrieves the content scale for the specified window.
  *
@@ -3735,7 +3760,8 @@ GLFWAPI void glfwGetWindowFrameSize(GLFWwindow* window, int* left, int* top, int
  *
  *  @ingroup window
  */
-GLFWAPI void glfwGetWindowContentScale(GLFWwindow* window, float* xscale, float* yscale);
+GLFWAPI void glfwGetWindowContentScale(GLFWwindow *window, float *xscale,
+                                       float *yscale);
 
 /*! @brief Returns the opacity of the whole window.
  *
@@ -3743,7 +3769,8 @@ GLFWAPI void glfwGetWindowContentScale(GLFWwindow* window, float* xscale, float*
  *
  *  The opacity (or alpha) value is a positive finite number between zero and
  *  one, where zero is fully transparent and one is fully opaque.  If the system
- *  does not support whole window transparency, this function always returns one.
+ *  does not support whole window transparency, this function always returns
+ * one.
  *
  *  The initial opacity value for newly created windows is one.
  *
@@ -3762,7 +3789,7 @@ GLFWAPI void glfwGetWindowContentScale(GLFWwindow* window, float* xscale, float*
  *
  *  @ingroup window
  */
-GLFWAPI float glfwGetWindowOpacity(GLFWwindow* window);
+GLFWAPI float glfwGetWindowOpacity(GLFWwindow *window);
 
 /*! @brief Sets the opacity of the whole window.
  *
@@ -3794,7 +3821,7 @@ GLFWAPI float glfwGetWindowOpacity(GLFWwindow* window);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwSetWindowOpacity(GLFWwindow* window, float opacity);
+GLFWAPI void glfwSetWindowOpacity(GLFWwindow *window, float opacity);
 
 /*! @brief Iconifies the specified window.
  *
@@ -3822,7 +3849,7 @@ GLFWAPI void glfwSetWindowOpacity(GLFWwindow* window, float opacity);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwIconifyWindow(GLFWwindow* window);
+GLFWAPI void glfwIconifyWindow(GLFWwindow *window);
 
 /*! @brief Restores the specified window.
  *
@@ -3853,7 +3880,7 @@ GLFWAPI void glfwIconifyWindow(GLFWwindow* window);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwRestoreWindow(GLFWwindow* window);
+GLFWAPI void glfwRestoreWindow(GLFWwindow *window);
 
 /*! @brief Maximizes the specified window.
  *
@@ -3878,7 +3905,7 @@ GLFWAPI void glfwRestoreWindow(GLFWwindow* window);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwMaximizeWindow(GLFWwindow* window);
+GLFWAPI void glfwMaximizeWindow(GLFWwindow *window);
 
 /*! @brief Makes the specified window visible.
  *
@@ -3910,7 +3937,7 @@ GLFWAPI void glfwMaximizeWindow(GLFWwindow* window);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwShowWindow(GLFWwindow* window);
+GLFWAPI void glfwShowWindow(GLFWwindow *window);
 
 /*! @brief Hides the specified window.
  *
@@ -3932,7 +3959,7 @@ GLFWAPI void glfwShowWindow(GLFWwindow* window);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwHideWindow(GLFWwindow* window);
+GLFWAPI void glfwHideWindow(GLFWwindow *window);
 
 /*! @brief Brings the specified window to front and sets input focus.
  *
@@ -3971,7 +3998,7 @@ GLFWAPI void glfwHideWindow(GLFWwindow* window);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwFocusWindow(GLFWwindow* window);
+GLFWAPI void glfwFocusWindow(GLFWwindow *window);
 
 /*! @brief Requests user attention to the specified window.
  *
@@ -3987,8 +4014,8 @@ GLFWAPI void glfwFocusWindow(GLFWwindow* window);
  *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
  *  GLFW_PLATFORM_ERROR.
  *
- *  @remark __macOS:__ Attention is requested to the application as a whole, not the
- *  specific window.
+ *  @remark __macOS:__ Attention is requested to the application as a whole, not
+ * the specific window.
  *
  *  @thread_safety This function must only be called from the main thread.
  *
@@ -3998,7 +4025,7 @@ GLFWAPI void glfwFocusWindow(GLFWwindow* window);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwRequestWindowAttention(GLFWwindow* window);
+GLFWAPI void glfwRequestWindowAttention(GLFWwindow *window);
 
 /*! @brief Returns the monitor that the window uses for full screen mode.
  *
@@ -4020,7 +4047,7 @@ GLFWAPI void glfwRequestWindowAttention(GLFWwindow* window);
  *
  *  @ingroup window
  */
-GLFWAPI GLFWmonitor* glfwGetWindowMonitor(GLFWwindow* window);
+GLFWAPI GLFWmonitor *glfwGetWindowMonitor(GLFWwindow *window);
 
 /*! @brief Sets the mode, monitor, video mode and placement of a window.
  *
@@ -4076,7 +4103,9 @@ GLFWAPI GLFWmonitor* glfwGetWindowMonitor(GLFWwindow* window);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwSetWindowMonitor(GLFWwindow* window, GLFWmonitor* monitor, int xpos, int ypos, int width, int height, int refreshRate);
+GLFWAPI void glfwSetWindowMonitor(GLFWwindow *window, GLFWmonitor *monitor,
+                                  int xpos, int ypos, int width, int height,
+                                  int refreshRate);
 
 /*! @brief Returns an attribute of the specified window.
  *
@@ -4114,7 +4143,7 @@ GLFWAPI void glfwSetWindowMonitor(GLFWwindow* window, GLFWmonitor* monitor, int 
  *
  *  @ingroup window
  */
-GLFWAPI int glfwGetWindowAttrib(GLFWwindow* window, int attrib);
+GLFWAPI int glfwGetWindowAttrib(GLFWwindow *window, int attrib);
 
 /*! @brief Sets an attribute of the specified window.
  *
@@ -4138,14 +4167,15 @@ GLFWAPI int glfwGetWindowAttrib(GLFWwindow* window, int attrib);
  *  @param[in] value `GLFW_TRUE` or `GLFW_FALSE`.
  *
  *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_INVALID_ENUM, @ref GLFW_INVALID_VALUE, @ref GLFW_PLATFORM_ERROR and @ref
- *  GLFW_FEATURE_UNAVAILABLE (see remarks).
+ *  GLFW_INVALID_ENUM, @ref GLFW_INVALID_VALUE, @ref GLFW_PLATFORM_ERROR and
+ * @ref GLFW_FEATURE_UNAVAILABLE (see remarks).
  *
  *  @remark Calling @ref glfwGetWindowAttrib will always return the latest
  *  value, even if that value is ignored by the current mode of the window.
  *
- *  @remark __Wayland:__ The [GLFW_FLOATING](@ref GLFW_FLOATING_attrib) window attribute is
- *  not supported.  Setting this will emit @ref GLFW_FEATURE_UNAVAILABLE.
+ *  @remark __Wayland:__ The [GLFW_FLOATING](@ref GLFW_FLOATING_attrib) window
+ * attribute is not supported.  Setting this will emit @ref
+ * GLFW_FEATURE_UNAVAILABLE.
  *
  *  @thread_safety This function must only be called from the main thread.
  *
@@ -4156,7 +4186,7 @@ GLFWAPI int glfwGetWindowAttrib(GLFWwindow* window, int attrib);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwSetWindowAttrib(GLFWwindow* window, int attrib, int value);
+GLFWAPI void glfwSetWindowAttrib(GLFWwindow *window, int attrib, int value);
 
 /*! @brief Sets the user pointer of the specified window.
  *
@@ -4179,7 +4209,7 @@ GLFWAPI void glfwSetWindowAttrib(GLFWwindow* window, int attrib, int value);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwSetWindowUserPointer(GLFWwindow* window, void* pointer);
+GLFWAPI void glfwSetWindowUserPointer(GLFWwindow *window, void *pointer);
 
 /*! @brief Returns the user pointer of the specified window.
  *
@@ -4200,7 +4230,7 @@ GLFWAPI void glfwSetWindowUserPointer(GLFWwindow* window, void* pointer);
  *
  *  @ingroup window
  */
-GLFWAPI void* glfwGetWindowUserPointer(GLFWwindow* window);
+GLFWAPI void *glfwGetWindowUserPointer(GLFWwindow *window);
 
 /*! @brief Sets the position callback for the specified window.
  *
@@ -4235,7 +4265,8 @@ GLFWAPI void* glfwGetWindowUserPointer(GLFWwindow* window);
  *
  *  @ingroup window
  */
-GLFWAPI GLFWwindowposfun glfwSetWindowPosCallback(GLFWwindow* window, GLFWwindowposfun callback);
+GLFWAPI GLFWwindowposfun glfwSetWindowPosCallback(GLFWwindow *window,
+                                                  GLFWwindowposfun callback);
 
 /*! @brief Sets the size callback for the specified window.
  *
@@ -4267,7 +4298,8 @@ GLFWAPI GLFWwindowposfun glfwSetWindowPosCallback(GLFWwindow* window, GLFWwindow
  *
  *  @ingroup window
  */
-GLFWAPI GLFWwindowsizefun glfwSetWindowSizeCallback(GLFWwindow* window, GLFWwindowsizefun callback);
+GLFWAPI GLFWwindowsizefun glfwSetWindowSizeCallback(GLFWwindow *window,
+                                                    GLFWwindowsizefun callback);
 
 /*! @brief Sets the close callback for the specified window.
  *
@@ -4307,7 +4339,8 @@ GLFWAPI GLFWwindowsizefun glfwSetWindowSizeCallback(GLFWwindow* window, GLFWwind
  *
  *  @ingroup window
  */
-GLFWAPI GLFWwindowclosefun glfwSetWindowCloseCallback(GLFWwindow* window, GLFWwindowclosefun callback);
+GLFWAPI GLFWwindowclosefun
+glfwSetWindowCloseCallback(GLFWwindow *window, GLFWwindowclosefun callback);
 
 /*! @brief Sets the refresh callback for the specified window.
  *
@@ -4343,7 +4376,8 @@ GLFWAPI GLFWwindowclosefun glfwSetWindowCloseCallback(GLFWwindow* window, GLFWwi
  *
  *  @ingroup window
  */
-GLFWAPI GLFWwindowrefreshfun glfwSetWindowRefreshCallback(GLFWwindow* window, GLFWwindowrefreshfun callback);
+GLFWAPI GLFWwindowrefreshfun
+glfwSetWindowRefreshCallback(GLFWwindow *window, GLFWwindowrefreshfun callback);
 
 /*! @brief Sets the focus callback for the specified window.
  *
@@ -4378,7 +4412,8 @@ GLFWAPI GLFWwindowrefreshfun glfwSetWindowRefreshCallback(GLFWwindow* window, GL
  *
  *  @ingroup window
  */
-GLFWAPI GLFWwindowfocusfun glfwSetWindowFocusCallback(GLFWwindow* window, GLFWwindowfocusfun callback);
+GLFWAPI GLFWwindowfocusfun
+glfwSetWindowFocusCallback(GLFWwindow *window, GLFWwindowfocusfun callback);
 
 /*! @brief Sets the iconify callback for the specified window.
  *
@@ -4412,7 +4447,8 @@ GLFWAPI GLFWwindowfocusfun glfwSetWindowFocusCallback(GLFWwindow* window, GLFWwi
  *
  *  @ingroup window
  */
-GLFWAPI GLFWwindowiconifyfun glfwSetWindowIconifyCallback(GLFWwindow* window, GLFWwindowiconifyfun callback);
+GLFWAPI GLFWwindowiconifyfun
+glfwSetWindowIconifyCallback(GLFWwindow *window, GLFWwindowiconifyfun callback);
 
 /*! @brief Sets the maximize callback for the specified window.
  *
@@ -4442,7 +4478,8 @@ GLFWAPI GLFWwindowiconifyfun glfwSetWindowIconifyCallback(GLFWwindow* window, GL
  *
  *  @ingroup window
  */
-GLFWAPI GLFWwindowmaximizefun glfwSetWindowMaximizeCallback(GLFWwindow* window, GLFWwindowmaximizefun callback);
+GLFWAPI GLFWwindowmaximizefun glfwSetWindowMaximizeCallback(
+    GLFWwindow *window, GLFWwindowmaximizefun callback);
 
 /*! @brief Sets the framebuffer resize callback for the specified window.
  *
@@ -4472,12 +4509,14 @@ GLFWAPI GLFWwindowmaximizefun glfwSetWindowMaximizeCallback(GLFWwindow* window, 
  *
  *  @ingroup window
  */
-GLFWAPI GLFWframebuffersizefun glfwSetFramebufferSizeCallback(GLFWwindow* window, GLFWframebuffersizefun callback);
+GLFWAPI GLFWframebuffersizefun glfwSetFramebufferSizeCallback(
+    GLFWwindow *window, GLFWframebuffersizefun callback);
 
 /*! @brief Sets the window content scale callback for the specified window.
  *
- *  This function sets the window content scale callback of the specified window,
- *  which is called when the content scale of the specified window changes.
+ *  This function sets the window content scale callback of the specified
+ * window, which is called when the content scale of the specified window
+ * changes.
  *
  *  @param[in] window The window whose callback to set.
  *  @param[in] callback The new callback, or `NULL` to remove the currently set
@@ -4503,7 +4542,8 @@ GLFWAPI GLFWframebuffersizefun glfwSetFramebufferSizeCallback(GLFWwindow* window
  *
  *  @ingroup window
  */
-GLFWAPI GLFWwindowcontentscalefun glfwSetWindowContentScaleCallback(GLFWwindow* window, GLFWwindowcontentscalefun callback);
+GLFWAPI GLFWwindowcontentscalefun glfwSetWindowContentScaleCallback(
+    GLFWwindow *window, GLFWwindowcontentscalefun callback);
 
 /*! @brief Processes all pending events.
  *
@@ -4683,7 +4723,7 @@ GLFWAPI void glfwPostEmptyEvent(void);
  *
  *  @ingroup input
  */
-GLFWAPI int glfwGetInputMode(GLFWwindow* window, int mode);
+GLFWAPI int glfwGetInputMode(GLFWwindow *window, int mode);
 
 /*! @brief Sets an input option for the specified window.
  *
@@ -4753,7 +4793,7 @@ GLFWAPI int glfwGetInputMode(GLFWwindow* window, int mode);
  *
  *  @ingroup input
  */
-GLFWAPI void glfwSetInputMode(GLFWwindow* window, int mode, int value);
+GLFWAPI void glfwSetInputMode(GLFWwindow *window, int mode, int value);
 
 /*! @brief Returns whether raw mouse motion is supported.
  *
@@ -4850,7 +4890,7 @@ GLFWAPI int glfwRawMouseMotionSupported(void);
  *
  *  @ingroup input
  */
-GLFWAPI const char* glfwGetKeyName(int key, int scancode);
+GLFWAPI const char *glfwGetKeyName(int key, int scancode);
 
 /*! @brief Returns the platform-specific scancode of the specified key.
  *
@@ -4884,7 +4924,8 @@ GLFWAPI int glfwGetKeyScancode(int key);
  *
  *  This function returns the last state reported for the specified key to the
  *  specified window.  The returned state is one of `GLFW_PRESS` or
- *  `GLFW_RELEASE`.  The action `GLFW_REPEAT` is only reported to the key callback.
+ *  `GLFW_RELEASE`.  The action `GLFW_REPEAT` is only reported to the key
+ * callback.
  *
  *  If the @ref GLFW_STICKY_KEYS input mode is enabled, this function returns
  *  `GLFW_PRESS` the first time you call it for a key that was pressed, even if
@@ -4916,7 +4957,7 @@ GLFWAPI int glfwGetKeyScancode(int key);
  *
  *  @ingroup input
  */
-GLFWAPI int glfwGetKey(GLFWwindow* window, int key);
+GLFWAPI int glfwGetKey(GLFWwindow *window, int key);
 
 /*! @brief Returns the last reported state of a mouse button for the specified
  *  window.
@@ -4948,7 +4989,7 @@ GLFWAPI int glfwGetKey(GLFWwindow* window, int key);
  *
  *  @ingroup input
  */
-GLFWAPI int glfwGetMouseButton(GLFWwindow* window, int button);
+GLFWAPI int glfwGetMouseButton(GLFWwindow *window, int button);
 
 /*! @brief Retrieves the position of the cursor relative to the content area of
  *  the window.
@@ -4986,7 +5027,7 @@ GLFWAPI int glfwGetMouseButton(GLFWwindow* window, int button);
  *
  *  @ingroup input
  */
-GLFWAPI void glfwGetCursorPos(GLFWwindow* window, double* xpos, double* ypos);
+GLFWAPI void glfwGetCursorPos(GLFWwindow *window, double *xpos, double *ypos);
 
 /*! @brief Sets the position of the cursor, relative to the content area of the
  *  window.
@@ -5015,7 +5056,8 @@ GLFWAPI void glfwGetCursorPos(GLFWwindow* window, double* xpos, double* ypos);
  *  GLFW_PLATFORM_ERROR and @ref GLFW_FEATURE_UNAVAILABLE (see remarks).
  *
  *  @remark __Wayland:__ This function will only work when the cursor mode is
- *  `GLFW_CURSOR_DISABLED`, otherwise it will emit @ref GLFW_FEATURE_UNAVAILABLE.
+ *  `GLFW_CURSOR_DISABLED`, otherwise it will emit @ref
+ * GLFW_FEATURE_UNAVAILABLE.
  *
  *  @thread_safety This function must only be called from the main thread.
  *
@@ -5026,7 +5068,7 @@ GLFWAPI void glfwGetCursorPos(GLFWwindow* window, double* xpos, double* ypos);
  *
  *  @ingroup input
  */
-GLFWAPI void glfwSetCursorPos(GLFWwindow* window, double xpos, double ypos);
+GLFWAPI void glfwSetCursorPos(GLFWwindow *window, double xpos, double ypos);
 
 /*! @brief Creates a custom cursor.
  *
@@ -5064,7 +5106,8 @@ GLFWAPI void glfwSetCursorPos(GLFWwindow* window, double xpos, double ypos);
  *
  *  @ingroup input
  */
-GLFWAPI GLFWcursor* glfwCreateCursor(const GLFWimage* image, int xhot, int yhot);
+GLFWAPI GLFWcursor *glfwCreateCursor(const GLFWimage *image, int xhot,
+                                     int yhot);
 
 /*! @brief Creates a cursor with a standard shape.
  *
@@ -5083,10 +5126,13 @@ GLFWAPI GLFWcursor* glfwCreateCursor(const GLFWimage* image, int xhot, int yhot)
  *  @ref GLFW_POINTING_HAND_CURSOR | Yes     | Yes   | Yes    | Yes
  *  @ref GLFW_RESIZE_EW_CURSOR     | Yes     | Yes   | Yes    | Yes
  *  @ref GLFW_RESIZE_NS_CURSOR     | Yes     | Yes   | Yes    | Yes
- *  @ref GLFW_RESIZE_NWSE_CURSOR   | Yes     | Yes<sup>1</sup> | Maybe<sup>2</sup> | Maybe<sup>2</sup>
- *  @ref GLFW_RESIZE_NESW_CURSOR   | Yes     | Yes<sup>1</sup> | Maybe<sup>2</sup> | Maybe<sup>2</sup>
+ *  @ref GLFW_RESIZE_NWSE_CURSOR   | Yes     | Yes<sup>1</sup> |
+ * Maybe<sup>2</sup> | Maybe<sup>2</sup>
+ *  @ref GLFW_RESIZE_NESW_CURSOR   | Yes     | Yes<sup>1</sup> |
+ * Maybe<sup>2</sup> | Maybe<sup>2</sup>
  *  @ref GLFW_RESIZE_ALL_CURSOR    | Yes     | Yes   | Yes    | Yes
- *  @ref GLFW_NOT_ALLOWED_CURSOR   | Yes     | Yes   | Maybe<sup>2</sup> | Maybe<sup>2</sup>
+ *  @ref GLFW_NOT_ALLOWED_CURSOR   | Yes     | Yes   | Maybe<sup>2</sup> |
+ * Maybe<sup>2</sup>
  *
  *  1) This uses a private system API and may fail in the future.
  *
@@ -5112,7 +5158,7 @@ GLFWAPI GLFWcursor* glfwCreateCursor(const GLFWimage* image, int xhot, int yhot)
  *
  *  @ingroup input
  */
-GLFWAPI GLFWcursor* glfwCreateStandardCursor(int shape);
+GLFWAPI GLFWcursor *glfwCreateStandardCursor(int shape);
 
 /*! @brief Destroys a cursor.
  *
@@ -5139,7 +5185,7 @@ GLFWAPI GLFWcursor* glfwCreateStandardCursor(int shape);
  *
  *  @ingroup input
  */
-GLFWAPI void glfwDestroyCursor(GLFWcursor* cursor);
+GLFWAPI void glfwDestroyCursor(GLFWcursor *cursor);
 
 /*! @brief Sets the cursor for the window.
  *
@@ -5166,7 +5212,7 @@ GLFWAPI void glfwDestroyCursor(GLFWcursor* cursor);
  *
  *  @ingroup input
  */
-GLFWAPI void glfwSetCursor(GLFWwindow* window, GLFWcursor* cursor);
+GLFWAPI void glfwSetCursor(GLFWwindow *window, GLFWcursor *cursor);
 
 /*! @brief Sets the key callback.
  *
@@ -5200,7 +5246,8 @@ GLFWAPI void glfwSetCursor(GLFWwindow* window, GLFWcursor* cursor);
  *
  *  @callback_signature
  *  @code
- *  void function_name(GLFWwindow* window, int key, int scancode, int action, int mods)
+ *  void function_name(GLFWwindow* window, int key, int scancode, int action,
+ * int mods)
  *  @endcode
  *  For more information about the callback parameters, see the
  *  [function pointer type](@ref GLFWkeyfun).
@@ -5216,7 +5263,7 @@ GLFWAPI void glfwSetCursor(GLFWwindow* window, GLFWcursor* cursor);
  *
  *  @ingroup input
  */
-GLFWAPI GLFWkeyfun glfwSetKeyCallback(GLFWwindow* window, GLFWkeyfun callback);
+GLFWAPI GLFWkeyfun glfwSetKeyCallback(GLFWwindow *window, GLFWkeyfun callback);
 
 /*! @brief Sets the Unicode character callback.
  *
@@ -5232,8 +5279,8 @@ GLFWAPI GLFWkeyfun glfwSetKeyCallback(GLFWwindow* window, GLFWkeyfun callback);
  *
  *  The character callback behaves as system text input normally does and will
  *  not be called if modifier keys are held down that would prevent normal text
- *  input on that platform, for example a Super (Command) key on macOS or Alt key
- *  on Windows.
+ *  input on that platform, for example a Super (Command) key on macOS or Alt
+ * key on Windows.
  *
  *  @param[in] window The window whose callback to set.
  *  @param[in] callback The new callback, or `NULL` to remove the currently set
@@ -5259,7 +5306,8 @@ GLFWAPI GLFWkeyfun glfwSetKeyCallback(GLFWwindow* window, GLFWkeyfun callback);
  *
  *  @ingroup input
  */
-GLFWAPI GLFWcharfun glfwSetCharCallback(GLFWwindow* window, GLFWcharfun callback);
+GLFWAPI GLFWcharfun glfwSetCharCallback(GLFWwindow *window,
+                                        GLFWcharfun callback);
 
 /*! @brief Sets the Unicode character with modifiers callback.
  *
@@ -5301,7 +5349,8 @@ GLFWAPI GLFWcharfun glfwSetCharCallback(GLFWwindow* window, GLFWcharfun callback
  *
  *  @ingroup input
  */
-GLFWAPI GLFWcharmodsfun glfwSetCharModsCallback(GLFWwindow* window, GLFWcharmodsfun callback);
+GLFWAPI GLFWcharmodsfun glfwSetCharModsCallback(GLFWwindow *window,
+                                                GLFWcharmodsfun callback);
 
 /*! @brief Sets the mouse button callback.
  *
@@ -5343,7 +5392,8 @@ GLFWAPI GLFWcharmodsfun glfwSetCharModsCallback(GLFWwindow* window, GLFWcharmods
  *
  *  @ingroup input
  */
-GLFWAPI GLFWmousebuttonfun glfwSetMouseButtonCallback(GLFWwindow* window, GLFWmousebuttonfun callback);
+GLFWAPI GLFWmousebuttonfun
+glfwSetMouseButtonCallback(GLFWwindow *window, GLFWmousebuttonfun callback);
 
 /*! @brief Sets the cursor position callback.
  *
@@ -5375,7 +5425,8 @@ GLFWAPI GLFWmousebuttonfun glfwSetMouseButtonCallback(GLFWwindow* window, GLFWmo
  *
  *  @ingroup input
  */
-GLFWAPI GLFWcursorposfun glfwSetCursorPosCallback(GLFWwindow* window, GLFWcursorposfun callback);
+GLFWAPI GLFWcursorposfun glfwSetCursorPosCallback(GLFWwindow *window,
+                                                  GLFWcursorposfun callback);
 
 /*! @brief Sets the cursor enter/leave callback.
  *
@@ -5406,7 +5457,8 @@ GLFWAPI GLFWcursorposfun glfwSetCursorPosCallback(GLFWwindow* window, GLFWcursor
  *
  *  @ingroup input
  */
-GLFWAPI GLFWcursorenterfun glfwSetCursorEnterCallback(GLFWwindow* window, GLFWcursorenterfun callback);
+GLFWAPI GLFWcursorenterfun
+glfwSetCursorEnterCallback(GLFWwindow *window, GLFWcursorenterfun callback);
 
 /*! @brief Sets the scroll callback.
  *
@@ -5440,7 +5492,8 @@ GLFWAPI GLFWcursorenterfun glfwSetCursorEnterCallback(GLFWwindow* window, GLFWcu
  *
  *  @ingroup input
  */
-GLFWAPI GLFWscrollfun glfwSetScrollCallback(GLFWwindow* window, GLFWscrollfun callback);
+GLFWAPI GLFWscrollfun glfwSetScrollCallback(GLFWwindow *window,
+                                            GLFWscrollfun callback);
 
 /*! @brief Sets the path drop callback.
  *
@@ -5475,7 +5528,8 @@ GLFWAPI GLFWscrollfun glfwSetScrollCallback(GLFWwindow* window, GLFWscrollfun ca
  *
  *  @ingroup input
  */
-GLFWAPI GLFWdropfun glfwSetDropCallback(GLFWwindow* window, GLFWdropfun callback);
+GLFWAPI GLFWdropfun glfwSetDropCallback(GLFWwindow *window,
+                                        GLFWdropfun callback);
 
 /*! @brief Returns whether the specified joystick is present.
  *
@@ -5532,7 +5586,7 @@ GLFWAPI int glfwJoystickPresent(int jid);
  *
  *  @ingroup input
  */
-GLFWAPI const float* glfwGetJoystickAxes(int jid, int* count);
+GLFWAPI const float *glfwGetJoystickAxes(int jid, int *count);
 
 /*! @brief Returns the state of all buttons of the specified joystick.
  *
@@ -5573,7 +5627,7 @@ GLFWAPI const float* glfwGetJoystickAxes(int jid, int* count);
  *
  *  @ingroup input
  */
-GLFWAPI const unsigned char* glfwGetJoystickButtons(int jid, int* count);
+GLFWAPI const unsigned char *glfwGetJoystickButtons(int jid, int *count);
 
 /*! @brief Returns the state of all hats of the specified joystick.
  *
@@ -5630,7 +5684,7 @@ GLFWAPI const unsigned char* glfwGetJoystickButtons(int jid, int* count);
  *
  *  @ingroup input
  */
-GLFWAPI const unsigned char* glfwGetJoystickHats(int jid, int* count);
+GLFWAPI const unsigned char *glfwGetJoystickHats(int jid, int *count);
 
 /*! @brief Returns the name of the specified joystick.
  *
@@ -5661,7 +5715,7 @@ GLFWAPI const unsigned char* glfwGetJoystickHats(int jid, int* count);
  *
  *  @ingroup input
  */
-GLFWAPI const char* glfwGetJoystickName(int jid);
+GLFWAPI const char *glfwGetJoystickName(int jid);
 
 /*! @brief Returns the SDL compatible GUID of the specified joystick.
  *
@@ -5702,7 +5756,7 @@ GLFWAPI const char* glfwGetJoystickName(int jid);
  *
  *  @ingroup input
  */
-GLFWAPI const char* glfwGetJoystickGUID(int jid);
+GLFWAPI const char *glfwGetJoystickGUID(int jid);
 
 /*! @brief Sets the user pointer of the specified joystick.
  *
@@ -5728,7 +5782,7 @@ GLFWAPI const char* glfwGetJoystickGUID(int jid);
  *
  *  @ingroup input
  */
-GLFWAPI void glfwSetJoystickUserPointer(int jid, void* pointer);
+GLFWAPI void glfwSetJoystickUserPointer(int jid, void *pointer);
 
 /*! @brief Returns the user pointer of the specified joystick.
  *
@@ -5752,7 +5806,7 @@ GLFWAPI void glfwSetJoystickUserPointer(int jid, void* pointer);
  *
  *  @ingroup input
  */
-GLFWAPI void* glfwGetJoystickUserPointer(int jid);
+GLFWAPI void *glfwGetJoystickUserPointer(int jid);
 
 /*! @brief Returns whether the specified joystick has a gamepad mapping.
  *
@@ -5850,7 +5904,7 @@ GLFWAPI GLFWjoystickfun glfwSetJoystickCallback(GLFWjoystickfun callback);
  *
  *  @ingroup input
  */
-GLFWAPI int glfwUpdateGamepadMappings(const char* string);
+GLFWAPI int glfwUpdateGamepadMappings(const char *string);
 
 /*! @brief Returns the human-readable gamepad name for the specified joystick.
  *
@@ -5867,7 +5921,8 @@ GLFWAPI int glfwUpdateGamepadMappings(const char* string);
  *  joystick is not present, does not have a mapping or an
  *  [error](@ref error_handling) occurred.
  *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref GLFW_INVALID_ENUM.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ * GLFW_INVALID_ENUM.
  *
  *  @pointer_lifetime The returned string is allocated and freed by GLFW.  You
  *  should not free it yourself.  It is valid until the specified joystick is
@@ -5882,7 +5937,7 @@ GLFWAPI int glfwUpdateGamepadMappings(const char* string);
  *
  *  @ingroup input
  */
-GLFWAPI const char* glfwGetGamepadName(int jid);
+GLFWAPI const char *glfwGetGamepadName(int jid);
 
 /*! @brief Retrieves the state of the specified joystick remapped as a gamepad.
  *
@@ -5920,7 +5975,7 @@ GLFWAPI const char* glfwGetGamepadName(int jid);
  *
  *  @ingroup input
  */
-GLFWAPI int glfwGetGamepadState(int jid, GLFWgamepadstate* state);
+GLFWAPI int glfwGetGamepadState(int jid, GLFWgamepadstate *state);
 
 /*! @brief Sets the clipboard to the specified string.
  *
@@ -5933,10 +5988,10 @@ GLFWAPI int glfwGetGamepadState(int jid, GLFWgamepadstate* state);
  *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
  *  GLFW_PLATFORM_ERROR.
  *
- *  @remark __Win32:__ The clipboard on Windows has a single global lock for reading and
- *  writing.  GLFW tries to acquire it a few times, which is almost always enough.  If it
- *  cannot acquire the lock then this function emits @ref GLFW_PLATFORM_ERROR and returns.
- *  It is safe to try this multiple times.
+ *  @remark __Win32:__ The clipboard on Windows has a single global lock for
+ * reading and writing.  GLFW tries to acquire it a few times, which is almost
+ * always enough.  If it cannot acquire the lock then this function emits @ref
+ * GLFW_PLATFORM_ERROR and returns. It is safe to try this multiple times.
  *
  *  @pointer_lifetime The specified string is copied before this function
  *  returns.
@@ -5950,7 +6005,7 @@ GLFWAPI int glfwGetGamepadState(int jid, GLFWgamepadstate* state);
  *
  *  @ingroup input
  */
-GLFWAPI void glfwSetClipboardString(GLFWwindow* window, const char* string);
+GLFWAPI void glfwSetClipboardString(GLFWwindow *window, const char *string);
 
 /*! @brief Returns the contents of the clipboard as a string.
  *
@@ -5966,10 +6021,10 @@ GLFWAPI void glfwSetClipboardString(GLFWwindow* window, const char* string);
  *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
  *  GLFW_FORMAT_UNAVAILABLE and @ref GLFW_PLATFORM_ERROR.
  *
- *  @remark __Win32:__ The clipboard on Windows has a single global lock for reading and
- *  writing.  GLFW tries to acquire it a few times, which is almost always enough.  If it
- *  cannot acquire the lock then this function emits @ref GLFW_PLATFORM_ERROR and returns.
- *  It is safe to try this multiple times.
+ *  @remark __Win32:__ The clipboard on Windows has a single global lock for
+ * reading and writing.  GLFW tries to acquire it a few times, which is almost
+ * always enough.  If it cannot acquire the lock then this function emits @ref
+ * GLFW_PLATFORM_ERROR and returns. It is safe to try this multiple times.
  *
  *  @pointer_lifetime The returned string is allocated and freed by GLFW.  You
  *  should not free it yourself.  It is valid until the next call to @ref
@@ -5985,7 +6040,7 @@ GLFWAPI void glfwSetClipboardString(GLFWwindow* window, const char* string);
  *
  *  @ingroup input
  */
-GLFWAPI const char* glfwGetClipboardString(GLFWwindow* window);
+GLFWAPI const char *glfwGetClipboardString(GLFWwindow *window);
 
 /*! @brief Returns the GLFW time.
  *
@@ -6132,7 +6187,7 @@ GLFWAPI uint64_t glfwGetTimerFrequency(void);
  *
  *  @ingroup context
  */
-GLFWAPI void glfwMakeContextCurrent(GLFWwindow* window);
+GLFWAPI void glfwMakeContextCurrent(GLFWwindow *window);
 
 /*! @brief Returns the window whose context is current on the calling thread.
  *
@@ -6153,7 +6208,7 @@ GLFWAPI void glfwMakeContextCurrent(GLFWwindow* window);
  *
  *  @ingroup context
  */
-GLFWAPI GLFWwindow* glfwGetCurrentContext(void);
+GLFWAPI GLFWwindow *glfwGetCurrentContext(void);
 
 /*! @brief Swaps the front and back buffers of the specified window.
  *
@@ -6191,7 +6246,7 @@ GLFWAPI GLFWwindow* glfwGetCurrentContext(void);
  *
  *  @ingroup window
  */
-GLFWAPI void glfwSwapBuffers(GLFWwindow* window);
+GLFWAPI void glfwSwapBuffers(GLFWwindow *window);
 
 /*! @brief Sets the swap interval for the current context.
  *
@@ -6275,7 +6330,7 @@ GLFWAPI void glfwSwapInterval(int interval);
  *
  *  @ingroup context
  */
-GLFWAPI int glfwExtensionSupported(const char* extension);
+GLFWAPI int glfwExtensionSupported(const char *extension);
 
 /*! @brief Returns the address of the specified function for the current
  *  context.
@@ -6317,18 +6372,19 @@ GLFWAPI int glfwExtensionSupported(const char* extension);
  *
  *  @ingroup context
  */
-GLFWAPI GLFWglproc glfwGetProcAddress(const char* procname);
+GLFWAPI GLFWglproc glfwGetProcAddress(const char *procname);
 
 /*! @brief Returns whether the Vulkan loader and an ICD have been found.
  *
  *  This function returns whether the Vulkan loader and any minimally functional
  *  ICD have been found.
  *
- *  The availability of a Vulkan loader and even an ICD does not by itself guarantee that
- *  surface creation or even instance creation is possible.  Call @ref
- *  glfwGetRequiredInstanceExtensions to check whether the extensions necessary for Vulkan
- *  surface creation are available and @ref glfwGetPhysicalDevicePresentationSupport to
- *  check whether a queue family of a physical device supports image presentation.
+ *  The availability of a Vulkan loader and even an ICD does not by itself
+ * guarantee that surface creation or even instance creation is possible.  Call
+ * @ref glfwGetRequiredInstanceExtensions to check whether the extensions
+ * necessary for Vulkan surface creation are available and @ref
+ * glfwGetPhysicalDevicePresentationSupport to check whether a queue family of a
+ * physical device supports image presentation.
  *
  *  @return `GLFW_TRUE` if Vulkan is minimally available, or `GLFW_FALSE`
  *  otherwise.
@@ -6347,10 +6403,10 @@ GLFWAPI int glfwVulkanSupported(void);
 
 /*! @brief Returns the Vulkan instance extensions required by GLFW.
  *
- *  This function returns an array of names of Vulkan instance extensions required
- *  by GLFW for creating Vulkan surfaces for GLFW windows.  If successful, the
- *  list will always contain `VK_KHR_surface`, so if you don't require any
- *  additional extensions you can pass this list directly to the
+ *  This function returns an array of names of Vulkan instance extensions
+ * required by GLFW for creating Vulkan surfaces for GLFW windows.  If
+ * successful, the list will always contain `VK_KHR_surface`, so if you don't
+ * require any additional extensions you can pass this list directly to the
  *  `VkInstanceCreateInfo` struct.
  *
  *  If Vulkan is not available on the machine, this function returns `NULL` and
@@ -6387,7 +6443,7 @@ GLFWAPI int glfwVulkanSupported(void);
  *
  *  @ingroup vulkan
  */
-GLFWAPI const char** glfwGetRequiredInstanceExtensions(uint32_t* count);
+GLFWAPI const char **glfwGetRequiredInstanceExtensions(uint32_t *count);
 
 #if defined(VK_VERSION_1_0)
 
@@ -6430,7 +6486,8 @@ GLFWAPI const char** glfwGetRequiredInstanceExtensions(uint32_t* count);
  *
  *  @ingroup vulkan
  */
-GLFWAPI GLFWvkproc glfwGetInstanceProcAddress(VkInstance instance, const char* procname);
+GLFWAPI GLFWvkproc glfwGetInstanceProcAddress(VkInstance instance,
+                                              const char *procname);
 
 /*! @brief Returns whether the specified queue family can present images.
  *
@@ -6454,9 +6511,9 @@ GLFWAPI GLFWvkproc glfwGetInstanceProcAddress(VkInstance instance, const char* p
  *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
  *  GLFW_API_UNAVAILABLE and @ref GLFW_PLATFORM_ERROR.
  *
- *  @remark __macOS:__ This function currently always returns `GLFW_TRUE`, as the
- *  `VK_MVK_macos_surface` and `VK_EXT_metal_surface` extensions do not provide
- *  a `vkGetPhysicalDevice*PresentationSupport` type function.
+ *  @remark __macOS:__ This function currently always returns `GLFW_TRUE`, as
+ * the `VK_MVK_macos_surface` and `VK_EXT_metal_surface` extensions do not
+ * provide a `vkGetPhysicalDevice*PresentationSupport` type function.
  *
  *  @thread_safety This function may be called from any thread.  For
  *  synchronization details of Vulkan objects, see the Vulkan specification.
@@ -6467,16 +6524,18 @@ GLFWAPI GLFWvkproc glfwGetInstanceProcAddress(VkInstance instance, const char* p
  *
  *  @ingroup vulkan
  */
-GLFWAPI int glfwGetPhysicalDevicePresentationSupport(VkInstance instance, VkPhysicalDevice device, uint32_t queuefamily);
+GLFWAPI int glfwGetPhysicalDevicePresentationSupport(VkInstance instance,
+                                                     VkPhysicalDevice device,
+                                                     uint32_t queuefamily);
 
 /*! @brief Creates a Vulkan surface for the specified window.
  *
  *  This function creates a Vulkan surface for the specified window.
  *
- *  If the Vulkan loader or at least one minimally functional ICD were not found,
- *  this function returns `VK_ERROR_INITIALIZATION_FAILED` and generates a @ref
- *  GLFW_API_UNAVAILABLE error.  Call @ref glfwVulkanSupported to check whether
- *  Vulkan is at least minimally available.
+ *  If the Vulkan loader or at least one minimally functional ICD were not
+ * found, this function returns `VK_ERROR_INITIALIZATION_FAILED` and generates a
+ * @ref GLFW_API_UNAVAILABLE error.  Call @ref glfwVulkanSupported to check
+ * whether Vulkan is at least minimally available.
  *
  *  If the required window surface creation instance extensions are not
  *  available or if the specified instance was not created with these extensions
@@ -6512,13 +6571,13 @@ GLFWAPI int glfwGetPhysicalDevicePresentationSupport(VkInstance instance, VkPhys
  *  @ref glfwVulkanSupported and @ref glfwGetRequiredInstanceExtensions should
  *  eliminate almost all occurrences of these errors.
  *
- *  @remark __macOS:__ GLFW prefers the `VK_EXT_metal_surface` extension, with the
- *  `VK_MVK_macos_surface` extension as a fallback.  The name of the selected
+ *  @remark __macOS:__ GLFW prefers the `VK_EXT_metal_surface` extension, with
+ * the `VK_MVK_macos_surface` extension as a fallback.  The name of the selected
  *  extension, if any, is included in the array returned by @ref
  *  glfwGetRequiredInstanceExtensions.
  *
- *  @remark __macOS:__ This function creates and sets a `CAMetalLayer` instance for
- *  the window content view, which is required for MoltenVK to function.
+ *  @remark __macOS:__ This function creates and sets a `CAMetalLayer` instance
+ * for the window content view, which is required for MoltenVK to function.
  *
  *  @remark __X11:__ By default GLFW prefers the `VK_KHR_xcb_surface` extension,
  *  with the `VK_KHR_xlib_surface` extension as a fallback.  You can make
@@ -6537,10 +6596,12 @@ GLFWAPI int glfwGetPhysicalDevicePresentationSupport(VkInstance instance, VkPhys
  *
  *  @ingroup vulkan
  */
-GLFWAPI VkResult glfwCreateWindowSurface(VkInstance instance, GLFWwindow* window, const VkAllocationCallbacks* allocator, VkSurfaceKHR* surface);
+GLFWAPI VkResult glfwCreateWindowSurface(VkInstance instance,
+                                         GLFWwindow *window,
+                                         const VkAllocationCallbacks *allocator,
+                                         VkSurfaceKHR *surface);
 
 #endif /*VK_VERSION_1_0*/
-
 
 /*************************************************************************
  * Global definition cleanup
@@ -6549,29 +6610,27 @@ GLFWAPI VkResult glfwCreateWindowSurface(VkInstance instance, GLFWwindow* window
 /* ------------------- BEGIN SYSTEM/COMPILER SPECIFIC -------------------- */
 
 #ifdef GLFW_WINGDIAPI_DEFINED
- #undef WINGDIAPI
- #undef GLFW_WINGDIAPI_DEFINED
+#undef WINGDIAPI
+#undef GLFW_WINGDIAPI_DEFINED
 #endif
 
 #ifdef GLFW_CALLBACK_DEFINED
- #undef CALLBACK
- #undef GLFW_CALLBACK_DEFINED
+#undef CALLBACK
+#undef GLFW_CALLBACK_DEFINED
 #endif
 
 /* Some OpenGL related headers need GLAPIENTRY, but it is unconditionally
  * defined by some gl.h variants (OpenBSD) so define it after if needed.
  */
 #ifndef GLAPIENTRY
- #define GLAPIENTRY APIENTRY
- #define GLFW_GLAPIENTRY_DEFINED
+#define GLAPIENTRY APIENTRY
+#define GLFW_GLAPIENTRY_DEFINED
 #endif
 
 /* -------------------- END SYSTEM/COMPILER SPECIFIC --------------------- */
-
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* _glfw3_h_ */
-

--- a/src/internal.h
+++ b/src/internal.h
@@ -421,6 +421,7 @@ struct _GLFWwndconfig
     struct {
         char      className[256];
         char      instanceName[256];
+        bool      overrideRedirect;
     } x11;
     struct {
         bool      keymenu;
@@ -1020,4 +1021,3 @@ int _glfw_max(int a, int b);
 void* _glfw_calloc(size_t count, size_t size);
 void* _glfw_realloc(void* pointer, size_t size);
 void _glfw_free(void* pointer);
-

--- a/src/window.c
+++ b/src/window.c
@@ -430,6 +430,9 @@ GLFWAPI void glfwWindowHint(int hint, int value)
         case GLFW_REFRESH_RATE:
             _glfw.hints.refreshRate = value;
             return;
+        case GLFW_X11_OVERRIDE_REDIRECT:
+            _glfw.hints.window.x11.overrideRedirect = value;
+            return;
     }
 
     _glfwInputError(GLFW_INVALID_ENUM, "Invalid window hint 0x%08X", hint);
@@ -1195,4 +1198,3 @@ GLFWAPI void glfwPostEmptyEvent(void)
     _GLFW_REQUIRE_INIT();
     _glfw.platform.postEmptyEvent();
 }
-

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -610,6 +610,7 @@ static GLFWbool createNativeWindow(_GLFWwindow* window,
     {
         wa.override_redirect = True;
         wamask |= CWOverrideRedirect;
+        window->x11.overrideRedirect = GLFW_TRUE;
     }
 
     _glfwGrabErrorHandlerX11();

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -597,11 +597,20 @@ static GLFWbool createNativeWindow(_GLFWwindow* window,
     window->x11.transparent = _glfwIsVisualTransparentX11(visual);
 
     XSetWindowAttributes wa = { 0 };
+
+    unsigned long wamask = CWBorderPixel | CWColormap | CWEventMask;
+
     wa.colormap = window->x11.colormap;
     wa.event_mask = StructureNotifyMask | KeyPressMask | KeyReleaseMask |
                     PointerMotionMask | ButtonPressMask | ButtonReleaseMask |
                     ExposureMask | FocusChangeMask | VisibilityChangeMask |
                     EnterWindowMask | LeaveWindowMask | PropertyChangeMask;
+
+    if (_glfw.hints.window.x11.overrideRedirect)
+    {
+        wa.override_redirect = True;
+        wamask |= CWOverrideRedirect;
+    }
 
     _glfwGrabErrorHandlerX11();
 
@@ -614,7 +623,7 @@ static GLFWbool createNativeWindow(_GLFWwindow* window,
                                        depth,  // Color depth
                                        InputOutput,
                                        visual,
-                                       CWBorderPixel | CWColormap | CWEventMask,
+                                       wamask,
                                        &wa);
 
     _glfwReleaseErrorHandlerX11();
@@ -3384,4 +3393,3 @@ GLFWAPI const char* glfwGetX11SelectionString(void)
 }
 
 #endif // _GLFW_X11
-

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -606,7 +606,7 @@ static GLFWbool createNativeWindow(_GLFWwindow* window,
                     ExposureMask | FocusChangeMask | VisibilityChangeMask |
                     EnterWindowMask | LeaveWindowMask | PropertyChangeMask;
 
-    if (_glfw.hints.window.x11.overrideRedirect)
+    if (wndconfig->x11.overrideRedirect)
     {
         wa.override_redirect = True;
         wamask |= CWOverrideRedirect;


### PR DESCRIPTION
This pull request adds the window hint GLFW_X11_OVERRIDE_REDIRECT so that it can be set on window construction. I need this because window managers such as i3 take over the window immediately and will not let go despite setting override redirect after the fact. (PS: ignore the branch name, I thought I was going to need way more patches but I didn't).